### PR TITLE
remove old style C casts from Tulip codebase + some other casts improvements

### DIFF
--- a/cmake/TulipUseFile.cmake
+++ b/cmake/TulipUseFile.cmake
@@ -28,7 +28,7 @@ MACRO(TULIP_SET_COMPILER_OPTIONS)
   STRING(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "Clang" CLANG)
 
   IF(NOT MSVC) #visual studio does not recognize these options
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wunused -Wno-long-long")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wunused -Wno-long-long -Wold-style-cast")
     IF(NOT APPLE)
       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
       # disable annoying GCC 7.x compilation warnings

--- a/demos/interactor_plugin/interactor_plugin.cpp
+++ b/demos/interactor_plugin/interactor_plugin.cpp
@@ -65,7 +65,7 @@ public :
     QMouseEvent * qMouseEv = dynamic_cast<QMouseEvent *>(e);
 
     if(qMouseEv != NULL) {
-      GlMainView *glMainView=dynamic_cast<GlMainView*>(view());
+      GlMainView *glMainView=static_cast<GlMainView*>(view());
 
 
       /*

--- a/library/tulip-core/include/tulip/AbstractProperty.h
+++ b/library/tulip-core/include/tulip/AbstractProperty.h
@@ -499,16 +499,16 @@ public:
     return NULL;
   }
   virtual void setNodeDataMemValue( const node n, const DataMem* v) {
-    setNodeValue(n, ((TypedValueContainer<typename Tnode::RealType> *) v)->value);
+    setNodeValue(n, static_cast<const TypedValueContainer<typename Tnode::RealType> *>(v)->value);
   }
   virtual void setEdgeDataMemValue( const edge e, const DataMem* v) {
-    setEdgeValue(e, ((TypedValueContainer<typename Tedge::RealType> *) v)->value);
+    setEdgeValue(e, static_cast<const TypedValueContainer<typename Tedge::RealType> *>(v)->value);
   }
   virtual void setAllNodeDataMemValue(const DataMem* v) {
-    setAllNodeValue(((TypedValueContainer<typename Tnode::RealType> *) v)->value);
+    setAllNodeValue(static_cast<const TypedValueContainer<typename Tnode::RealType> *>(v)->value);
   }
   virtual void setAllEdgeDataMemValue(const DataMem* v) {
-    setAllEdgeValue(((TypedValueContainer<typename Tedge::RealType> *) v)->value);
+    setAllEdgeValue(static_cast<const TypedValueContainer<typename Tedge::RealType> *>(v)->value);
   }
 
   // PropertyInterface methods
@@ -516,14 +516,13 @@ public:
   // and mg is the graph owning mN
   virtual void computeMetaValue(node n, Graph* sg, Graph* mg) {
     if (Tprop::metaValueCalculator)
-      ((typename tlp::AbstractProperty<Tnode,Tedge,Tprop>::MetaValueCalculator *)
-       Tprop::metaValueCalculator)->computeMetaValue(this, n, sg, mg);
+      static_cast<typename tlp::AbstractProperty<Tnode,Tedge,Tprop>::MetaValueCalculator *>(Tprop::metaValueCalculator)->computeMetaValue(this, n, sg, mg);
   }
   // mE is the meta edge, itE is an iterator on the underlying edges
   // mg is the graph owning mE
   virtual void computeMetaValue(edge e, tlp::Iterator<edge>* itE, Graph* mg) {
     if (Tprop::metaValueCalculator)
-      ((typename tlp::AbstractProperty<Tnode,Tedge,Tprop>::MetaValueCalculator *) Tprop::metaValueCalculator)->computeMetaValue(this, e, itE, mg);
+      static_cast<typename tlp::AbstractProperty<Tnode,Tedge,Tprop>::MetaValueCalculator *>(Tprop::metaValueCalculator)->computeMetaValue(this, e, itE, mg);
   }
   virtual void setMetaValueCalculator(PropertyInterface::MetaValueCalculator *mvCalc) {
     if (mvCalc && !dynamic_cast<typename tlp::AbstractProperty<Tnode,Tedge,Tprop>::MetaValueCalculator *>(mvCalc)) {

--- a/library/tulip-core/include/tulip/Algorithm.h
+++ b/library/tulip-core/include/tulip/Algorithm.h
@@ -52,8 +52,7 @@ public :
    */
   Algorithm (const PluginContext* context) : graph(NULL),pluginProgress(NULL),dataSet(NULL) {
     if(context != NULL) {
-      const AlgorithmContext* algorithmContext = dynamic_cast<const AlgorithmContext*>(context);
-      assert(algorithmContext != NULL);
+      const AlgorithmContext* algorithmContext = static_cast<const AlgorithmContext*>(context);
       graph = algorithmContext->graph;
       pluginProgress = algorithmContext->pluginProgress;
       dataSet = algorithmContext->dataSet;

--- a/library/tulip-core/include/tulip/Color.h
+++ b/library/tulip-core/include/tulip/Color.h
@@ -190,16 +190,16 @@ unsigned char tlp::Color::getA()const {
 }
 
 float tlp::Color::getRGL()const {
-  return (float)array[0]/255.0;
+  return float(array[0]/255.0);
 }
 float tlp::Color::getGGL()const {
-  return (float)array[1]/255.0;
+  return float(array[1]/255.0);
 }
 float tlp::Color::getBGL()const {
-  return (float)array[2]/255.0;
+  return float(array[2]/255.0);
 }
 float tlp::Color::getAGL()const {
-  return (float)array[3]/255.0;
+  return float(array[3]/255.0);
 }
 float* tlp::Color::getGL()const {
   float *result=new float[4];

--- a/library/tulip-core/include/tulip/DataSet.h
+++ b/library/tulip-core/include/tulip/DataSet.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *
  * This file is part of Tulip (http://tulip.labri.fr)
  *
@@ -94,18 +94,18 @@ template<typename T>
 struct TypedData :public DataType {
   TypedData(void *value) :DataType(value) {}
   ~TypedData() {
-    delete (T*) value;
+    delete static_cast<T*>(value);
   }
   DataType* clone() const {
-    return new TypedData<T>(new T(*(T*)value));
+    return new TypedData<T>(new T(getValue()));
   }
 
   std::string getTypeName() const {
     return std::string(typeid(T).name());
   }
 
-  const T& getValue() {
-    return (T&) this->value;
+  const T& getValue() const {
+    return *(static_cast<const T*>(this->value));
   }
 };
 
@@ -145,7 +145,7 @@ struct TypedDataSerializer :public DataTypeSerializer {
   virtual bool read(std::istream& is, T& value)=0;
   // define virtually inherited functions using the previous ones
   void writeData(std::ostream& os, const DataType* data) {
-    write(os, *((T*) data->value));
+    write(os, *(static_cast<T*>(data->value)));
   }
   DataType* readData(std::istream& is) {
     T value;

--- a/library/tulip-core/include/tulip/ExportModule.h
+++ b/library/tulip-core/include/tulip/ExportModule.h
@@ -43,8 +43,7 @@ public:
 
   ExportModule(const tlp::PluginContext* context) {
     if(context != NULL) {
-      const tlp::AlgorithmContext* algoritmContext = dynamic_cast<const tlp::AlgorithmContext*>(context);
-      assert(algoritmContext != NULL);
+      const tlp::AlgorithmContext* algoritmContext = static_cast<const tlp::AlgorithmContext*>(context);
       graph = algoritmContext->graph;
       pluginProgress = algoritmContext->pluginProgress;
       dataSet = algoritmContext->dataSet;

--- a/library/tulip-core/include/tulip/Graph.h
+++ b/library/tulip-core/include/tulip/Graph.h
@@ -1163,7 +1163,7 @@ public:
    * @return The attributes of the graph.
    */
   const DataSet & getAttributes() const {
-    return (const_cast<Graph *>(this))->getNonConstAttributes();
+    return const_cast<Graph *>(this)->getNonConstAttributes();
   }
 
   /**

--- a/library/tulip-core/include/tulip/GraphView.h
+++ b/library/tulip-core/include/tulip/GraphView.h
@@ -51,7 +51,7 @@ DECL_STORED_PTR(SGraphNodeDataPtr);
 class GraphView:public GraphAbstract {
 
   inline GraphImpl* getRootImpl() const {
-    return (GraphImpl *) getRoot();
+    return static_cast<GraphImpl *>(getRoot());
   }
 
   friend class GraphImpl;

--- a/library/tulip-core/include/tulip/ImportModule.h
+++ b/library/tulip-core/include/tulip/ImportModule.h
@@ -45,8 +45,7 @@ public:
 
   ImportModule (const tlp::PluginContext* context) {
     if(context != NULL) {
-      const tlp::AlgorithmContext* algoritmContext = dynamic_cast<const tlp::AlgorithmContext*>(context);
-      assert(algoritmContext != NULL);
+      const tlp::AlgorithmContext* algoritmContext = static_cast<const tlp::AlgorithmContext*>(context);
       graph = algoritmContext->graph;
       pluginProgress = algoritmContext->pluginProgress;
       dataSet = algoritmContext->dataSet;

--- a/library/tulip-core/include/tulip/IntegerProperty.h
+++ b/library/tulip-core/include/tulip/IntegerProperty.h
@@ -64,28 +64,28 @@ public :
 
   // NumericProperty interface
   virtual double getNodeDoubleValue(const node n) const {
-    return (double) getNodeValue(n);
+    return getNodeValue(n);
   }
   virtual double getNodeDoubleDefaultValue() const {
-    return (double) getNodeDefaultValue();
+    return getNodeDefaultValue();
   }
   virtual double getNodeDoubleMin(const Graph* g = NULL) {
-    return (double) getNodeMin(g);
+    return getNodeMin(g);
   }
   virtual double getNodeDoubleMax(const Graph* g = NULL) {
-    return (double) getNodeMax(g);
+    return getNodeMax(g);
   }
   virtual double getEdgeDoubleValue(const edge e) const {
-    return (double) getEdgeValue(e);
+    return getEdgeValue(e);
   }
   virtual double getEdgeDoubleDefaultValue() const {
-    return (double) getEdgeDefaultValue();
+    return getEdgeDefaultValue();
   }
   virtual double getEdgeDoubleMin(const Graph* g = NULL) {
-    return (double) getEdgeMin(g);
+    return getEdgeMin(g);
   }
   virtual double getEdgeDoubleMax(const Graph* g = NULL) {
-    return (double) getEdgeMax(g);
+    return getEdgeMax(g);
   }
 
   void nodesUniformQuantification(unsigned int);

--- a/library/tulip-core/include/tulip/MutableContainer.h
+++ b/library/tulip-core/include/tulip/MutableContainer.h
@@ -155,7 +155,7 @@ public:
     return tmp;
   }
   unsigned int nextValue(DataMem& val) {
-    ((TypedValueContainer<TYPE>&) val).value = StoredType<TYPE>::get(*it);
+    static_cast<TypedValueContainer<TYPE>&>(val).value = StoredType<TYPE>::get(*it);
     unsigned int pos = _pos;
 
     do {
@@ -205,7 +205,7 @@ public:
     return tmp;
   }
   unsigned int nextValue(DataMem& val) {
-    ((TypedValueContainer<TYPE>&) val).value =
+    static_cast<TypedValueContainer<TYPE>&>(val).value =
       StoredType<TYPE>::get((*it).second);
     unsigned int pos = (*it).first;
 

--- a/library/tulip-core/include/tulip/PropertyInterface.h
+++ b/library/tulip-core/include/tulip/PropertyInterface.h
@@ -622,7 +622,7 @@ public:
     : Event(prop, evtType), evtType(propEvtType), eltId(id) {}
 
   PropertyInterface* getProperty() const {
-    return reinterpret_cast<PropertyInterface *>(sender());
+    return static_cast<PropertyInterface *>(sender());
   }
 
   node getNode() const {

--- a/library/tulip-core/include/tulip/SerializableType.h
+++ b/library/tulip-core/include/tulip/SerializableType.h
@@ -128,8 +128,8 @@ public:
   }
   static void writeb(std::ostream& oss, const typename TypeInterface<std::vector<ELT_TYPE> >::RealType& v) {
     unsigned int vSize = v.size();
-    oss.write((char *) &vSize, sizeof(vSize));
-    oss.write((char *) v.data(), vSize * sizeof(ELT_TYPE));
+    oss.write(reinterpret_cast<const char *>(&vSize), sizeof(vSize));
+    oss.write(reinterpret_cast<const char *>(v.data()), vSize * sizeof(ELT_TYPE));
   }
   static bool read(std::istream& iss, typename TypeInterface<std::vector<ELT_TYPE> >::RealType& v, char openChar = '(', char sepChar = ',', char closeChar = ')') {
     return readVector(iss, v, openChar, sepChar, closeChar);
@@ -137,9 +137,9 @@ public:
   static bool readb(std::istream& iss, typename TypeInterface<std::vector<ELT_TYPE> >::RealType& v) {
     unsigned int vSize;
 
-    if (bool(iss.read((char *) &vSize, sizeof(vSize)))) {
+    if (bool(iss.read(reinterpret_cast<char *>(&vSize), sizeof(vSize)))) {
       v.resize(vSize);
-      return bool(iss.read((char *) v.data(), vSize * sizeof(ELT_TYPE)));
+      return bool(iss.read(reinterpret_cast<char *>(v.data()), vSize * sizeof(ELT_TYPE)));
     }
 
     return false;

--- a/library/tulip-core/include/tulip/StoredType.h
+++ b/library/tulip-core/include/tulip/StoredType.h
@@ -38,7 +38,7 @@ struct StoredType {
   enum {isPointer=0};
   // simply get
   inline static TYPE& get(const TYPE& val) {
-    return (TYPE&) val;
+    return const_cast<TYPE&>(val);
   }
   // equallity test
   inline static bool equal(const TYPE& val1, const TYPE& val2) {
@@ -52,7 +52,7 @@ struct StoredType {
   inline static void destroy(Value) {}
   // the default value of that type
   inline static Value defaultValue() {
-    return (Value) 0;
+    return static_cast<Value>(0);
   }
 };
 

--- a/library/tulip-core/include/tulip/TypeInterface.h
+++ b/library/tulip-core/include/tulip/TypeInterface.h
@@ -47,14 +47,14 @@ public:
 
   static void write(std::ostream&, const RealType&) {}
   static void writeb(std::ostream& oss, const RealType& v) {
-    oss.write((char *) &v, sizeof(v));
+    oss.write(reinterpret_cast<const char *>(&v), sizeof(v));
   }
 
   static bool read(std::istream&, RealType&) {
     return false;
   }
   static bool readb(std::istream& iss, RealType& v) {
-    return bool(iss.read((char *) &v, sizeof(v)));
+    return bool(iss.read(reinterpret_cast<char *>(&v), sizeof(v)));
   }
 
   static std::string toString(const RealType &) {

--- a/library/tulip-core/include/tulip/Vector.h
+++ b/library/tulip-core/include/tulip/Vector.h
@@ -47,7 +47,7 @@ inline TYPE tlpsqrt(const OTYPE a) {
 
 template<>
 inline double tlpsqrt<double, long double>(long double a) {
-  return static_cast<double>(sqrtl(a));
+  return double(sqrtl(a));
 }
 
 
@@ -136,22 +136,22 @@ public:
   }
   inline void set(const Vector<TYPE, 2, OTYPE> &v, const TYPE z) {
     assert(SIZE>2);
-    memcpy( &((*this)[0]), (void*)&(v.array[0]), 2 * sizeof(TYPE) );
+    memcpy( &((*this)[0]), &(v.array[0]), 2 * sizeof(TYPE) );
     (*this)[2] = z;
   }
   inline void set(const Vector<TYPE, 2, OTYPE> &v, const TYPE z, const TYPE w) {
     assert(SIZE>3);
-    memcpy( &((*this)[0]), (void*)&(v.array[0]), 2 * sizeof(TYPE) );
+    memcpy( &((*this)[0]), &(v.array[0]), 2 * sizeof(TYPE) );
     (*this)[2] = z;
     (*this)[3] = w;
   }
   inline void set(const Vector<TYPE, 3, OTYPE> &v, const TYPE w) {
     assert(SIZE>3);
-    memcpy( &((*this)[0]), (void*)&(v.array[0]), 3 * sizeof(TYPE) );
+    memcpy( &((*this)[0]), &(v.array[0]), 3 * sizeof(TYPE) );
     (*this)[3] = w;
   }
   inline void set(const Vector<TYPE, SIZE, OTYPE> &v) {
-    memcpy(&((*this)[0]), (void*)&(v.array[0]), SIZE * sizeof(TYPE) );
+    memcpy(&((*this)[0]), &(v.array[0]), SIZE * sizeof(TYPE) );
   }
   inline void set(const Vector<TYPE, SIZE + 1, OTYPE> &v) {
     memcpy(&((*this)[0]), &(v.array[0]), SIZE * sizeof(TYPE) );

--- a/library/tulip-core/include/tulip/cxx/DataSet.cxx
+++ b/library/tulip-core/include/tulip/cxx/DataSet.cxx
@@ -25,7 +25,7 @@ template<typename T> bool tlp::DataSet::get(const std::string& str,T& value) con
     const std::pair<std::string, tlp::DataType*> &p = *it;
 
     if (p.first == str) {
-      value = *((T*) p.second->value);
+      value = *(static_cast<T*>(p.second->value));
       return true;
     }
   }
@@ -39,7 +39,7 @@ template<typename T> bool tlp::DataSet::getAndFree(const std::string &str,T& val
     std::pair<std::string, tlp::DataType *> &p = *it;
 
     if (p.first == str) {
-      value = *((T*) p.second->value);
+      value = *(static_cast<T*>(p.second->value));
       delete p.second;
       data.erase(it);
       return true;

--- a/library/tulip-core/include/tulip/cxx/Vector.cxx
+++ b/library/tulip-core/include/tulip/cxx/Vector.cxx
@@ -231,7 +231,7 @@ bool VECTORTLP::operator>(const VECTORTLP &vecto) const {
 TEMPLATEVECTOR
 bool VECTORTLP::operator<(const VECTORTLP &v) const {
   if (std::numeric_limits<TYPE>::is_integer) {
-    return memcmp(&((*this).array[0]), (void*)&(v.array[0]), SIZE * sizeof(TYPE)) < 0;
+    return memcmp(&((*this).array[0]), &(v.array[0]), SIZE * sizeof(TYPE)) < 0;
   }
 
   for (unsigned int i=0; i<SIZE; ++i) {
@@ -255,7 +255,7 @@ bool VECTORTLP::operator!=(const VECTORTLP &vecto) const {
 TEMPLATEVECTOR
 bool VECTORTLP::operator==(const VECTORTLP &v) const {
   if (std::numeric_limits<TYPE>::is_integer) {
-    return memcmp((void*)&((*this).array[0]), (void*)&(v.array[0]), SIZE * sizeof(TYPE)) == 0;
+    return memcmp(&((*this).array[0]), &(v.array[0]), SIZE * sizeof(TYPE)) == 0;
   }
 
   for (unsigned int i=0; i<SIZE; ++i) {

--- a/library/tulip-core/include/tulip/memorypool.h
+++ b/library/tulip-core/include/tulip/memorypool.h
@@ -107,18 +107,18 @@ private:
 
       if (_freeObject[threadId].empty()) {
         void *chunk = malloc(BUFFOBJ * sizeof(TYPE));
-        TYPE * p = reinterpret_cast<TYPE *>(chunk);
+        TYPE * p = static_cast<TYPE *>(chunk);
         _allocatedChunks[threadId].push_back(chunk);
 
         for (size_t j=0; j< BUFFOBJ - 1; ++j) {
-          _freeObject[threadId].push_back(reinterpret_cast<void *>(p));
+          _freeObject[threadId].push_back(static_cast<void *>(p));
           p += 1;
         }
 
         result = p;
       }
       else {
-        result = reinterpret_cast<TYPE *>(_freeObject[threadId].back());
+        result = static_cast<TYPE *>(_freeObject[threadId].back());
         _freeObject[threadId].pop_back();
       }
 

--- a/library/tulip-core/include/tulip/tulipconf.h
+++ b/library/tulip-core/include/tulip/tulipconf.h
@@ -29,7 +29,7 @@
 #define STRINGIFY(PARAM) STRINGIFY_INTERNAL(PARAM)
 #define STRINGIFY_INTERNAL(PARAM) #PARAM
 
-//MSVC and GCC in c++11 mode use decltype instead of typeof
+// MSVC and GCC in c++11 mode use decltype instead of typeof
 #if !defined(_MSC_VER)
 #  if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
 #    define TLP_TYPEOF decltype
@@ -37,6 +37,10 @@
 #    define TLP_TYPEOF typeof
 #  endif
 #endif
+
+// some usefull typedefs
+typedef unsigned int uint;
+typedef unsigned char uchar;
 
 #if defined(_MSC_VER)
 // disable some annoying Visual Studio warnings
@@ -72,7 +76,7 @@
 #include <cmath>
 
 inline double fabs(int i) {
-  return std::fabs(static_cast<double>(i));
+  return std::fabs(double(i));
 }
 
 #  if _MSC_VER < 1800 // Visual Studio 2013 improved C99 support, no need to redefine some cmath functions
@@ -81,27 +85,27 @@ inline double fabs(int i) {
 #include <cstdlib>
 
 inline double sqrt(int i) {
-  return std::sqrt(static_cast<double>(i));
+  return std::sqrt(double(i));
 }
 
 inline double sqrt(unsigned int i) {
-  return std::sqrt(static_cast<double>(i));
+  return std::sqrt(double(i));
 }
 
 inline double log(int i) {
-  return std::log(static_cast<double>(i));
+  return std::log(double(i));
 }
 
 inline double log(unsigned int i) {
-  return std::log(static_cast<double>(i));
+  return std::log(double(i));
 }
 
 inline double floor(int i) {
-  return std::floor(static_cast<double>(i));
+  return std::floor(double(i));
 }
 
 inline double floor(unsigned int i) {
-  return std::floor(static_cast<double>(i));
+  return std::floor(double(i));
 }
 
 inline double round(double d) {
@@ -113,7 +117,7 @@ inline float strtof(const char* cptr, char** endptr) {
 }
 
 #define isnan(x) ((x) != (x)) //you guessed it, this is a C99 feature, and VC++ does not support C99. workaroud this.
-#define rint(arg) arg > 0 ? static_cast<int>(std::floor(static_cast<double>(arg))) : static_cast<int>(std::ceil(static_cast<double>(arg))) //Hey, nother C99 feature !
+#define rint(arg) arg > 0 ? int(std::floor(double(arg))) : int(std::ceil(double(arg))) //Hey, nother C99 feature !
 
 #if _MSC_VER <= 1600
 inline double log1p(double x) {

--- a/library/tulip-core/src/AcyclicTest.cpp
+++ b/library/tulip-core/src/AcyclicTest.cpp
@@ -205,11 +205,10 @@ void AcyclicTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       resultsBuffer.erase(graph);
   }
 }

--- a/library/tulip-core/src/BiconnectedTest.cpp
+++ b/library/tulip-core/src/BiconnectedTest.cpp
@@ -271,11 +271,10 @@ void BiconnectedTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE) {
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE) {
       resultsBuffer.erase(graph);
     }
   }

--- a/library/tulip-core/src/Color.cpp
+++ b/library/tulip-core/src/Color.cpp
@@ -114,7 +114,7 @@ std::ostream& tlp::operator<<(std::ostream &os,const tlp::Color &a) {
     if( i>0 )
       os << ",";
 
-    os << (unsigned int)a[i];
+    os << uint(a[i]);
   }
 
   os << ")" ;
@@ -224,11 +224,11 @@ void RGBtoHSV(unsigned char r, unsigned char g, unsigned char b, int &h, int &s,
   }
 
   if(r == theMax)
-    h = (int) (60 * (float)(g - b) / (float)delta);   // between yellow & magenta
+    h = int(60 * (g - b) / float(delta));   // between yellow & magenta
   else if(g == theMax)
-    h = (int) (60 * (2.0f + (float)(b - r) / (float)delta));  // between cyan & yellow
+    h = int(60 * (2.0f + (b - r) / float(delta)));  // between cyan & yellow
   else
-    h = (int) (60 * (4.0f + (float)(r - g) / (float)delta));  // between magenta & cyan
+    h = int(60 * (4.0f + (r - g) / float(delta)));  // between magenta & cyan
 
   if(h < 0)
     h += 360;
@@ -256,9 +256,9 @@ void HSVtoRGB(int h, int s, int v, unsigned char &r, unsigned char &g, unsigned 
 
   i = h/60;     // sector 0 to 5
   f = (h/60.0f - i);      // factorial part of h
-  p = (int) (v * (1 - sf));
-  q = (int) (v * (1 - sf * f));
-  t = (int) (v * (1 - sf * (1 - f)));
+  p = int(v * (1 - sf));
+  q = int(v * (1 - sf * f));
+  t = int(v * (1 - sf * (1 - f)));
 
   switch(i) {
   case 0:

--- a/library/tulip-core/src/ColorScale.cpp
+++ b/library/tulip-core/src/ColorScale.cpp
@@ -133,7 +133,7 @@ Color ColorScale::getColorAtPos(const float pos) const {
       double ratio = (pos - startPos) / (endPos - startPos);
 
       for (unsigned int i = 0; i < 4; ++i) {
-        ret[i] = static_cast<unsigned char>((double(startColor[i]) + (double(endColor[i])
+        ret[i] = uchar((double(startColor[i]) + (double(endColor[i])
                                              - double(startColor[i])) * ratio));
       }
 

--- a/library/tulip-core/src/ConnectedTest.cpp
+++ b/library/tulip-core/src/ConnectedTest.cpp
@@ -253,11 +253,10 @@ void ConnectedTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       resultsBuffer.erase(graph);
   }
 }

--- a/library/tulip-core/src/ConvexHull.cpp
+++ b/library/tulip-core/src/ConvexHull.cpp
@@ -24,6 +24,11 @@
 #include <map>
 #include <algorithm>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 extern "C" {
 #ifdef HAVE_REENTRANT_QHULL
 #include <qhull_ra.h>
@@ -208,3 +213,7 @@ void tlp::convexHull(const std::vector<Coord> &points,
 
   runQHull(dim, pointsQHull, convexHullFacets, facetNeighbors);
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/library/tulip-core/src/DataSet.cpp
+++ b/library/tulip-core/src/DataSet.cpp
@@ -152,7 +152,7 @@ void DataSet::setData(const std::string &str, const DataType* value) {
 }
 
 unsigned int DataSet::size() const {
-  return (unsigned int) data.size();
+  return uint(data.size());
 }
 
 bool DataSet::empty() const {
@@ -364,7 +364,7 @@ string DataSet::toString() const {
     }
     else {
       if (p.second->isTulipProperty()) {
-        PropertyInterface* prop = *((PropertyInterface **) p.second->value);
+        PropertyInterface* prop = *(static_cast<PropertyInterface **>(p.second->value));
         ss << "'" << p.first << "'=";
 
         if (prop)

--- a/library/tulip-core/src/Delaunay.cpp
+++ b/library/tulip-core/src/Delaunay.cpp
@@ -27,6 +27,11 @@
 
 #include <iostream>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 extern "C" {
 #ifdef HAVE_REENTRANT_QHULL
 #include <qhull_ra.h>
@@ -650,3 +655,7 @@ bool tlp::voronoiDiagram(vector<Coord> &sites, VoronoiDiagram &voronoiDiagram) {
   sites.resize(nbSites);
   return ret;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/library/tulip-core/src/DoubleProperty.cpp
+++ b/library/tulip-core/src/DoubleProperty.cpp
@@ -195,8 +195,8 @@ public:
                                      DoubleProperty::PredefinedMetaValueCalculator eCalc =
                                        DoubleProperty::AVG_CALC)
     :AbstractProperty<tlp::DoubleType, tlp::DoubleType, tlp::NumericProperty>::MetaValueCalculator(),
-     nodeCalc(nodeCalculators[(int) nCalc]),
-     edgeCalc(edgeCalculators[(int) eCalc]) {}
+     nodeCalc(nodeCalculators[nCalc]),
+     edgeCalc(edgeCalculators[eCalc]) {}
 
   void computeMetaValue(AbstractProperty<tlp::DoubleType, tlp::DoubleType, tlp::NumericProperty>* metric, node mN, Graph* sg, Graph*) {
     if (nodeCalc)
@@ -246,7 +246,7 @@ void DoubleProperty::nodesUniformQuantification(unsigned int k) {
 
   while(itN->hasNext()) {
     node itn=itN->next();
-    setNodeValue(itn, (double) nodeMapping[getNodeValue(itn)]);
+    setNodeValue(itn, nodeMapping[getNodeValue(itn)]);
   }
 
   delete itN;
@@ -260,14 +260,14 @@ void DoubleProperty::edgesUniformQuantification(unsigned int k) {
 
   while(itE->hasNext()) {
     edge ite=itE->next();
-    setEdgeValue(ite, (double) edgeMapping[getEdgeValue(ite)]);
+    setEdgeValue(ite, edgeMapping[getEdgeValue(ite)]);
   }
 
   delete itE;
 }
 //====================================================================
 void DoubleProperty::clone_handler(AbstractProperty< DoubleType, DoubleType, tlp::NumericProperty>& proxyC) {
-  DoubleProperty *proxy=(DoubleProperty *)&proxyC;
+  DoubleProperty *proxy = static_cast<DoubleProperty *>(&proxyC);
   minMaxNode = proxy->minMaxNode;
   minMaxEdge = proxy->minMaxEdge;
 }

--- a/library/tulip-core/src/DrawingTools.cpp
+++ b/library/tulip-core/src/DrawingTools.cpp
@@ -294,7 +294,7 @@ Coord tlp::computePolygonCentroid(const vector<Coord> &points) {
   A *= 0.5;
   Cx *= 1.0 / (6.0*A);
   Cy *= 1.0 / (6.0*A);
-  return Coord(static_cast<float>(Cx), static_cast<float>(Cy));
+  return Coord(float(Cx), float(Cy));
 }
 
 //======================================================================================================
@@ -372,7 +372,7 @@ std::vector<tlp::Coord> tlp::computeRegularPolygon(unsigned int numberOfSides, c
 
   BoundingBox box;
   vector<Coord> points;
-  float delta = (2.0f * M_PI) / static_cast<float>(numberOfSides);
+  float delta = (2.0f * M_PI) / float(numberOfSides);
 
   for (unsigned int i = 0 ; i < numberOfSides ; ++i) {
     float deltaX = cos(i * delta + startAngle);

--- a/library/tulip-core/src/Graph.cpp
+++ b/library/tulip-core/src/Graph.cpp
@@ -1360,8 +1360,7 @@ node Graph::createMetaNode(Graph *subGraph, bool multiEdges, bool edgeDelAll) {
     return node();
   }
 
-  GraphProperty* metaInfo =
-    ((GraphAbstract *)getRoot())->getMetaGraphProperty();
+  GraphProperty* metaInfo = static_cast<GraphAbstract *>(getRoot())->getMetaGraphProperty();
   node metaNode = addNode();
   metaInfo->setNodeValue(metaNode, subGraph);
   Observable::holdObservers();
@@ -1512,8 +1511,7 @@ void Graph::openMetaNode(node metaNode, bool updateProperties) {
     return;
   }
 
-  GraphProperty* metaInfo =
-    ((GraphAbstract *) getRoot())->getMetaGraphProperty();
+  GraphProperty* metaInfo = static_cast<GraphAbstract *>(getRoot())->getMetaGraphProperty();
   Graph *metaGraph = metaInfo->getNodeValue(metaNode);
 
   if (metaGraph == NULL) return;
@@ -1751,8 +1749,7 @@ struct less<MetaEdge> {
 
 void Graph::createMetaNodes(Iterator<Graph *> *itS, Graph *quotientGraph,
                             vector<node>& metaNodes) {
-  GraphProperty *metaInfo =
-    ((GraphAbstract*)getRoot())->getMetaGraphProperty();
+  GraphProperty *metaInfo = static_cast<GraphAbstract*>(getRoot())->getMetaGraphProperty();
   map <edge, set<edge> > eMapping;
   Observable::holdObservers();
   {
@@ -1987,9 +1984,9 @@ const std::vector<node>& GraphEvent::getNodes() const {
            nbElts * sizeof(node));
     // set addedNodes size using underlying vector pointers
     // to avoid unnecessary multiple constructeur calls
-    ((node **) addedNodes)[1] = ((node **) addedNodes)[0] + nbElts;
+    reinterpret_cast<node **>(addedNodes)[1] = reinterpret_cast<node **>(addedNodes)[0] + nbElts;
     // record allocated vector in vectInfos
-    ((GraphEvent *) this)->vectInfos.addedNodes = addedNodes;
+    const_cast<GraphEvent*>(this)->vectInfos.addedNodes = addedNodes;
   }
 
   return *vectInfos.addedNodes;
@@ -2008,9 +2005,9 @@ const std::vector<edge>& GraphEvent::getEdges() const {
            nbElts * sizeof(edge));
     // set addedEdges size using underlying vector pointers
     // to avoid unnecessary multiple constructeur calls
-    ((edge **) addedEdges)[1] = ((edge **) addedEdges)[0] + nbElts;
+    reinterpret_cast<edge **>(addedEdges)[1] = reinterpret_cast<edge **>(addedEdges)[0] + nbElts;
     // record allocated vector in vectInfos
-    ((GraphEvent *) this)->vectInfos.addedEdges = addedEdges;
+    const_cast<GraphEvent*>(this)->vectInfos.addedEdges = addedEdges;
   }
 
   return *vectInfos.addedEdges;

--- a/library/tulip-core/src/GraphAbstract.cpp
+++ b/library/tulip-core/src/GraphAbstract.cpp
@@ -39,7 +39,7 @@ GraphAbstract::GraphAbstract(Graph *supergraph, unsigned int sgId)
    subGraphToKeep(NULL), metaGraphProperty(NULL) {
   // get id
   if (supergraph != this)
-    id = ((GraphImpl *) getRoot())->getSubGraphId(sgId);
+    id = static_cast<GraphImpl *>(getRoot())->getSubGraphId(sgId);
 
   propertyContainer = new PropertyManager(this);
 }
@@ -65,7 +65,7 @@ GraphAbstract::~GraphAbstract() {
   delete propertyContainer;
 
   if (id != 0)
-    ((GraphImpl *) getRoot())->freeSubGraphId(id);
+    static_cast<GraphImpl *>(getRoot())->freeSubGraphId(id);
 }
 //=========================================================================
 void GraphAbstract::clear() {
@@ -179,7 +179,7 @@ void GraphAbstract::delAllSubGraphs(Graph * toRemove) {
   StableIterator<Graph *> itS(toRemove->getSubGraphs());
 
   while (itS.hasNext())
-    ((GraphAbstract*) toRemove)->delAllSubGraphs(itS.next());
+    static_cast<GraphAbstract*>(toRemove)->delAllSubGraphs(itS.next());
 
   delSubGraph(toRemove);
 }
@@ -374,7 +374,7 @@ void GraphAbstract::addLocalProperty(const std::string &name, PropertyInterface 
   propertyContainer->setLocalProperty(name, prop);
 
   if (name == metaGraphPropertyName) {
-    metaGraphProperty = (GraphProperty *) prop;
+    metaGraphProperty = static_cast<GraphProperty *>(prop);
   }
 
   notifyAddLocalProperty(name);

--- a/library/tulip-core/src/GraphImpl.cpp
+++ b/library/tulip-core/src/GraphImpl.cpp
@@ -274,7 +274,7 @@ void GraphImpl::delNode(const node n, bool) {
     delete sgs;
 
     if (sg == sgq.top()) {
-      ((GraphView *) sg)->removeNode(n, edges);
+      static_cast<GraphView *>(sg)->removeNode(n, edges);
       sgq.pop();
     }
   }
@@ -373,7 +373,7 @@ void GraphImpl::reverse(const edge e) {
   // propagate edge reversal on subgraphs
   Graph* sg;
   forEach(sg, getSubGraphs()) {
-    ((GraphView*) sg)->reverseInternal(e, eEnds.first, eEnds.second);
+    static_cast<GraphView*>(sg)->reverseInternal(e, eEnds.first, eEnds.second);
   }
 }
 //----------------------------------------------------------------
@@ -411,7 +411,7 @@ void GraphImpl::setEnds(const edge e, const node newSrc, const node newTgt) {
   node nTgt = eEnds.second;
 
   forEach(sg, getSubGraphs()) {
-    ((GraphView*) sg)->setEndsInternal(e, src, tgt, nSrc, nTgt);
+    static_cast<GraphView*>(sg)->setEndsInternal(e, src, tgt, nSrc, nTgt);
   }
 }
 //----------------------------------------------------------------

--- a/library/tulip-core/src/GraphMeasure.cpp
+++ b/library/tulip-core/src/GraphMeasure.cpp
@@ -399,7 +399,7 @@ void tlp::degree(const Graph *graph, tlp::NodeStaticProperty<double> &deg,
       double normalization = 1.0;
 
       if (nbNodes > 1 && graph->numberOfEdges())
-        normalization = 1./(double) (nbNodes - 1);
+        normalization = 1./(nbNodes - 1);
 
       switch(direction) {
       case UNDIRECTED:

--- a/library/tulip-core/src/GraphStorage.cpp
+++ b/library/tulip-core/src/GraphStorage.cpp
@@ -23,7 +23,7 @@
 
 using namespace tlp;
 
-#define VECT_SET_SIZE(v, t, sz) ((t **) v)[1] = ((t **) v)[0] + sz
+#define VECT_SET_SIZE(v, t, sz) reinterpret_cast<t **>(v)[1] = reinterpret_cast<t **>(v)[0] + sz
 #define VECT_INC_SIZE(v, t, sz) (*v).reserve(sz); VECT_SET_SIZE(v, t, sz)
 
 //=======================================================

--- a/library/tulip-core/src/GraphUpdatesRecorder.cpp
+++ b/library/tulip-core/src/GraphUpdatesRecorder.cpp
@@ -269,7 +269,7 @@ void GraphUpdatesRecorder::recordNewValues(GraphImpl* g) {
     newValuesRecorded = true;
 
     // get ids memento
-    GraphImpl* root = (GraphImpl*) g;
+    GraphImpl* root = static_cast<GraphImpl*>(g);
     assert(newIdsState == NULL);
 
     // record ids memento only if needed
@@ -597,7 +597,7 @@ void GraphUpdatesRecorder::recordNewEdgeValues(PropertyInterface* p) {
 void GraphUpdatesRecorder::startRecording(GraphImpl* g) {
   if (g->getSuperGraph() == g) {
     if (oldIdsState == NULL)
-      oldIdsState = ((GraphImpl*) g)->storage.getIdsMemento();
+      oldIdsState = static_cast<GraphImpl*>(g)->storage.getIdsMemento();
   }
 
   restartRecording(g);
@@ -696,7 +696,7 @@ void GraphUpdatesRecorder::doUpdates(GraphImpl* g, bool undo) {
     propsToDel.begin();
 
   while(itpg != propsToDel.end()) {
-    Graph* g = (Graph*) itpg->first;
+    Graph* g = itpg->first;
     set<PropertyInterface*>::const_iterator itp = itpg->second.begin();
     set<PropertyInterface*>::const_iterator itpe = itpg->second.end();
 
@@ -713,7 +713,7 @@ void GraphUpdatesRecorder::doUpdates(GraphImpl* g, bool undo) {
   std::list<std::pair<Graph*, Graph*> >::const_iterator its = subGraphsToDel.begin();
 
   while(its != subGraphsToDel.end()) {
-    Graph* g = (Graph*) its->first;
+    Graph* g = its->first;
     Graph* sg = its->second;
 
     // remove from list of subgraphs + notify observers
@@ -937,7 +937,7 @@ void GraphUpdatesRecorder::doUpdates(GraphImpl* g, bool undo) {
   itpg = propsToAdd.begin();
 
   while(itpg != propsToAdd.end()) {
-    Graph* g = (Graph*) itpg->first;
+    Graph* g = itpg->first;
     set<PropertyInterface*>::const_iterator itp = itpg->second.begin();
     set<PropertyInterface*>::const_iterator itpe = itpg->second.end();
 
@@ -1289,7 +1289,7 @@ void GraphUpdatesRecorder::delNode(Graph* g, node n) {
   }
 
   if (g == g->getSuperGraph())
-    recordEdgeContainer(oldContainers, (GraphImpl*) g, n);
+    recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), n);
 }
 
 void GraphUpdatesRecorder::delEdge(Graph* g, edge e) {
@@ -1382,8 +1382,8 @@ void GraphUpdatesRecorder::delEdge(Graph* g, edge e) {
   if (g == g->getSuperGraph()) {
     // record source & target old containers
     const pair<node, node> &eEnds = g->ends(e);
-    recordEdgeContainer(oldContainers, (GraphImpl*) g, eEnds.first);
-    recordEdgeContainer(oldContainers, (GraphImpl*) g, eEnds.second);
+    recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), eEnds.first);
+    recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), eEnds.second);
   }
 }
 
@@ -1416,8 +1416,8 @@ void GraphUpdatesRecorder::reverseEdge(Graph* g, edge e) {
         revertedEdges.insert(e);
         // record source & target old containers
         const pair<node, node>& eEnds = g->ends(e);
-        recordEdgeContainer(oldContainers, (GraphImpl*) g, eEnds.first);
-        recordEdgeContainer(oldContainers, (GraphImpl*) g, eEnds.second);
+        recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), eEnds.first);
+        recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), eEnds.second);
       }
     }
   }
@@ -1440,8 +1440,8 @@ void GraphUpdatesRecorder::beforeSetEnds(Graph* g, edge e) {
     }
     else {
       // record source & target old containers
-      recordEdgeContainer(oldContainers, (GraphImpl*) g, ends.first);
-      recordEdgeContainer(oldContainers, (GraphImpl*) g, ends.second);
+      recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), ends.first);
+      recordEdgeContainer(oldContainers, static_cast<GraphImpl*>(g), ends.second);
     }
 
     // add e old ends in oldEdgesEnds

--- a/library/tulip-core/src/GraphView.cpp
+++ b/library/tulip-core/src/GraphView.cpp
@@ -144,7 +144,7 @@ void GraphView::reverseInternal(const edge e, const node src, const node tgt) {
     // propagate edge reversal on subgraphs
     Graph* sg;
     forEach(sg, getSubGraphs()) {
-      ((GraphView*) sg)->reverseInternal(e, src, tgt);
+      static_cast<GraphView*>(sg)->reverseInternal(e, src, tgt);
     }
   }
 }
@@ -183,7 +183,7 @@ void GraphView::setEndsInternal(const edge e, node src, node tgt,
       // propagate edge ends update on subgraphs
       Graph* sg;
       forEach(sg, getSubGraphs()) {
-        ((GraphView*) sg)->setEndsInternal(e, src, tgt, newSrc, newTgt);
+        static_cast<GraphView*>(sg)->setEndsInternal(e, src, tgt, newSrc, newTgt);
       }
     }
     else {
@@ -191,7 +191,7 @@ void GraphView::setEndsInternal(const edge e, node src, node tgt,
       // propagate edge ends update on subgraphs
       Graph* sg;
       forEach(sg, getSubGraphs()) {
-        ((GraphView*) sg)->setEndsInternal(e, src, tgt, newSrc, newTgt);
+        static_cast<GraphView*>(sg)->setEndsInternal(e, src, tgt, newSrc, newTgt);
       }
       notifyDelEdge(e);
 
@@ -449,7 +449,7 @@ void GraphView::delNode(const node n, bool deleteInAllGraphs) {
       delete sgs;
 
       if (sg == sgq.top()) {
-        ((GraphView *) sg)->removeNode(n, ee);
+        static_cast<GraphView *>(sg)->removeNode(n, ee);
         sgq.pop();
       }
     }

--- a/library/tulip-core/src/IdManager.cpp
+++ b/library/tulip-core/src/IdManager.cpp
@@ -101,6 +101,6 @@ ostream& tlp::operator<<(std::ostream &os,const tlp::IdManager &idM) {
   os << "Minimum index :" << idM.state.firstId<< endl;
   os << "Maximum index :" << idM.state.nextId - 1 << endl;
   os << "Size          :" << idM.state.freeIds.size() << endl;
-  os << "Fragmentation :" << (double)idM.state.freeIds.size() / (1+idM.state.nextId - idM.state.firstId) << endl;
+  os << "Fragmentation :" << double(idM.state.freeIds.size()) / (1+idM.state.nextId - idM.state.firstId) << endl;
   return os;
 }

--- a/library/tulip-core/src/IntegerProperty.cpp
+++ b/library/tulip-core/src/IntegerProperty.cpp
@@ -34,7 +34,7 @@ IntegerProperty::IntegerProperty (Graph *g, const std::string& n):IntegerMinMaxP
 //====================================================================
 void IntegerProperty::clone_handler(AbstractProperty<tlp::IntegerType, tlp::IntegerType, tlp::NumericProperty> &proxyC) {
   if (typeid(this)==typeid(&proxyC)) {
-    IntegerProperty *proxy=(IntegerProperty *)&proxyC;
+    IntegerProperty *proxy = static_cast<IntegerProperty *>(&proxyC);
     minMaxNode = proxy->minMaxNode;
     minMaxEdge = proxy->minMaxEdge;
   }

--- a/library/tulip-core/src/LayoutProperty.cpp
+++ b/library/tulip-core/src/LayoutProperty.cpp
@@ -67,7 +67,7 @@ std::pair<tlp::Coord, tlp::Coord> tlp::MinMaxProperty<tlp::PointType, tlp::LineT
 
   delete itN;
 
-  if (((LayoutProperty *) this)->nbBendedEdges > 0) {
+  if (static_cast<LayoutProperty *>(this)->nbBendedEdges > 0) {
     tlp::Iterator<edge> *itE = sg->getEdges();
 
     while (itE->hasNext()) {
@@ -111,7 +111,7 @@ void tlp::MinMaxProperty<tlp::PointType, tlp::LineType>::updateEdgeValue(tlp::ed
   if (newValue == oldV)
     return;
 
-  ((LayoutProperty*) this)->nbBendedEdges += (newValue.empty() ? 0 : 1) - (oldV.empty() ? 0 : 1);
+  static_cast<LayoutProperty*>(this)->nbBendedEdges += (newValue.empty() ? 0 : 1) - (oldV.empty() ? 0 : 1);
 
   if (it != minMaxNode.end()) {
     // loop on subgraph min/max
@@ -160,7 +160,7 @@ void tlp::MinMaxProperty<tlp::PointType, tlp::LineType>::updateEdgeValue(tlp::ed
 
       // reset bounding box if needed
       if (reset) {
-        needGraphListener = (((LayoutProperty*) this)->nbBendedEdges > 0);
+        needGraphListener = static_cast<LayoutProperty*>(this)->nbBendedEdges > 0;
         removeListenersAndClearNodeMap();
         return;
       }
@@ -169,7 +169,7 @@ void tlp::MinMaxProperty<tlp::PointType, tlp::LineType>::updateEdgeValue(tlp::ed
 
   // we need to observe the graph as soon as there is an edge
   // with bends
-  if (!needGraphListener && (needGraphListener = (((LayoutProperty*) this)->nbBendedEdges > 0)) &&
+  if (!needGraphListener && (needGraphListener = (static_cast<LayoutProperty*>(this)->nbBendedEdges > 0)) &&
       (minMaxNode.find(graph->getId()) == minMaxNode.end()))
     graph->addListener(this);
 }
@@ -202,14 +202,14 @@ public:
       return;
 
     case 1:
-      layout->setNodeValue(mN,((LayoutProperty *)layout)->getMax(sg));
+      layout->setNodeValue(mN, static_cast<LayoutProperty *>(layout)->getMax(sg));
       return;
 
     default:
       // between the min and max computed values
       layout->setNodeValue(mN,
-                           (((LayoutProperty *)layout)->getMax(sg) +
-                            ((LayoutProperty *)layout)->getMin(sg)) / 2.0f);
+                           (static_cast<LayoutProperty *>(layout)->getMax(sg) +
+                            static_cast<LayoutProperty *>(layout)->getMin(sg)) / 2.0f);
     }
   }
 };
@@ -242,8 +242,8 @@ Coord  LayoutProperty::getMin(const Graph *sg) {
 static void rotateVector(Coord &vec, double alpha, int rot) {
   Coord backupVec(vec);
   double aRot =  2.0*M_PI * alpha / 360.0;
-  float cosA = static_cast<float>(cos(aRot));
-  float sinA = static_cast<float>(sin(aRot));
+  float cosA = float(cos(aRot));
+  float sinA = float(sin(aRot));
 
   switch(rot) {
   case Z_ROT:
@@ -353,7 +353,7 @@ void LayoutProperty::scale(const tlp::Vec3f& v, Iterator<node> *itN, Iterator<ed
   while (itN->hasNext()) {
     node itn = itN->next();
     Coord tmpCoord(getNodeValue(itn));
-    tmpCoord *= *(Coord*)&v;
+    tmpCoord *= v;
     setNodeValue(itn,tmpCoord);
   }
 
@@ -366,7 +366,7 @@ void LayoutProperty::scale(const tlp::Vec3f& v, Iterator<node> *itN, Iterator<ed
       itCoord=tmp.begin();
 
       while(itCoord!=tmp.end()) {
-        *itCoord *= *(Coord*)&v;
+        *itCoord *= v;
         ++itCoord;
       }
 
@@ -408,7 +408,7 @@ void LayoutProperty::translate(const tlp::Vec3f& v, Iterator<node> *itN, Iterato
     while (itN->hasNext()) {
       node itn = itN->next();
       Coord tmpCoord(getNodeValue(itn));
-      tmpCoord += *(Coord*)&v;
+      tmpCoord += v;
       // minimize computation time
       LayoutMinMaxProperty::setNodeValue(itn,tmpCoord);
     }
@@ -423,7 +423,7 @@ void LayoutProperty::translate(const tlp::Vec3f& v, Iterator<node> *itN, Iterato
         itCoord=tmp.begin();
 
         while(itCoord!=tmp.end()) {
-          *itCoord += *(Coord*)&v;
+          *itCoord += v;
           ++itCoord;
         }
 
@@ -498,7 +498,7 @@ void LayoutProperty::normalize(const Graph *sg) {
 
   delete itN;
   dtmpMax = 1.0 / sqrt(dtmpMax);
-  scale(Coord(static_cast<float>(dtmpMax),static_cast<float>(dtmpMax),static_cast<float>(dtmpMax)), sg);
+  scale(Coord(float(dtmpMax),float(dtmpMax),float(dtmpMax)), sg);
   resetBoundingBox();
   Observable::unholdObservers();
 }
@@ -511,9 +511,9 @@ void LayoutProperty::perfectAspectRatio(const Graph *subgraph) {
   center(subgraph);
   double scaleX,scaleY,scaleZ;
   double deltaX,deltaY,deltaZ;
-  deltaX = (double )getMax()[0]-(double )getMin()[0];
-  deltaY = (double )getMax()[1]-(double )getMin()[1];
-  deltaZ = (double )getMax()[2]-(double )getMin()[2];
+  deltaX = double(getMax()[0])-double(getMin()[0]);
+  deltaY = double(getMax()[1])-double(getMin()[1]);
+  deltaZ = double(getMax()[2])-double(getMin()[2]);
   double delta = std::max(deltaX , deltaY);
   delta = std::max(delta, deltaZ);
 
@@ -528,14 +528,14 @@ void LayoutProperty::perfectAspectRatio(const Graph *subgraph) {
   scaleX = delta / deltaX;
   scaleY = delta / deltaY;
   scaleZ = delta / deltaZ;
-  scale(Coord(static_cast<float>(scaleX),static_cast<float>(scaleY),static_cast<float>(scaleZ)),subgraph);
+  scale(Coord(float(scaleX),float(scaleY),float(scaleZ)),subgraph);
   Observable::unholdObservers();
 }
 
 //=================================================================================
 void LayoutProperty::clone_handler(AbstractProperty<tlp::PointType, tlp::LineType>& proxyC) {
   if (typeid(this)==typeid(&proxyC)) {
-    LayoutProperty *proxy=(LayoutProperty *)&proxyC;
+    LayoutProperty *proxy=static_cast<LayoutProperty *>(&proxyC);
     minMaxNode = proxy->minMaxNode;
   }
 }
@@ -596,7 +596,7 @@ double LayoutProperty::averageAngularResolution(const Graph *sg) const {
   }
 
   delete itN;
-  return result/(double)sg->numberOfNodes();
+  return result/double(sg->numberOfNodes());
 }
 //=================================================================================
 struct AngularOrder {

--- a/library/tulip-core/src/Observable.cpp
+++ b/library/tulip-core/src/Observable.cpp
@@ -390,8 +390,8 @@ void Observable::addOnlooker(const Observable &obs, OBSERVABLEEDGETYPE type) con
     if (!link.isValid()) {
       // add new link
       // at this time both Observables need to be bound
-      link = _oGraph.addEdge(((Observable &) obs).getBoundNode(),
-      ((Observable *) this)->getBoundNode());
+      link = _oGraph.addEdge(const_cast<Observable &>(obs).getBoundNode(),
+      const_cast<Observable *>(this)->getBoundNode());
       _oType[link] = type;
     }
     else {

--- a/library/tulip-core/src/Ordering.cpp
+++ b/library/tulip-core/src/Ordering.cpp
@@ -955,7 +955,7 @@ void Ordering::selectAndUpdate(node n) {
   n2 = Gp->opposite(e,n1);
   bool spli = false;
 
-  for(int i = 0; static_cast<unsigned int>(i) < noeuds.size()-1; i++) {
+  for(int i = 0; uint(i) < noeuds.size()-1; i++) {
     bool entered=false;
 
     while(n2 != noeuds[i+1]) {
@@ -1007,7 +1007,7 @@ void Ordering::selectAndUpdate(node n) {
   }
 
   // update visitedFaces
-  for(int i = 0; static_cast<unsigned int>(i)<noeuds.size(); i++) {
+  for(int i = 0; uint(i)<noeuds.size(); i++) {
     int deg = Gp->deg(noeuds[i]);
     Iterator<Face > * itf = Gp->getFacesAdj(noeuds[i]);
 
@@ -1043,7 +1043,7 @@ void Ordering::selectAndUpdate(node n) {
   vector<Face> v_face;
   update_seqp.setAll(false);
 
-  for(int i=0; static_cast<unsigned int>(i)<faces.size(); i++) {
+  for(int i=0; uint(i)<faces.size(); i++) {
     if(splited[i]) {
       outv.set((faces[i]).id,0);
       oute.set((faces[i]).id,0);

--- a/library/tulip-core/src/OuterPlanarTest.cpp
+++ b/library/tulip-core/src/OuterPlanarTest.cpp
@@ -108,11 +108,10 @@ void OuterPlanarTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       resultsBuffer.erase(graph);
   }
 }

--- a/library/tulip-core/src/ParametricCurves.cpp
+++ b/library/tulip-core/src/ParametricCurves.cpp
@@ -24,7 +24,7 @@ using namespace std;
 namespace tlp {
 
 static void computeLinearBezierPoints(const Coord &p0, const Coord &p1, vector<Coord> &curvePoints, const unsigned int nbCurvePoints) {
-  float h = 1.0 / static_cast<float>((nbCurvePoints - 1));
+  float h = 1.0 / float((nbCurvePoints - 1));
   Coord firstFD((p1 - p0) * h);
   Coord c(p0);
 
@@ -46,7 +46,7 @@ static void computeLinearBezierPoints(const Coord &p0, const Coord &p1, vector<C
 static void computeQuadraticBezierPoints(const Coord &p0, const Coord &p1, const Coord &p2, vector<Coord> &curvePoints, const unsigned int nbCurvePoints) {
 
   // Compute our step size
-  float h = 1.0 / static_cast<float>(nbCurvePoints - 1);
+  float h = 1.0 / float(nbCurvePoints - 1);
   float h2 = h*h;
 
   // Compute Initial forward difference
@@ -81,7 +81,7 @@ static void computeCubicBezierPoints(const Coord &p0, const Coord &p1, const Coo
   Coord C(p0 * -3.f + p1 * 3.f);
 
   // Compute our step size
-  float h = 1.0 / static_cast<float>(nbCurvePoints - 1);
+  float h = 1.0 / float(nbCurvePoints - 1);
   float h2 = h*h;
   float h3 = h2*h;
   float h36 = h3*6;
@@ -149,8 +149,8 @@ static void computeCoefficients(double t, unsigned int nbControlPoints) {
     vector<double> tCoeff, sCoeff;
 
     for (size_t i = 0 ; i < nbControlPoints ; ++i) {
-      tCoeff.push_back(pow(t, static_cast<double>(i)));
-      sCoeff.push_back(pow(s, static_cast<double>(i)));
+      tCoeff.push_back(pow(t, double(i)));
+      sCoeff.push_back(pow(s, double(i)));
     }
 
     tCoeffs[t] = tCoeff;
@@ -164,8 +164,8 @@ static void computeCoefficients(double t, unsigned int nbControlPoints) {
       size_t oldSize = tCoeff.size();
 
       for (size_t i = oldSize ; i < nbControlPoints ; ++i) {
-        tCoeff.push_back(pow(t, static_cast<double>(i)));
-        sCoeff.push_back(pow(s, static_cast<double>(i)));
+        tCoeff.push_back(pow(t, double(i)));
+        sCoeff.push_back(pow(s, double(i)));
       }
     }
   }
@@ -180,15 +180,15 @@ Coord computeBezierPoint(const vector<Coord> &controlPoints, const float t) {
   Vector<double, 3> bezierPoint;
   bezierPoint[0] = bezierPoint[1] = bezierPoint[2] = 0;
   double curCoeff = 1.0;
-  double r = static_cast<double>(nbControlPoints);
+  double r = double(nbControlPoints);
 
   for (size_t i = 0 ; i < controlPoints.size() ; ++i) {
     Vector<double, 3> controlPoint;
     controlPoint[0] = controlPoints[i][0];
     controlPoint[1] = controlPoints[i][1];
     controlPoint[2] = controlPoints[i][2];
-    bezierPoint += controlPoint * curCoeff * tCoeffs[static_cast<double>(t)][i] * sCoeffs[static_cast<double>(t)][nbControlPoints - 1 - i];
-    double c = static_cast<double>(i+1);
+    bezierPoint += controlPoint * curCoeff * tCoeffs[double(t)][i] * sCoeffs[double(t)][nbControlPoints - 1 - i];
+    double c = double(i+1);
     curCoeff *= (r -c)/c;
   }
 
@@ -214,7 +214,7 @@ void computeBezierPoints(const vector<Coord> &controlPoints, vector<Coord> &curv
 
   default:
     curvePoints.resize(nbCurvePoints);
-    float h = 1.0 / static_cast<float>(nbCurvePoints - 1);
+    float h = 1.0 / float(nbCurvePoints - 1);
 // With Visual Studio, the parallelization of the curve points computation
 // leads to incorrect results (why? I don't know ...)
 #if defined(_OPENMP) && !defined(_MSC_VER)
@@ -239,7 +239,7 @@ static void computeCatmullRomGlobalParameter(const vector<Coord> &controlPoints,
   float totalDist = 0.f;
 
   for (size_t i = 1 ; i < controlPoints.size() ; ++i) {
-    float dist = pow((float) controlPoints[i-1].dist(controlPoints[i]), alpha);
+    float dist = pow(controlPoints[i-1].dist(controlPoints[i]), alpha);
     cumDist[i] = cumDist[i-1] + dist;
     totalDist += dist;
   }
@@ -349,7 +349,7 @@ void computeCatmullRomPoints(const vector<Coord> &controlPoints, vector<Coord> &
 #endif
 
   for (OMP_ITER_TYPE i = 0 ; i < nbCurvePoints ; ++i) {
-    curvePoints[i] = computeCatmullRomPointImpl(controlPointsCp, i / static_cast<float>(nbCurvePoints - 1), globalParameter, closedCurve, alpha);
+    curvePoints[i] = computeCatmullRomPointImpl(controlPointsCp, i / float(nbCurvePoints - 1), globalParameter, closedCurve, alpha);
   }
 }
 
@@ -360,7 +360,7 @@ static float clamp(float f, float minVal, float maxVal) {
 Coord computeOpenUniformBsplinePoint(const vector<Coord> &controlPoints, const float t, const unsigned int curveDegree) {
   assert(controlPoints.size() > 3);
   unsigned int nbKnots = controlPoints.size() + curveDegree + 1;
-  float stepKnots = 1.0f / ((static_cast<float>(nbKnots) - 2.0f * (static_cast<float>(curveDegree) + 1.0f)) + 2.0f - 1.0f);
+  float stepKnots = 1.0f / ((float(nbKnots) - 2.0f * (float(curveDegree) + 1.0f)) + 2.0f - 1.0f);
 
   if (t == 0.0) {
     return controlPoints[0];
@@ -382,7 +382,7 @@ Coord computeOpenUniformBsplinePoint(const vector<Coord> &controlPoints, const f
     float knotVal = (cpt * stepKnots);
     coeffs[curveDegree] = 1.0;
 
-    for (int i = 1 ; i <= static_cast<int>(curveDegree) ; ++i) {
+    for (int i = 1 ; i <= int(curveDegree) ; ++i) {
       coeffs[curveDegree-i] = (clamp(knotVal + stepKnots, 0.0, 1.0) - t) / (clamp(knotVal + stepKnots, 0.0, 1.0) - clamp(knotVal + (-i+1) * stepKnots, 0.0, 1.0)) * coeffs[curveDegree-i+1];
       int tabIdx = curveDegree-i+1;
 
@@ -414,7 +414,7 @@ void computeOpenUniformBsplinePoints(const vector<Coord> &controlPoints, vector<
 #endif
 
   for (OMP_ITER_TYPE i = 0 ; i < nbCurvePoints ; ++i) {
-    curvePoints[i] = computeOpenUniformBsplinePoint(controlPoints, i / static_cast<float>(nbCurvePoints - 1), curveDegree);
+    curvePoints[i] = computeOpenUniformBsplinePoint(controlPoints, i / float(nbCurvePoints - 1), curveDegree);
   }
 }
 

--- a/library/tulip-core/src/PlanarityTest.cpp
+++ b/library/tulip-core/src/PlanarityTest.cpp
@@ -157,11 +157,10 @@ void PlanarityTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       resultsBuffer.erase(graph);
   }
 }

--- a/library/tulip-core/src/PluginLibraryLoader.cpp
+++ b/library/tulip-core/src/PluginLibraryLoader.cpp
@@ -333,12 +333,13 @@ bool PluginLibraryLoader::initPluginDir(PluginLoader *loader, bool recursive) {
 #else
 
   struct dirent **namelist;
-  int n = scandir((const char *) pluginPath.c_str(),
+  int n = scandir(pluginPath.c_str(),
                   &namelist,
 #if !(defined(__APPLE__) || defined(__FreeBSD__)) || (defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
-                  (int (*) (const dirent *))
-#endif
+                  reinterpret_cast<int (*) (const dirent *)>(__tulip_select_libs),
+#else
                   __tulip_select_libs,
+#endif
                   alphasort);
 
   if (loader!=NULL)
@@ -416,12 +417,13 @@ bool PluginLibraryLoader::initPluginDir(PluginLoader *loader, bool recursive) {
 
   if (recursive) {
 
-    n = scandir((const char *) pluginPath.c_str(),
+    n = scandir(pluginPath.c_str(),
                 &namelist,
 #if !(defined(__APPLE__) || defined(__FreeBSD__)) || (defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
-                (int (*) (const dirent *))
-#endif
+                reinterpret_cast<int (*) (const dirent *)>(__tulip_select_dirs),
+#else
                 __tulip_select_dirs,
+#endif
                 alphasort);
 
     std::string rootPath = pluginPath;

--- a/library/tulip-core/src/PluginLister.cpp
+++ b/library/tulip-core/src/PluginLister.cpp
@@ -27,7 +27,7 @@ PluginLoader* PluginLister::currentLoader = NULL;
 PluginLister* PluginLister::_instance = NULL;
 
 tlp::PluginLister* PluginLister::instance() {
-  if(dynamic_cast<tlp::PluginLister*>(_instance) == 0) {
+  if(_instance == NULL) {
     _instance = new PluginLister();
   }
 

--- a/library/tulip-core/src/PropertyManager.cpp
+++ b/library/tulip-core/src/PropertyManager.cpp
@@ -81,7 +81,7 @@ PropertyManager::PropertyManager(Graph *g): graph(g) {
       inheritedProperties[prop->getName()] = prop;
 
       if (prop->getName() == metaGraphPropertyName)
-        ((GraphAbstract *) graph)->metaGraphProperty = (GraphProperty *) prop;
+        static_cast<GraphAbstract *>(graph)->metaGraphProperty = static_cast<GraphProperty *>(prop);
     }
 
     delete it;
@@ -135,14 +135,14 @@ void PropertyManager::setLocalProperty(const string &str,
 
   //If we had an inherited property notify it's destruction.
   if(hasInheritedProperty) {
-    ((GraphAbstract *) graph)->notifyAfterDelInheritedProperty(str);
+    static_cast<GraphAbstract *>(graph)->notifyAfterDelInheritedProperty(str);
   }
 
   // loop on subgraphs
   Graph* sg;
   forEach(sg, graph->getSubGraphs()) {
     // to set p as inherited property
-    (((GraphAbstract *) sg)->propertyContainer)->setInheritedProperty(str, p);
+    static_cast<GraphAbstract *>(sg)->propertyContainer->setInheritedProperty(str, p);
   }
 }
 //==============================================================
@@ -163,7 +163,7 @@ bool PropertyManager::renameLocalProperty(PropertyInterface *prop,
   assert(it->second == prop);
 
   // before rename notification
-  ((GraphAbstract *) graph)->notifyBeforeRenameLocalProperty(prop, newName);
+  static_cast<GraphAbstract *>(graph)->notifyBeforeRenameLocalProperty(prop, newName);
 
   // loop in the ascendant hierarchy to get
   // an inherited property
@@ -182,13 +182,13 @@ bool PropertyManager::renameLocalProperty(PropertyInterface *prop,
   //Warn subgraphs for deletion.
   Graph* sg;
   forEach(sg, graph->getSubGraphs()) {
-    (((GraphAbstract *) sg)->propertyContainer)->notifyBeforeDelInheritedProperty(propName);
+    static_cast<GraphAbstract *>(sg)->propertyContainer->notifyBeforeDelInheritedProperty(propName);
   }
 
   //Remove property from map.
   localProperties.erase(it);
   //Set the inherited property in this graph and all it's subgraphs.
-  (((GraphAbstract *) graph)->propertyContainer)->setInheritedProperty(propName, newProp);
+  static_cast<GraphAbstract *>(graph)->propertyContainer->setInheritedProperty(propName, newProp);
 
   // remove previously existing inherited property
   bool hasInheritedProperty =
@@ -206,20 +206,20 @@ bool PropertyManager::renameLocalProperty(PropertyInterface *prop,
 
   //If we had an inherited property notify it's destruction.
   if(hasInheritedProperty) {
-    ((GraphAbstract *) graph)->notifyAfterDelInheritedProperty(newName);
+    static_cast<GraphAbstract *>(graph)->notifyAfterDelInheritedProperty(newName);
   }
 
   // loop on subgraphs
   forEach(sg, graph->getSubGraphs()) {
     // to set p as inherited property
-    (((GraphAbstract *) sg)->propertyContainer)->setInheritedProperty(newName, prop);
+    static_cast<GraphAbstract *>(sg)->propertyContainer->setInheritedProperty(newName, prop);
   }
 
   // update property name
   prop->name = newName;
 
   // after renaming notification
-  ((GraphAbstract *) graph)->notifyAfterRenameLocalProperty(prop, propName);
+  static_cast<GraphAbstract *>(graph)->notifyAfterRenameLocalProperty(prop, propName);
 
   return true;
 }
@@ -230,11 +230,11 @@ void PropertyManager::setInheritedProperty(const string &str,
     bool hasInheritedProperty = inheritedProperties.find(str)!=inheritedProperties.end();
 
     if( p != NULL) {
-      ((GraphAbstract *) graph)->notifyBeforeAddInheritedProperty(str);
+      static_cast<GraphAbstract *>(graph)->notifyBeforeAddInheritedProperty(str);
       inheritedProperties[str] = p;
 
       if (str == metaGraphPropertyName)
-        ((GraphAbstract *) graph)->metaGraphProperty = (GraphProperty *) p;
+        static_cast<GraphAbstract *>(graph)->metaGraphProperty = static_cast<GraphProperty *>(p);
     }
     else {
       // no need for notification
@@ -244,19 +244,19 @@ void PropertyManager::setInheritedProperty(const string &str,
     }
 
     if(hasInheritedProperty) {
-      ((GraphAbstract *) graph)->notifyAfterDelInheritedProperty(str);
+      static_cast<GraphAbstract *>(graph)->notifyAfterDelInheritedProperty(str);
     }
 
     // graph observers notification
     if( p != NULL) {
-      ((GraphAbstract *) graph)->notifyAddInheritedProperty(str);
+      static_cast<GraphAbstract *>(graph)->notifyAddInheritedProperty(str);
     }
 
     // loop on subgraphs
     Graph* sg;
     forEach(sg, graph->getSubGraphs()) {
       // to set p as inherited property
-      (((GraphAbstract *) sg)->propertyContainer)->setInheritedProperty(str, p);
+      static_cast<GraphAbstract *>(sg)->propertyContainer->setInheritedProperty(str, p);
     }
   }
 }
@@ -275,12 +275,12 @@ PropertyInterface* PropertyManager::getProperty(const string &str) const {
 //==============================================================
 PropertyInterface* PropertyManager::getLocalProperty(const string &str) const {
   assert(existLocalProperty(str));
-  return ((PropertyManager *)this)->localProperties[str];
+  return const_cast<PropertyManager *>(this)->localProperties[str];
 }
 //==============================================================
 PropertyInterface* PropertyManager::getInheritedProperty(const string &str) const {
   assert(existInheritedProperty(str));
-  return ((PropertyManager *)this)->inheritedProperties[str];
+  return const_cast<PropertyManager *>(this)->inheritedProperties[str];
 }
 //==============================================================
 void PropertyManager::delLocalProperty(const string &str) {
@@ -308,13 +308,13 @@ void PropertyManager::delLocalProperty(const string &str) {
     //Warn subgraphs.
     Graph* sg;
     forEach(sg, graph->getSubGraphs()) {
-      (((GraphAbstract *) sg)->propertyContainer)->notifyBeforeDelInheritedProperty(str);
+      static_cast<GraphAbstract *>(sg)->propertyContainer->notifyBeforeDelInheritedProperty(str);
     }
 
     //Remove property from map.
     localProperties.erase(it);
     //Set the inherited property in this graph and all it's subgraphs.
-    (((GraphAbstract *) graph)->propertyContainer)->setInheritedProperty(str, newProp);
+    static_cast<GraphAbstract *>(graph)->propertyContainer->setInheritedProperty(str, newProp);
 
     //Delete property
     //Need to be done after subgraph notification.
@@ -333,31 +333,31 @@ void PropertyManager::notifyBeforeDelInheritedProperty(const string& str) {
   // if found remove from inherited properties
   if (it != inheritedProperties.end()) {
     // graph observers notification
-    ((GraphAbstract *) graph)->notifyBeforeDelInheritedProperty(str);
+    static_cast<GraphAbstract *>(graph)->notifyBeforeDelInheritedProperty(str);
     // loop on subgraphs
     Graph* sg;
     forEach(sg, graph->getSubGraphs()) {
       // to remove as inherited property
-      (((GraphAbstract *) sg)->propertyContainer)->notifyBeforeDelInheritedProperty(str);
+      static_cast<GraphAbstract *>(sg)->propertyContainer->notifyBeforeDelInheritedProperty(str);
     }
   }
 }
 
 Iterator<string>*  PropertyManager::getLocalProperties() {
-  return (new PropertyNamesIterator(localProperties.begin(),
-                                    localProperties.end()));
+  return new PropertyNamesIterator(localProperties.begin(),
+                                   localProperties.end());
 }
 Iterator<string>*  PropertyManager::getInheritedProperties() {
-  return (new PropertyNamesIterator(inheritedProperties.begin(),
-                                    inheritedProperties.end()));
+  return new PropertyNamesIterator(inheritedProperties.begin(),
+                                   inheritedProperties.end());
 }
 Iterator<PropertyInterface*>*  PropertyManager::getLocalObjectProperties() {
-  return (new PropertiesIterator(localProperties.begin(),
-                                 localProperties.end()));
+  return new PropertiesIterator(localProperties.begin(),
+                                localProperties.end());
 }
 Iterator<PropertyInterface*>*  PropertyManager::getInheritedObjectProperties() {
-  return (new PropertiesIterator(inheritedProperties.begin(),
-                                 inheritedProperties.end()));
+  return new PropertiesIterator(inheritedProperties.begin(),
+                                inheritedProperties.end());
 }
 //===============================================================
 void PropertyManager::erase(const node n) {

--- a/library/tulip-core/src/SimpleTest.cpp
+++ b/library/tulip-core/src/SimpleTest.cpp
@@ -152,11 +152,10 @@ void SimpleTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       deleteResult(graph);
   }
 }

--- a/library/tulip-core/src/SizeProperty.cpp
+++ b/library/tulip-core/src/SizeProperty.cpp
@@ -58,8 +58,8 @@ public:
     else
       // between the min and max computed values for other size properties
       prop->setNodeValue(mN,
-                         (((SizeProperty *)prop)->getMax(sg) +
-                          ((SizeProperty *)prop)->getMin(sg)) / 2.0f);
+                         (static_cast<SizeProperty *>(prop)->getMax(sg) +
+                          static_cast<SizeProperty *>(prop)->getMin(sg)) / 2.0f);
   }
 };
 

--- a/library/tulip-core/src/TLPExport.cpp
+++ b/library/tulip-core/src/TLPExport.cpp
@@ -375,7 +375,7 @@ public:
           // for GraphProperty we must ensure the reindexing
           // of embedded edges
           edge ite = itE->next();
-          const set<edge>& edges = ((GraphProperty*)prop)->getEdgeValue(ite);
+          const set<edge>& edges = static_cast<GraphProperty*>(prop)->getEdgeValue(ite);
           set<edge> rEdges;
           set<edge>::const_iterator its;
 
@@ -439,22 +439,22 @@ public:
       pair<string, DataType*> attribute;
       forEach(attribute, attributes.getValues()) {
         if (attribute.second->getTypeName() == string(typeid(node).name())) {
-          node *n = reinterpret_cast<node*>(attribute.second->value);
+          node *n = static_cast<node*>(attribute.second->value);
           n->id = getNode(*n).id;
         }
         else if (attribute.second->getTypeName() == string(typeid(edge).name())) {
-          edge *e = reinterpret_cast<edge*>(attribute.second->value);
+          edge *e = static_cast<edge*>(attribute.second->value);
           e->id = getEdge(*e).id;
         }
         else if (attribute.second->getTypeName() == string(typeid(vector<node>).name())) {
-          vector<node> *vn = reinterpret_cast<vector<node>*>(attribute.second->value);
+          vector<node> *vn = static_cast<vector<node>*>(attribute.second->value);
 
           for (size_t i = 0 ; i < vn->size() ; ++i) {
             (*vn)[i].id = getNode((*vn)[i]).id;
           }
         }
         else if (attribute.second->getTypeName() == string(typeid(vector<edge>).name())) {
-          vector<edge> *ve = reinterpret_cast<vector<edge>*>(attribute.second->value);
+          vector<edge> *ve = static_cast<vector<edge>*>(attribute.second->value);
 
           for (size_t i = 0 ; i < ve->size() ; ++i) {
             (*ve)[i].id = getEdge((*ve)[i]).id;

--- a/library/tulip-core/src/TLPImport.cpp
+++ b/library/tulip-core/src/TLPImport.cpp
@@ -95,7 +95,7 @@ struct TLPGraphBuilder:public TLPTrue {
   bool inTLP;
   double version;
 
-  TLPGraphBuilder(Graph *graph, DataSet *dataSet): _graph((GraphImpl *) graph),
+  TLPGraphBuilder(Graph *graph, DataSet *dataSet): _graph(static_cast<GraphImpl*>(graph)),
     _cluster(NULL), dataSet(dataSet) {
     clusterIndex[0]=graph;
     inTLP = false;
@@ -452,7 +452,7 @@ struct TLPGraphBuilder:public TLPTrue {
   bool addCluster(int id, const std::string& name, int supergraphId=0) {
     if (clusterIndex[supergraphId]) {
       _cluster = clusterIndex[id] =
-                   ((GraphAbstract *) clusterIndex[supergraphId])->addSubGraph((unsigned int) id);
+                   static_cast<GraphAbstract *>(clusterIndex[supergraphId])->addSubGraph(uint(id));
 
       if (name.size())
         _cluster->setAttribute("name", name);
@@ -633,7 +633,7 @@ struct TLPDataSetBuilder: public TLPFalse {
   DataSet* currentDataSet;
   char* dataSetName;
 
-  TLPDataSetBuilder(TLPGraphBuilder *graphBuilder):graphBuilder(graphBuilder),currentDataSet((DataSet *) &(graphBuilder->_graph->getAttributes())), dataSetName(NULL) {
+  TLPDataSetBuilder(TLPGraphBuilder *graphBuilder):graphBuilder(graphBuilder),currentDataSet(const_cast<DataSet *>(&(graphBuilder->_graph->getAttributes()))), dataSetName(NULL) {
   }
   TLPDataSetBuilder(TLPGraphBuilder *graphBuilder, char* name):graphBuilder(graphBuilder),currentDataSet(graphBuilder->dataSet), dataSetName(name) {
     graphBuilder->dataSet->get(dataSetName, dataSet);
@@ -689,7 +689,7 @@ struct TLPSceneBuilder: public TLPFalse {
   }
 
   bool addString(const std::string &str) {
-    graphBuilder->dataSet->set(SCENE, (std::string) str);
+    graphBuilder->dataSet->set(SCENE, str);
     return true;
   }
   bool close() {
@@ -758,25 +758,25 @@ struct TLPPropertyBuilder:public TLPFalse {
   }
   bool setNodeValue(int nodeId, const std::string& value)  {
     return property ?
-           graphBuilder->setNodeValue(nodeId, property, (std::string&) value,
+           graphBuilder->setNodeValue(nodeId, property, const_cast<std::string&>(value),
                                       isGraphProperty, isPathViewProperty) :
            false;
   }
   bool setEdgeValue(int edgeId, const std::string& value)  {
     return property ?
-           graphBuilder->setEdgeValue(edgeId, property, (std::string&) value,
+           graphBuilder->setEdgeValue(edgeId, property, const_cast<std::string&>(value),
                                       isGraphProperty, isPathViewProperty) :
            false;
   }
   bool setAllNodeValue(const std::string& value)  {
     return property ?
-           graphBuilder->setAllNodeValue(property, (std::string&) value,
+           graphBuilder->setAllNodeValue(property, const_cast<std::string&>(value),
                                          isGraphProperty, isPathViewProperty) :
            false;
   }
   bool setAllEdgeValue(const std::string& value)  {
     return property ?
-           graphBuilder->setAllEdgeValue(property, (std::string&) value,
+           graphBuilder->setAllEdgeValue(property, const_cast<std::string&>(value),
                                          isGraphProperty, isPathViewProperty) :
            false;
   }
@@ -887,7 +887,7 @@ bool TLPGraphBuilder::addStruct(const std::string& structName,TLPBuilder*&newBui
     newBuilder=new TLPPropertyBuilder(this);
   }
   else if (structName==DISPLAYING) {
-    newBuilder=new TLPDataSetBuilder(this, (char *) DISPLAYING);
+    newBuilder=new TLPDataSetBuilder(this, const_cast<char*>(DISPLAYING));
   }
   else if (structName==OLD_ATTRIBUTES) {
     newBuilder=new TLPDataSetBuilder(this);
@@ -899,10 +899,10 @@ bool TLPGraphBuilder::addStruct(const std::string& structName,TLPBuilder*&newBui
     newBuilder=new TLPSceneBuilder(this);
   }
   else if (structName==VIEWS) {
-    newBuilder=new TLPDataSetBuilder(this, (char *) VIEWS);
+    newBuilder=new TLPDataSetBuilder(this, const_cast<char*>(VIEWS));
   }
   else if (structName==CONTROLLER) {
-    newBuilder=new TLPDataSetBuilder(this, (char *) CONTROLLER);
+    newBuilder=new TLPDataSetBuilder(this, const_cast<char*>(CONTROLLER));
   }
   else
     newBuilder=new TLPFileInfoBuilder(this, structName);
@@ -956,7 +956,6 @@ public:
 
   TLPImport(tlp::PluginContext* context):ImportModule(context) {
     addInParameter<std::string>("file::filename", "The pathname of the TLP file to import.", "");
-//    addInParameter<DataSet>(DISPLAYING);
   }
   ~TLPImport() {}
 

--- a/library/tulip-core/src/TlpJsonExport.cpp
+++ b/library/tulip-core/src/TlpJsonExport.cpp
@@ -297,22 +297,22 @@ public:
       // we need to update their id before serializing them
       // as nodes and edges have been reindexed
       if (attribute.second->getTypeName() == string(typeid(node).name())) {
-        node *n = reinterpret_cast<node*>(attribute.second->value);
+        node *n = static_cast<node*>(attribute.second->value);
         n->id = graph->nodePos(*n);
       }
       else if (attribute.second->getTypeName() == string(typeid(edge).name())) {
-        edge *e = reinterpret_cast<edge*>(attribute.second->value);
+        edge *e = static_cast<edge*>(attribute.second->value);
         e->id = g->edgePos(*e);
       }
       else if (attribute.second->getTypeName() == string(typeid(vector<node>).name())) {
-        vector<node> *vn = reinterpret_cast<vector<node>*>(attribute.second->value);
+        vector<node> *vn = static_cast<vector<node>*>(attribute.second->value);
 
         for (size_t i = 0 ; i < vn->size() ; ++i) {
           (*vn)[i].id = graph->nodePos((*vn)[i]);
         }
       }
       else if (attribute.second->getTypeName() == string(typeid(vector<edge>).name())) {
-        vector<edge> *ve = reinterpret_cast<vector<edge>*>(attribute.second->value);
+        vector<edge> *ve = static_cast<vector<edge>*>(attribute.second->value);
 
         for (size_t i = 0 ; i < ve->size() ; ++i) {
           (*ve)[i].id = graph->edgePos((*ve)[i]);

--- a/library/tulip-core/src/TlpJsonImport.cpp
+++ b/library/tulip-core/src/TlpJsonImport.cpp
@@ -243,7 +243,7 @@ public:
   virtual void parseInteger(long long integerVal) {
     if(_waitingForGraphId) {
       if(integerVal > 0) {
-        _graph = ((GraphAbstract *)_graph)->addSubGraph(integerVal);
+        _graph = static_cast<GraphAbstract *>(_graph)->addSubGraph(integerVal);
         _dataSet = &const_cast<DataSet&>(_graph->getAttributes());
         _clusterIndex[integerVal] = _graph;
       }

--- a/library/tulip-core/src/TlpTools.cpp
+++ b/library/tulip-core/src/TlpTools.cpp
@@ -266,8 +266,7 @@ std::string tlp::demangleClassName(const char* className,
   static char demangleBuffer[1024];
   int status;
   size_t length = 1024;
-  abi::__cxa_demangle((char *) className, (char *) demangleBuffer,
-                      &length, &status);
+  abi::__cxa_demangle(className, demangleBuffer, &length, &status);
 
   // skip tlp::
   if (hideTlp && strstr(demangleBuffer, "tlp::") == demangleBuffer)
@@ -354,7 +353,7 @@ void tlp::initRandomSequence() {
     mt.seed(rd());
 #else
     // std::random_device implementation is deterministic in MinGW so initialize seed with current time (microsecond precision)
-    mt.seed(static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+    mt.seed(uint(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
 #endif
   }
   else {
@@ -364,7 +363,7 @@ void tlp::initRandomSequence() {
 #else
 
   if (randomSeed == UINT_MAX) {
-    unsigned int seed = (unsigned int) time(NULL);
+    unsigned int seed = uint(time(NULL));
     // init a sequence of rand() calls
     srand(seed);
 #ifndef WIN32
@@ -429,7 +428,7 @@ unsigned int tlp::randomUnsignedInteger(unsigned int max) {
   }
 
 #else
-  return static_cast<unsigned int>(randomInteger(static_cast<int>(max)));
+  return uint(randomInteger(int(max)));
 #endif
 }
 
@@ -438,7 +437,7 @@ double tlp::randomDouble(double max) {
   std::uniform_real_distribution<double> dist(0, std::nextafter(max, DBL_MAX));
   return dist(mt);
 #else
-  return max * rand() / static_cast<double>(RAND_MAX);
+  return max * rand() / double(RAND_MAX);
 #endif
 }
 

--- a/library/tulip-core/src/TreeTest.cpp
+++ b/library/tulip-core/src/TreeTest.cpp
@@ -436,11 +436,10 @@ void TreeTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       resultsBuffer.erase(graph);
   }
 }

--- a/library/tulip-core/src/TriconnectedTest.cpp
+++ b/library/tulip-core/src/TriconnectedTest.cpp
@@ -107,11 +107,10 @@ void TriconnectedTest::treatEvent(const Event& evt) {
     }
   }
   else {
-    // From my point of view the use of dynamic_cast should be correct
-    // but it fails, so I use reinterpret_cast (pm)
-    Graph* graph = reinterpret_cast<Graph *>(evt.sender());
 
-    if (graph && evt.type() == Event::TLP_DELETE)
+    Graph* graph = static_cast<Graph *>(evt.sender());
+
+    if (evt.type() == Event::TLP_DELETE)
       resultsBuffer.erase(graph);
   }
 }

--- a/library/tulip-core/src/WithParameter.cpp
+++ b/library/tulip-core/src/WithParameter.cpp
@@ -167,7 +167,7 @@ ParameterDescription* ParameterDescriptionList::getParameter(const string& name)
 }
 
 const string& ParameterDescriptionList::getDefaultValue(const string& name)  const {
-  return ((ParameterDescriptionList *) this)->getParameter(name)->getDefaultValue();
+  return const_cast<ParameterDescriptionList *>(this)->getParameter(name)->getDefaultValue();
 }
 
 void ParameterDescriptionList::setDefaultValue(const string& name,
@@ -181,15 +181,15 @@ void ParameterDescriptionList::setDirection(const string& name,
 }
 
 bool ParameterDescriptionList::isMandatory(const string& name) const {
-  return ((ParameterDescriptionList *) this)->getParameter(name)->isMandatory();
+  return const_cast<ParameterDescriptionList *>(this)->getParameter(name)->isMandatory();
 }
 
 #define CHECK_PROPERTY(T)\
 if (type.compare(typeid(T).name()) == 0) {\
   if (!g || defaultValue.empty() || !g->existProperty(defaultValue))\
-    dataSet.set(name, (T*) NULL);               \
+    dataSet.set(name, static_cast<T*>(NULL));               \
   else\
-    dataSet.set(name, (T*) g->getProperty<T>(defaultValue));  \
+    dataSet.set(name, static_cast<T*>(g->getProperty<T>(defaultValue)));  \
   continue;\
 }\
 
@@ -237,7 +237,7 @@ void ParameterDescriptionList::buildDefaultDataSet(DataSet &dataSet, Graph *g) c
 
     if (type.compare(typeid(NumericProperty*).name()) == 0) {
       if (!g || defaultValue.empty())
-        dataSet.set(name, (NumericProperty*) NULL);
+        dataSet.set(name, static_cast<NumericProperty*>(NULL));
       else {
         PropertyInterface* prop = g->getProperty(defaultValue);
 
@@ -246,7 +246,7 @@ void ParameterDescriptionList::buildDefaultDataSet(DataSet &dataSet, Graph *g) c
           prop = NULL;
         }
 
-        dataSet.set(name, (NumericProperty *) prop);
+        dataSet.set(name, static_cast<NumericProperty *>(prop));
       }
 
       continue;
@@ -254,11 +254,11 @@ void ParameterDescriptionList::buildDefaultDataSet(DataSet &dataSet, Graph *g) c
 
     if (type.compare(typeid(PropertyInterface*).name()) == 0) {
       if (!g || defaultValue.empty())
-        dataSet.set(name, (PropertyInterface*) NULL);
+        dataSet.set(name, static_cast<PropertyInterface*>(NULL));
       else {
         if (!g->existProperty(defaultValue)) {
           tlp::error() << "Property '" << defaultValue.c_str() << "' not found for parameter '" << name.c_str() << endl;
-          dataSet.set(name, (PropertyInterface*) NULL);
+          dataSet.set(name, static_cast<PropertyInterface*>(NULL));
         }
         else
           dataSet.set(name, g->getProperty(defaultValue));

--- a/library/tulip-core/src/YajlFacade.cpp
+++ b/library/tulip-core/src/YajlFacade.cpp
@@ -34,25 +34,25 @@ extern "C" {
 YajlParseFacade::YajlParseFacade(tlp::PluginProgress* progress) : _progress(progress), _parsingSucceeded(true) {}
 
 static int parse_null(void *ctx) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseNull();
   return 1;
 }
 
 static int parse_boolean(void * ctx, int boolVal) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseBoolean(boolVal);
   return 1;
 }
 
 static int parse_integer(void *ctx, long long integerVal) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseInteger(integerVal);
   return 1;
 }
 
 static int parse_double(void *ctx, double doubleVal) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseDouble(doubleVal);
   return 1;
 }
@@ -65,39 +65,39 @@ static int parse_double(void *ctx, double doubleVal) {
 // }
 
 static int parse_string(void *ctx, const unsigned char * stringVal, size_t stringLen) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
-  std::string key((char*)stringVal, stringLen);
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
+  std::string key(reinterpret_cast<const char *>(stringVal), stringLen);
   facade->parseString(key);
   return 1;
 }
 
 static int parse_map_key(void *ctx, const unsigned char * stringVal, size_t stringLen) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
-  std::string key((char*)stringVal, stringLen);
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
+  std::string key(reinterpret_cast<const char*>(stringVal), stringLen);
   facade->parseMapKey(key);
   return 1;
 }
 
 static int parse_start_map(void *ctx) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseStartMap();
   return 1;
 }
 
 static int parse_end_map(void *ctx) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseEndMap();
   return 1;
 }
 
 static int parse_start_array(void *ctx) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseStartArray();
   return 1;
 }
 
 static int parse_end_array(void *ctx) {
-  YajlParseFacade* facade = (YajlParseFacade*) ctx;
+  YajlParseFacade* facade = static_cast<YajlParseFacade*>(ctx);
   facade->parseEndArray();
   return 1;
 }
@@ -105,7 +105,7 @@ static int parse_end_array(void *ctx) {
 void YajlParseFacade::parse(std::string filename) {
   // check if file exists
   tlp_stat_t infoEntry;
-  bool result = (tlp::statPath(filename,&infoEntry) == 0);
+  bool result = tlp::statPath(filename,&infoEntry) == 0;
 
   if (!result) {
     std::stringstream ess;
@@ -135,7 +135,7 @@ void YajlParseFacade::parse(std::string filename) {
   ifs->read (fileData, fileLength);
   delete ifs;
 
-  parse((const unsigned char *) fileData, fileLength);
+  parse(reinterpret_cast<const unsigned char *>(fileData), fileLength);
 
   delete[] fileData;
 }
@@ -160,11 +160,10 @@ void YajlParseFacade::parse(const unsigned char* data, int length) {
   if (stat != yajl_status_ok) {
     unsigned char * str = yajl_get_error(hand, 1, data, length);
     _parsingSucceeded = false;
-    _errorMessage = std::string((const char *)str);
+    _errorMessage = std::string(reinterpret_cast<const char *>(str));
     yajl_free_error(hand, str);
   }
 
-  //   yajl_gen_free(g);
   yajl_free(hand);
 }
 
@@ -245,7 +244,7 @@ void YajlWriteFacade::writeNumber(const char* str, size_t len) {
 }
 
 void YajlWriteFacade::writeString(const std::string& text) {
-  yajl_gen_string(_generator, (unsigned char*)text.c_str(), text.size());
+  yajl_gen_string(_generator, reinterpret_cast<const unsigned char*>(text.c_str()), text.size());
 }
 
 void YajlWriteFacade::writeNull() {
@@ -281,6 +280,6 @@ std::string YajlWriteFacade::generatedString() {
     tlp::debug() << __PRETTY_FUNCTION__ << ": parse error.";
   }
 
-  std::string result((const char*)buffer);
+  std::string result(reinterpret_cast<const char*>(buffer));
   return result;
 }

--- a/library/tulip-gui/include/tulip/CaptionGraphicsSubItems.h
+++ b/library/tulip-gui/include/tulip/CaptionGraphicsSubItems.h
@@ -78,7 +78,7 @@ public :
 protected :
 
   bool sceneEvent ( QEvent * event ) {
-    return ((SelectionArrowItem*)parentItem())->sceneEvent(event);
+    return static_cast<SelectionArrowItem*>(parentItem())->sceneEvent(event);
   }
 
 };

--- a/library/tulip-gui/include/tulip/PluginModel.h
+++ b/library/tulip-gui/include/tulip/PluginModel.h
@@ -139,7 +139,7 @@ public:
     TreeItem* item = _root;
 
     if (parent.isValid())
-      item = (TreeItem*)parent.internalPointer();
+      item = static_cast<TreeItem*>(parent.internalPointer());
 
     return item->children.size();
   }
@@ -152,7 +152,7 @@ public:
     if (!child.isValid())
       return QModelIndex();
 
-    TreeItem* childItem = (TreeItem*)child.internalPointer();
+    TreeItem* childItem = static_cast<TreeItem*>(child.internalPointer());
 
     if (childItem->parent == _root)
       return QModelIndex();
@@ -166,7 +166,7 @@ public:
     TreeItem* parentItem = _root;
 
     if (parent.isValid()) {
-      parentItem = (TreeItem*)parent.internalPointer();
+      parentItem = static_cast<TreeItem*>(parent.internalPointer());
     }
 
     if (row >= parentItem->children.size())
@@ -176,7 +176,7 @@ public:
   }
 
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const {
-    TreeItem* item = (TreeItem*)index.internalPointer();
+    TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
 
     if (role == Qt::DisplayRole)
       return item->name;
@@ -204,7 +204,7 @@ public:
     Qt::ItemFlags result(QAbstractItemModel::flags(index));
 
     if(index.isValid()) {
-      TreeItem* item = (TreeItem*)index.internalPointer();
+      TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
 
       if (!PluginLister::instance()->pluginExists<PLUGIN>(tlp::QStringToTlpString(item->name)))
         result = Qt::ItemIsEnabled;

--- a/library/tulip-gui/include/tulip/TulipMetaTypes.h
+++ b/library/tulip-gui/include/tulip/TulipMetaTypes.h
@@ -152,7 +152,7 @@ class TLP_QT_SCOPE TulipMetaTypes {
     T result;
 
     if (dm)
-      result = *((T*)dm->value);
+      result = *(static_cast<T*>(dm->value));
 
     return QVariant::fromValue<T>(result);
   }

--- a/library/tulip-gui/include/tulip/cxx/GraphPropertiesModel.cxx
+++ b/library/tulip-gui/include/tulip/cxx/GraphPropertiesModel.cxx
@@ -119,7 +119,7 @@ QVariant GraphPropertiesModel<PROPTYPE>::data(const QModelIndex &index, int role
   if (_graph == NULL || (index.internalPointer() == NULL && index.row() != 0))
     return QVariant();
 
-  PropertyInterface* pi = (PropertyInterface*)(index.internalPointer());
+  PropertyInterface* pi = static_cast<PropertyInterface*>(index.internalPointer());
 
   if (role == Qt::DisplayRole || role == Qt::ToolTipRole) {
     if (!_placeholder.isEmpty() && index.row() == 0)
@@ -151,7 +151,7 @@ QVariant GraphPropertiesModel<PROPTYPE>::data(const QModelIndex &index, int role
     return QVariant::fromValue<PropertyInterface*>(pi);
   }
   else if (_checkable && role == Qt::CheckStateRole && index.column() == 0) {
-    return (_checkedProperties.contains((PROPTYPE*) pi) ? Qt::Checked : Qt::Unchecked);
+    return (_checkedProperties.contains(static_cast<PROPTYPE*>(pi)) ? Qt::Checked : Qt::Unchecked);
   }
 
   return QVariant();
@@ -199,12 +199,12 @@ bool tlp::GraphPropertiesModel<PROPTYPE>::setData(const QModelIndex &index, cons
     return false;
 
   if (_checkable && role == Qt::CheckStateRole && index.column() == 0) {
-    if (value.value<int>() == (int)Qt::Checked)
-      _checkedProperties.insert((PROPTYPE*)index.internalPointer());
+    if (value.value<int>() == int(Qt::Checked))
+      _checkedProperties.insert(static_cast<PROPTYPE*>(index.internalPointer()));
     else
-      _checkedProperties.remove((PROPTYPE*)index.internalPointer());
+      _checkedProperties.remove(static_cast<PROPTYPE*>(index.internalPointer()));
 
-    emit checkStateChanged(index,(Qt::CheckState)(value.value<int>()));
+    emit checkStateChanged(index, static_cast<Qt::CheckState>(value.value<int>()));
     return true;
   }
 

--- a/library/tulip-gui/include/tulip/cxx/GraphTableModel.cxx
+++ b/library/tulip-gui/include/tulip/cxx/GraphTableModel.cxx
@@ -64,7 +64,7 @@ void GraphTableModel::removeFromVector(const std::set<T>& objects,std::vector<T>
 
     //Update objToIndex map
     for(unsigned int i = fromIndex ; i < vect.size() ; ++i) {
-      objToIndexes[vect[i]] = static_cast<int>(i);
+      objToIndexes[vect[i]] = int(i);
     }
 
     if(deleteRows) {
@@ -204,6 +204,6 @@ std::pair<unsigned int,unsigned int> GraphTableModel::computeArea(const std::set
   }
 
   first = std::max(first,0);
-  last = std::min(last,static_cast<int>(elements.size()-1));
+  last = std::min(last,int(elements.size()-1));
   return std::make_pair(first,last);
 }

--- a/library/tulip-gui/include/tulip/cxx/TulipItemEditorCreators.cxx
+++ b/library/tulip-gui/include/tulip/cxx/TulipItemEditorCreators.cxx
@@ -221,7 +221,7 @@ QVariant PropertyEditorCreator<PROPTYPE>::editorData(QWidget* w,tlp::Graph* g) {
   GraphPropertiesModel<PROPTYPE>* model = static_cast<GraphPropertiesModel<PROPTYPE> *>(combo->model());
   QVariant var = model->data(model->index(combo->currentIndex(),0),TulipModel::PropertyRole);
   tlp::PropertyInterface* pi = var.value<tlp::PropertyInterface*>();
-  PROPTYPE* prop = (PROPTYPE*)(pi);
+  PROPTYPE* prop = static_cast<PROPTYPE*>(pi);
   return QVariant::fromValue<PROPTYPE*>(prop);
 }
 

--- a/library/tulip-gui/src/CSVGraphImport.cpp
+++ b/library/tulip-gui/src/CSVGraphImport.cpp
@@ -637,7 +637,7 @@ bool CSVGraphImport::line(unsigned int row,const vector<string>& lineTokens) {
               continue;
 
             if (!(isVectorProperty ?
-                  ((VectorPropertyInterface *)property)->setNodeStringValueAsVector(node(elements.second[i]), tokenCopy, '\0', ',', '\0') :
+                  static_cast<VectorPropertyInterface *>(property)->setNodeStringValueAsVector(node(elements.second[i]), tokenCopy, '\0', ',', '\0') :
                   property->setNodeStringValue(node(elements.second[i]), token))) {
               //We add one to the row number as in the configuration widget we start from row 1 not row 0
               qWarning()<<__PRETTY_FUNCTION__<<":"<<__LINE__<<" error when importing token \""<< token <<"\" in property \""<<property->getName()<<"\" of type \""<<property->getTypename()<<"\" at line "<<row+1;
@@ -647,7 +647,7 @@ bool CSVGraphImport::line(unsigned int row,const vector<string>& lineTokens) {
         else {
           for (size_t i = 0; i < elements.second.size(); ++i) {
             if(!(isVectorProperty ?
-                 ((VectorPropertyInterface *)property)->setEdgeStringValueAsVector(edge(elements.second[i]), tokenCopy, '\0', ',', '\0') :
+                 static_cast<VectorPropertyInterface *>(property)->setEdgeStringValueAsVector(edge(elements.second[i]), tokenCopy, '\0', ',', '\0') :
                  property->setEdgeStringValue(edge(elements.second[i]), token))) {
               //We add one to the row number as in the configuration widget we start from row 1 not row 0
               qWarning()<<__PRETTY_FUNCTION__<<":"<<__LINE__<<" error when importing token \""<<token<<"\" in property \""<<property->getName()<<"\" of type \""<<property->getTypename()<<"\" at line "<<row+1;

--- a/library/tulip-gui/src/CSVImportConfigurationWidget.cpp
+++ b/library/tulip-gui/src/CSVImportConfigurationWidget.cpp
@@ -165,7 +165,7 @@ bool CSVTableWidget::line(unsigned int row,const vector<string>& lineTokens) {
 
   for(size_t column = 0 ; column < lineTokens.size() ; ++column) {
     //Add a new column if needed
-    if(static_cast<unsigned int>(columnCount()) <= column ) {
+    if(uint(columnCount()) <= column ) {
       insertColumn(column);
     }
 
@@ -589,7 +589,7 @@ const string& CSVImportConfigurationWidget::combinePropertyDataType(const string
 static const std::string emptyString;
 
 const string& CSVImportConfigurationWidget::guessDataType(const string& data) const {
-  char *ptr = (char *) data.c_str();
+  char *ptr = const_cast<char *>(data.c_str());
 
   while(isspace(*ptr))
     ++ptr;

--- a/library/tulip-gui/src/CSVParser.cpp
+++ b/library/tulip-gui/src/CSVParser.cpp
@@ -327,7 +327,7 @@ bool CSVInvertMatrixParser::begin() {
 }
 
 bool CSVInvertMatrixParser::line(unsigned int ,const std::vector<std::string>& lineTokens) {
-  maxLineSize = max(maxLineSize,static_cast<unsigned int>(lineTokens.size()));
+  maxLineSize = max(maxLineSize,uint(lineTokens.size()));
   columns.push_back(lineTokens);
   return true;
 }

--- a/library/tulip-gui/src/CaptionGraphicsSubItems.cpp
+++ b/library/tulip-gui/src/CaptionGraphicsSubItems.cpp
@@ -259,7 +259,7 @@ void CaptionGraphicsBackgroundItem::updateCaption(float begin ,float end) {
 
 bool CaptionGraphicsBackgroundItem::sceneEvent ( QEvent * event ) {
   if(event->type()==QEvent::GraphicsSceneMousePress) {
-    if(((QGraphicsSceneMouseEvent*)event)->button()==Qt::LeftButton) {
+    if(static_cast<QGraphicsSceneMouseEvent*>(event)->button()==Qt::LeftButton) {
       activateInteractions(!_interactionsActivated);
       return true;
     }
@@ -338,7 +338,7 @@ SelectionArrowItem::SelectionArrowItem(float initRangePos,const QPoint &initPos)
 
 bool SelectionArrowItem::sceneEvent ( QEvent * event ) {
   if(event->type()==QEvent::GraphicsSceneMouseMove) {
-    QGraphicsSceneMouseEvent *e=(QGraphicsSceneMouseEvent *)event;
+    QGraphicsSceneMouseEvent *e=static_cast<QGraphicsSceneMouseEvent *>(event);
     qreal diffPosY=e->pos().y()-e->lastPos().y();
 
     if(pos().y()+diffPosY>initPos.y()+130)
@@ -365,7 +365,7 @@ MovableRectItem::MovableRectItem(const QRectF &rect,const QRectF &size, Selectio
 
 bool MovableRectItem::sceneEvent ( QEvent * event ) {
   if(event->type()==QEvent::GraphicsSceneMouseMove) {
-    QGraphicsSceneMouseEvent *e=(QGraphicsSceneMouseEvent *)event;
+    QGraphicsSceneMouseEvent *e=static_cast<QGraphicsSceneMouseEvent *>(event);
     qreal diffPosY=e->pos().y()-e->lastPos().y();
 
     if(_currentRect.bottom()*160+diffPosY>160)
@@ -487,7 +487,7 @@ void MovablePathItem::updatePath() {
       }
     }
 
-    for(int i2=(int)pathsPoints[i1].size()-1; i2>=0; --i2) {
+    for(int i2=int(pathsPoints[i1].size())-1; i2>=0; --i2) {
       paths[i1].lineTo(QPoint(30-pathsPoints[i1][i2].x(),pathsPoints[i1][i2].y()));
     }
 
@@ -505,7 +505,7 @@ void MovablePathItem::updatePath() {
 
 bool MovablePathItem::sceneEvent ( QEvent * event ) {
   if(event->type()==QEvent::GraphicsSceneMouseMove) {
-    QGraphicsSceneMouseEvent *e=(QGraphicsSceneMouseEvent *)event;
+    QGraphicsSceneMouseEvent *e=static_cast<QGraphicsSceneMouseEvent *>(event);
     qreal diffPosY=e->pos().y()-e->lastPos().y();
 
     if(_currentRect.bottom()*160+diffPosY>160)

--- a/library/tulip-gui/src/ColorButton.cpp
+++ b/library/tulip-gui/src/ColorButton.cpp
@@ -27,7 +27,7 @@
 
 using namespace tlp;
 
-ChooseColorButton::ChooseColorButton(QWidget *parent): QPushButton(parent), _color(Qt::black), _dialogParent(parent), _dialogTitle((char *) NULL) {
+ChooseColorButton::ChooseColorButton(QWidget *parent): QPushButton(parent), _color(Qt::black), _dialogParent(parent) {
   connect(this,SIGNAL(clicked()),this,SLOT(chooseColor()));
   setFocusPolicy(Qt::WheelFocus);
 }

--- a/library/tulip-gui/src/ColorScalesManager.cpp
+++ b/library/tulip-gui/src/ColorScalesManager.cpp
@@ -146,7 +146,7 @@ ColorScale ColorScalesManager::getColorScale(const string &colorScaleName) {
 
     for (int i = 0 ; i < colorsListv.size() ; ++i) {
       QColor color = colorsListv.at(i).value<QColor>();
-      float stop = i / static_cast<float>(colorsListv.size()-1);
+      float stop = i / float(colorsListv.size()-1);
       colorsMap[stop] = QColorToColor(color);
     }
   }
@@ -179,7 +179,7 @@ void ColorScalesManager::registerColorScale(const string &colorScaleName, const 
       QList<QVariant> colorsVector;
 
       for (unsigned int i = 0; i < const_cast<ColorScale&>(colorScale).getStopsCount() ; ++i) {
-        float stop = i / static_cast<float>(const_cast<ColorScale&>(colorScale).getStopsCount()-1);
+        float stop = i / float(const_cast<ColorScale&>(colorScale).getStopsCount()-1);
         Color color = colorScale.getColorAtPos(stop);
         colorsVector.push_back(QVariant(colorToQColor(color)));
       }

--- a/library/tulip-gui/src/GlCompositeHierarchyManager.cpp
+++ b/library/tulip-gui/src/GlCompositeHierarchyManager.cpp
@@ -200,11 +200,11 @@ DataSet GlCompositeHierarchyManager::getData() {
 
   for(std::map<tlp::Graph*, std::pair<tlp::GlComposite*, tlp::GlConvexGraphHull*> >::const_iterator it = _graphsComposites.begin(); it != _graphsComposites.end(); ++it) {
     unsigned int graphId = it->first->getId();
-    unsigned int visibility = (int)it->second.first->isVisible()*2 + (int)it->second.second->isVisible();
+    unsigned int visibility = uint(it->second.first->isVisible())*2 +
+                              uint(it->second.second->isVisible());
     stringstream graph;
     graph << graphId;
-    set.set<unsigned int>(graph.str(), visibility);
-//      set.set<pair<unsigned int, unsigned int> >(graph.str(), pair<unsigned int, unsigned int>(graphId, visibility));
+    set.set(graph.str(), visibility);
   }
 
   return set;
@@ -217,7 +217,7 @@ void GlCompositeHierarchyManager::setData(const DataSet &dataSet) {
 
     if(dataSet.exist(graph.str())) {
       unsigned int visibility = 0;
-      dataSet.get<unsigned int>(graph.str(), visibility);
+      dataSet.get(graph.str(), visibility);
       bool firstVisibility = visibility-1 > 0;
       it->second.first->setVisible(firstVisibility);
       bool secondVisibility = visibility%2 > 0;

--- a/library/tulip-gui/src/GlMainView.cpp
+++ b/library/tulip-gui/src/GlMainView.cpp
@@ -131,7 +131,7 @@ void GlMainView::assignNewGlMainWidget(GlMainWidget *glMainWidget, bool deleteOl
   connect(_sceneLayersConfigurationWidget,SIGNAL(drawNeeded()),this,SIGNAL(drawNeeded()));
 
   setCentralWidget(_glMainWidget,deleteOldGlMainWidget);
-  GlMainWidgetGraphicsItem *glMainWidgetGraphicsItem=dynamic_cast<GlMainWidgetGraphicsItem*>(centralItem());
+  GlMainWidgetGraphicsItem *glMainWidgetGraphicsItem=static_cast<GlMainWidgetGraphicsItem*>(centralItem());
   delete _sceneConfigurationWidget;
   _sceneConfigurationWidget = new SceneConfigWidget();
   _sceneConfigurationWidget->setGlMainWidget(_glMainWidget);
@@ -190,7 +190,7 @@ void GlMainView::centerView(bool graphChanged) {
     return;
   }
 
-  float gvWidth = (float) graphicsView()->width();
+  float gvWidth = graphicsView()->width();
   // we apply a zoom factor to preserve a 50 px margin width
   // to ensure the scene will not be drawn under the configuration tabs title
   getGlMainWidget()->centerScene(graphChanged, (gvWidth - 50) / gvWidth);
@@ -360,7 +360,7 @@ void GlMainView::sceneRectChanged(const QRectF& rect) {
   GlLayer *fgLayer = getGlMainWidget()->getScene()->getLayer("Foreground");
 
   if (fgLayer) {
-    Gl2DRect *labriLogo = dynamic_cast<Gl2DRect*>(fgLayer->findGlEntity("labrilogo"));
+    Gl2DRect *labriLogo = static_cast<Gl2DRect*>(fgLayer->findGlEntity("labrilogo"));
 
     if (labriLogo) {
       labriLogo->setCoordinates((_quickAccessBar != NULL) ? 35. : 0., 5., 50., 50.);
@@ -387,7 +387,7 @@ void GlMainView::openSnapshotDialog() {
 }
 
 void GlMainView::undoCallback() {
-  float gvWidth = (float) graphicsView()->width();
+  float gvWidth = graphicsView()->width();
   // we apply a zoom factor to preserve a 50 px margin width
   // to ensure the scene will not be drawn under the configuration tabs title
   getGlMainWidget()->centerScene(true, (gvWidth - 50) / gvWidth);

--- a/library/tulip-gui/src/GlMainWidget.cpp
+++ b/library/tulip-gui/src/GlMainWidget.cpp
@@ -53,9 +53,9 @@ bool GlMainWidget::inRendering=false;
 static void setRasterPosition(unsigned int x, unsigned int y) {
   float val[4];
   unsigned char tmp[10];
-  glGetFloatv(GL_CURRENT_RASTER_POSITION, (float*)&val);
+  glGetFloatv(GL_CURRENT_RASTER_POSITION, val);
   glBitmap(0,0,0,0,-val[0] + x, -val[1] + y, tmp);
-  glGetFloatv(GL_CURRENT_RASTER_POSITION, (float*)&val);
+  glGetFloatv(GL_CURRENT_RASTER_POSITION, val);
   glTest(__PRETTY_FUNCTION__);
 }
 //==================================================
@@ -391,10 +391,10 @@ bool GlMainWidget::pickGlEntities(const int x, const int y,
                                   std::vector<SelectedEntity> &pickedEntities,
                                   GlLayer* layer) {
   makeCurrent();
-  return scene.selectEntities((RenderingEntitiesFlag)(RenderingSimpleEntities | RenderingWithoutRemove),screenToViewport(x), screenToViewport(y),
+  return scene.selectEntities(static_cast<RenderingEntitiesFlag>(RenderingSimpleEntities | RenderingWithoutRemove),
+                              screenToViewport(x), screenToViewport(y),
                               screenToViewport(width), screenToViewport(height),
-                              layer,
-                              pickedEntities);
+                              layer, pickedEntities);
 }
 //==================================================
 bool GlMainWidget::pickGlEntities(const int x, const int y,
@@ -410,11 +410,15 @@ void GlMainWidget::pickNodesEdges(const int x, const int y,
   makeCurrent();
 
   if (pickNodes) {
-    scene.selectEntities((RenderingEntitiesFlag)(RenderingNodes | RenderingWithoutRemove), screenToViewport(x), screenToViewport(y), screenToViewport(width), screenToViewport(height), layer, selectedNodes);
+    scene.selectEntities(static_cast<RenderingEntitiesFlag>(RenderingNodes | RenderingWithoutRemove),
+                         screenToViewport(x), screenToViewport(y), screenToViewport(width), screenToViewport(height),
+                         layer, selectedNodes);
   }
 
   if (pickEdges) {
-    scene.selectEntities((RenderingEntitiesFlag)(RenderingEdges | RenderingWithoutRemove), screenToViewport(x), screenToViewport(y), screenToViewport(width), screenToViewport(height), layer, selectedEdges);
+    scene.selectEntities(static_cast<RenderingEntitiesFlag>(RenderingEdges | RenderingWithoutRemove),
+                         screenToViewport(x), screenToViewport(y), screenToViewport(width), screenToViewport(height),
+                         layer, selectedEdges);
   }
 }
 //=====================================================
@@ -422,12 +426,16 @@ bool GlMainWidget::pickNodesEdges(const int x, const int y, SelectedEntity &sele
   makeCurrent();
   vector<SelectedEntity> selectedEntities;
 
-  if(pickNodes && scene.selectEntities((RenderingEntitiesFlag)(RenderingNodes | RenderingWithoutRemove), screenToViewport(x-1), screenToViewport(y-1), screenToViewport(3), screenToViewport(3), layer, selectedEntities)) {
+  if(pickNodes && scene.selectEntities(static_cast<RenderingEntitiesFlag>(RenderingNodes | RenderingWithoutRemove),
+                                       screenToViewport(x-1), screenToViewport(y-1), screenToViewport(3), screenToViewport(3),
+                                       layer, selectedEntities)) {
     selectedEntity=selectedEntities[0];
     return true;
   }
 
-  if(pickEdges && scene.selectEntities((RenderingEntitiesFlag)(RenderingEdges | RenderingWithoutRemove), screenToViewport(x-1), screenToViewport(y-1), screenToViewport(3), screenToViewport(3), layer, selectedEntities)) {
+  if(pickEdges && scene.selectEntities(static_cast<RenderingEntitiesFlag>(RenderingEdges | RenderingWithoutRemove),
+                                       screenToViewport(x-1), screenToViewport(y-1), screenToViewport(3), screenToViewport(3),
+                                       layer, selectedEntities)) {
     selectedEntity=selectedEntities[0];
     return true;
   }

--- a/library/tulip-gui/src/GlOffscreenRenderer.cpp
+++ b/library/tulip-gui/src/GlOffscreenRenderer.cpp
@@ -124,7 +124,7 @@ void GlOffscreenRenderer::initFrameBuffers(const bool antialiased) {
   antialiasedFbo = antialiased && QGLFramebufferObject::hasOpenGLFramebufferBlit();
 #endif
 
-  if (glFrameBuf != NULL && (vPWidth != static_cast<unsigned int>(glFrameBuf->width()) || vPHeight != static_cast<unsigned int>(glFrameBuf->height()))) {
+  if (glFrameBuf != NULL && (vPWidth != uint(glFrameBuf->width()) || vPHeight != uint(glFrameBuf->height()))) {
     delete glFrameBuf;
     glFrameBuf = NULL;
     delete glFrameBuf2;

--- a/library/tulip-gui/src/GlSimpleEntityItemModel.cpp
+++ b/library/tulip-gui/src/GlSimpleEntityItemModel.cpp
@@ -85,7 +85,7 @@ QModelIndex GlSimpleEntityItemModel::index(int row, int column,const QModelIndex
   if (!hasIndex(row,column,parent))
     return QModelIndex();
 
-  return QAbstractItemModel::createIndex(row,column,(void*)(NULL));
+  return QAbstractItemModel::createIndex(row,column,static_cast<void*>(NULL));
 }
 
 QVariant GlSimpleEntityItemModel::data(const QModelIndex &index, int role) const {

--- a/library/tulip-gui/src/GraphElementModel.cpp
+++ b/library/tulip-gui/src/GraphElementModel.cpp
@@ -128,10 +128,10 @@ QModelIndex GraphElementModel::index(int row, int column,const QModelIndex &pare
 
 QVariant GraphElementModel::data(const QModelIndex &index, int role) const {
   if (role == Qt::DisplayRole)
-    return value(_id,(PropertyInterface*)(index.internalPointer()));
+    return value(_id, static_cast<PropertyInterface*>(index.internalPointer()));
 
   if (role == TulipModel::PropertyRole)
-    return QVariant::fromValue<PropertyInterface *>((PropertyInterface*)(index.internalPointer()));
+    return QVariant::fromValue<PropertyInterface *>(static_cast<PropertyInterface*>(index.internalPointer()));
 
   return QVariant();
 }

--- a/library/tulip-gui/src/GraphHierarchiesModel.cpp
+++ b/library/tulip-gui/src/GraphHierarchiesModel.cpp
@@ -429,7 +429,7 @@ QModelIndex GraphHierarchiesModel::index(int row, int column, const QModelIndex 
   Graph *g = NULL;
 
   if (parent.isValid())
-    g = reinterpret_cast<Graph*>(parent.internalPointer())->getNthSubGraph(row);
+    g = static_cast<Graph*>(parent.internalPointer())->getNthSubGraph(row);
   else if (row < _graphs.size())
     g = _graphs[row];
 
@@ -444,7 +444,7 @@ QModelIndex GraphHierarchiesModel::parent(const QModelIndex &child) const {
   if (!child.isValid())
     return QModelIndex();
 
-  Graph* childGraph = reinterpret_cast<Graph*>(child.internalPointer());
+  Graph* childGraph = static_cast<Graph*>(child.internalPointer());
 
   if (childGraph == NULL || _graphs.contains(childGraph) || childGraph->getSuperGraph() == childGraph) {
     return QModelIndex();
@@ -477,7 +477,7 @@ int GraphHierarchiesModel::rowCount(const QModelIndex &parent) const {
   if (parent.column() != 0)
     return 0;
 
-  Graph* parentGraph = reinterpret_cast<Graph*>(parent.internalPointer());
+  Graph* parentGraph = static_cast<Graph*>(parent.internalPointer());
 
   return parentGraph->numberOfSubGraphs();
 }
@@ -488,7 +488,7 @@ int GraphHierarchiesModel::columnCount(const QModelIndex&) const {
 
 bool GraphHierarchiesModel::setData(const QModelIndex &index, const QVariant &value, int role) {
   if (index.column() == NAME_SECTION) {
-    Graph *graph = reinterpret_cast<Graph*>(index.internalPointer());
+    Graph *graph = static_cast<Graph*>(index.internalPointer());
     graph->setName(QStringToTlpString(value.toString()));
     return true;
   }
@@ -501,7 +501,7 @@ QVariant GraphHierarchiesModel::data(const QModelIndex &index, int role) const {
   if (!index.isValid())
     return QVariant();
 
-  Graph *graph = reinterpret_cast<Graph*>(index.internalPointer());
+  Graph *graph = static_cast<Graph*>(index.internalPointer());
 
   if (role == Qt::DisplayRole || role == Qt::EditRole) {
     if (index.column() == NAME_SECTION)
@@ -519,7 +519,7 @@ QVariant GraphHierarchiesModel::data(const QModelIndex &index, int role) const {
   }
 
   else if (role == GraphRole) {
-    return QVariant::fromValue<Graph*>(reinterpret_cast<Graph*>(index.internalPointer()));
+    return QVariant::fromValue<Graph*>(static_cast<Graph*>(index.internalPointer()));
   }
 
   else if (role == Qt::TextAlignmentRole && index.column() != NAME_SECTION)
@@ -704,8 +704,7 @@ void GraphHierarchiesModel::removeGraph(tlp::Graph *g) {
 
 // Observation
 void GraphHierarchiesModel::treatEvent(const Event &e) {
-  Graph *g = dynamic_cast<tlp::Graph *>(e.sender());
-  assert(g);
+  Graph *g = static_cast<tlp::Graph *>(e.sender());
 
   if (e.type() == Event::TLP_DELETE && _graphs.contains(g)) { // A root graph has been deleted
     int pos = _graphs.indexOf(g);

--- a/library/tulip-gui/src/GraphModel.cpp
+++ b/library/tulip-gui/src/GraphModel.cpp
@@ -148,15 +148,15 @@ QModelIndex GraphModel::index(int row, int column, const QModelIndex &parent) co
 
 QVariant GraphModel::data(const QModelIndex &index, int role) const {
   if (role == Qt::DisplayRole)
-    return value(_elements[index.row()],(PropertyInterface*)(index.internalPointer()));
+    return value(_elements[index.row()],static_cast<PropertyInterface*>(index.internalPointer()));
   else if (role == PropertyRole)
-    return QVariant::fromValue<PropertyInterface*>((PropertyInterface*)(index.internalPointer()));
+    return QVariant::fromValue<PropertyInterface*>(static_cast<PropertyInterface*>(index.internalPointer()));
   else if (role == GraphRole)
     return QVariant::fromValue<Graph*>(_graph);
   else if (role == IsNodeRole)
     return isNode();
   else if (role == StringRole)
-    return stringValue(_elements[index.row()],(PropertyInterface*)(index.internalPointer()));
+    return stringValue(_elements[index.row()],static_cast<PropertyInterface*>(index.internalPointer()));
   else if (role == ElementIdRole)
     return _elements[index.row()];
 
@@ -165,7 +165,7 @@ QVariant GraphModel::data(const QModelIndex &index, int role) const {
 
 bool GraphModel::setData(const QModelIndex &index, const QVariant &value, int role) {
   if (role == Qt::EditRole) {
-    bool ok = setValue(_elements[index.row()],(PropertyInterface*)(index.internalPointer()),value);
+    bool ok = setValue(_elements[index.row()],static_cast<PropertyInterface*>(index.internalPointer()),value);
 
     if (ok) {
       emit dataChanged(index, index);
@@ -178,8 +178,8 @@ bool GraphModel::setData(const QModelIndex &index, const QVariant &value, int ro
 }
 
 void GraphModel::treatEvent(const Event& ev) {
-  if (dynamic_cast<const GraphEvent*>(&ev) != NULL) {
-    const GraphEvent* graphEv = static_cast<const GraphEvent*>(&ev);
+  const GraphEvent* graphEv = dynamic_cast<const GraphEvent*>(&ev);
+  if (graphEv != NULL) {
 
     if (graphEv->getType() == GraphEvent::TLP_ADD_INHERITED_PROPERTY || graphEv->getType() == GraphEvent::TLP_ADD_LOCAL_PROPERTY) {
 #ifdef NDEBUG
@@ -844,7 +844,7 @@ void GraphModel::treatEvents(const std::vector<tlp::Event>&) {
       // id of element to add is greather than the last one currently stored in the model,
       // meaning its index in the model will be contiguous with the one of the last added element.
       // So add it to the current rows sequence that will be further added in the model
-      if (_elements.empty() || id > static_cast<unsigned int>(_elements.back())) {
+      if (_elements.empty() || id > uint(_elements.back())) {
         rowsSequence.push_back(id);
       }
       // case where an element previously deleted, whose id is lower than the last one stored in the model,

--- a/library/tulip-gui/src/GraphTableItemDelegate.cpp
+++ b/library/tulip-gui/src/GraphTableItemDelegate.cpp
@@ -34,7 +34,7 @@ void GraphTableItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem
   PropertyInterface* pi = index.data(TulipModel::PropertyRole).value<PropertyInterface*>();
 
   if (index.data().type() == QVariant::Double && dynamic_cast<DoubleProperty*>(pi) != NULL) {
-    DoubleProperty* prop = dynamic_cast<DoubleProperty*>(pi);
+    DoubleProperty* prop = static_cast<DoubleProperty*>(pi);
     double value = index.data().value<double>();
     double min=0,max=0;
 

--- a/library/tulip-gui/src/ItemsListWidget.cpp
+++ b/library/tulip-gui/src/ItemsListWidget.cpp
@@ -95,7 +95,7 @@ void ItemsListWidget::dropEvent(QDropEvent *event) {
 }
 
 bool ItemsListWidget::addItemList(QString item) {
-  if (maxListSize == 0 || ((unsigned int) count() < maxListSize)) {
+  if (maxListSize == 0 || uint(count()) < maxListSize) {
     addItem(item);
     return true;
   }

--- a/library/tulip-gui/src/LayoutPropertyAnimation.cpp
+++ b/library/tulip-gui/src/LayoutPropertyAnimation.cpp
@@ -39,7 +39,7 @@ Coord LayoutPropertyAnimation::getNodeFrameValue(const Coord &startValue, const 
     stepVal = it->second;
   else {
     for (unsigned i = 0; i < 3; ++i)
-      stepVal[i] = ((double) endValue[i] - (double) startValue[i]) * 1. / (frameCount() - 1);
+      stepVal[i] = (double(endValue[i]) - double(startValue[i])) * 1. / (frameCount() - 1);
   }
 
   Coord result;

--- a/library/tulip-gui/src/MouseBoxZoomer.cpp
+++ b/library/tulip-gui/src/MouseBoxZoomer.cpp
@@ -161,7 +161,7 @@ bool MouseBoxZoomer::draw(GlMainWidget *glw) {
   glMatrixMode (GL_PROJECTION);
   glPushMatrix();
   glLoadIdentity();
-  glOrtho(0.0, (GLdouble)glw->width(), 0.0, (GLdouble)glw->height(), -1, 1);
+  glOrtho(0, glw->width(), 0, glw->height(), -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
   glLoadIdentity();

--- a/library/tulip-gui/src/MouseEdgeBendEditor.cpp
+++ b/library/tulip-gui/src/MouseEdgeBendEditor.cpp
@@ -68,7 +68,7 @@ void MouseEdgeBendEditor::stopEdition() {
 //========================================================================================
 bool MouseEdgeBendEditor::eventFilter(QObject *widget, QEvent *e) {
 
-  QMouseEvent * qMouseEv = (QMouseEvent *) e;
+  QMouseEvent * qMouseEv = dynamic_cast<QMouseEvent *>(e);
 
   if(qMouseEv == NULL)
     return false;
@@ -82,7 +82,7 @@ bool MouseEdgeBendEditor::eventFilter(QObject *widget, QEvent *e) {
 
   if (e->type() == QEvent::MouseButtonPress) {
     if(!glMainWidget)
-      glMainWidget = (GlMainWidget *) widget;
+      glMainWidget = static_cast<GlMainWidget *>(widget);
 
     initProxies(glMainWidget);
     bool hasSelection = haveSelection(glMainWidget);
@@ -102,7 +102,9 @@ bool MouseEdgeBendEditor::eventFilter(QObject *widget, QEvent *e) {
       }
       else {
 
-        bool entityIsSelected = glMainWidget->pickGlEntities((int)editPosition[0] - 3, (int)editPosition[1] - 3, 6, 6, select, layer);
+        bool entityIsSelected = glMainWidget->pickGlEntities(int(editPosition[0]) - 3,
+                                                             int(editPosition[1]) - 3,
+                                                             6, 6, select, layer);
 
         if(!entityIsSelected) {
           // We have click outside an entity
@@ -146,7 +148,7 @@ bool MouseEdgeBendEditor::eventFilter(QObject *widget, QEvent *e) {
   if (e->type() == QEvent::MouseButtonRelease &&
       qMouseEv->button() == Qt::LeftButton &&
       _operation != NONE_OP) {
-    GlMainWidget *glMainWidget = (GlMainWidget *) widget;
+    GlMainWidget *glMainWidget = static_cast<GlMainWidget *>(widget);
 
     if(selectedEntity=="targetTriangle") {
       SelectedEntity selectedEntity;
@@ -213,7 +215,7 @@ bool MouseEdgeBendEditor::eventFilter(QObject *widget, QEvent *e) {
   if  (e->type() == QEvent::MouseMove) {
     if(qMouseEv->buttons() == Qt::LeftButton &&
         _operation != NONE_OP) {
-      GlMainWidget *glMainWidget = (GlMainWidget *) widget;
+      GlMainWidget *glMainWidget = static_cast<GlMainWidget *>(widget);
 
       switch (_operation) {
       case TRANSLATE_OP:
@@ -226,7 +228,7 @@ bool MouseEdgeBendEditor::eventFilter(QObject *widget, QEvent *e) {
     }
     else if(qMouseEv->buttons() == Qt::NoButton) {
       SelectedEntity selectedEntity;
-      GlMainWidget *g = (GlMainWidget *) widget;
+      GlMainWidget *g = static_cast<GlMainWidget *>(widget);
 
       if (g->pickNodesEdges(qMouseEv->x(), qMouseEv->y(), selectedEntity) && selectedEntity.getEntityType() == SelectedEntity::NODE_SELECTED) {
         g->setCursor(Qt::CrossCursor);
@@ -319,7 +321,7 @@ void MouseEdgeBendEditor::mMouseTranslate(int newX, int newY, GlMainWidget *glMa
   initProxies(glMainWidget);
 
   Coord v0(0,0,0);
-  Coord v1((double)(editPosition[0] - newX), -(double)(editPosition[1] - newY),0);
+  Coord v1(editPosition[0] - newX, -(editPosition[1] - newY), 0);
   v0 = glMainWidget->getScene()->getLayer("Main")->getCamera().viewportTo3DWorld(glMainWidget->screenToViewport(v0));
   v1 = glMainWidget->getScene()->getLayer("Main")->getCamera().viewportTo3DWorld(glMainWidget->screenToViewport(v1));
   v1 -= v0;

--- a/library/tulip-gui/src/MouseEdgeSelector.cpp
+++ b/library/tulip-gui/src/MouseEdgeSelector.cpp
@@ -38,8 +38,8 @@ MouseEdgeSelector::MouseEdgeSelector():
 //==================================================================
 bool MouseEdgeSelector::eventFilter(QObject *widget, QEvent *e) {
   if (e->type() == QEvent::MouseButtonPress) {
-    QMouseEvent * qMouseEv = (QMouseEvent *) e;
-    GlMainWidget *glMainWidget = (GlMainWidget *) widget;
+    QMouseEvent * qMouseEv = static_cast<QMouseEvent *>(e);
+    GlMainWidget *glMainWidget = static_cast<GlMainWidget *>(widget);
 
     if (qMouseEv->button()==Qt::LeftButton) {
       if (!started) {
@@ -69,8 +69,8 @@ bool MouseEdgeSelector::eventFilter(QObject *widget, QEvent *e) {
   }
 
   if  (e->type() == QEvent::MouseMove) {
-    QMouseEvent * qMouseEv = (QMouseEvent *) e;
-    GlMainWidget *glMainWidget = (GlMainWidget *) widget;
+    QMouseEvent * qMouseEv = static_cast<QMouseEvent *>(e);
+    GlMainWidget *glMainWidget = static_cast<GlMainWidget *>(widget);
 
     if (glMainWidget->getScene()->getGlGraphComposite()->getInputData()->getGraph()!=graph) {
       graph=0;
@@ -92,7 +92,7 @@ bool MouseEdgeSelector::eventFilter(QObject *widget, QEvent *e) {
   }
 
   if  (e->type() == QEvent::MouseButtonRelease) {
-    GlMainWidget *glMainWidget = (GlMainWidget *) widget;
+    GlMainWidget *glMainWidget = static_cast<GlMainWidget *>(widget);
 
     if (glMainWidget->getScene()->getGlGraphComposite()->getInputData()->getGraph()!=graph) {
       graph=0;
@@ -173,7 +173,7 @@ bool MouseEdgeSelector::draw(GlMainWidget *glMainWidget) {
   glMatrixMode (GL_PROJECTION);
   glPushMatrix();
   glLoadIdentity ();
-  glOrtho(0.0, (GLdouble) glMainWidget->width(), 0.0, (GLdouble) glMainWidget->height(), -1, 1);
+  glOrtho(0, glMainWidget->width(), 0, glMainWidget->height(), -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
   glLoadIdentity();

--- a/library/tulip-gui/src/MouseNodeBuilder.cpp
+++ b/library/tulip-gui/src/MouseNodeBuilder.cpp
@@ -33,15 +33,13 @@ using namespace tlp;
 using namespace std;
 
 bool MouseNodeBuilder::eventFilter(QObject *widget, QEvent *e) {
-  QMouseEvent * qMouseEv = (QMouseEvent *) e;
+  QMouseEvent * qMouseEv = dynamic_cast<QMouseEvent *>(e);
 
   if(qMouseEv != NULL) {
     SelectedEntity selectedEntity;
 
     if (glMainWidget == NULL)
-      glMainWidget = dynamic_cast<GlMainWidget *>(widget);
-
-    assert(glMainWidget);
+      glMainWidget = static_cast<GlMainWidget *>(widget);
 
     if(e->type() == QEvent::MouseMove) {
       if (glMainWidget->pickNodesEdges(qMouseEv->x(), qMouseEv->y(), selectedEntity) && selectedEntity.getEntityType() == SelectedEntity::NODE_SELECTED) {
@@ -68,7 +66,7 @@ bool MouseNodeBuilder::eventFilter(QObject *widget, QEvent *e) {
         Observable::holdObservers();
         node newNode;
         newNode = _graph->addNode();
-        Coord point((double) glMainWidget->width() - (double) qMouseEv->x(),(double) qMouseEv->y(),0);
+        Coord point(glMainWidget->width() - qMouseEv->x(), qMouseEv->y(),0);
         point = glMainWidget->getScene()->getGraphCamera().viewportTo3DWorld(glMainWidget->screenToViewport(point));
 
         // This code is here to block z coordinate to 0 when we are in "2D mode"

--- a/library/tulip-gui/src/MouseSelectionEditor.cpp
+++ b/library/tulip-gui/src/MouseSelectionEditor.cpp
@@ -208,7 +208,7 @@ bool MouseSelectionEditor::eventFilter(QObject *widget, QEvent *e) {
       }
 
       if (!hasSelection ||
-          (!glMainWidget->pickGlEntities((int)editPosition[0]-3, (int)editPosition[1]-3,
+          (!glMainWidget->pickGlEntities(int(editPosition[0])-3, int(editPosition[1])-3,
                                          6, 6, select,layer))) {
         // event occurs outside the selection rectangle
         // so from now we delegate the job to a MouseSelector object
@@ -241,8 +241,8 @@ bool MouseSelectionEditor::eventFilter(QObject *widget, QEvent *e) {
 
       if (shapeId != -1) {
         if(!advShape) {
-          ((GlCircle *)select[shapeId].getSimpleEntity())->setFillColor(Color(40,255,40,200));
-          ((GlCircle *)select[shapeId].getSimpleEntity())->setOutlineColor(Color(20,128,20,200));
+          static_cast<GlCircle *>(select[shapeId].getSimpleEntity())->setFillColor(Color(40,255,40,200));
+          static_cast<GlCircle *>(select[shapeId].getSimpleEntity())->setOutlineColor(Color(20,128,20,200));
         }
 
         getOperation(select[shapeId].getSimpleEntity());
@@ -350,7 +350,7 @@ bool MouseSelectionEditor::eventFilter(QObject *widget, QEvent *e) {
     }
 
     if(hasSelection) {
-      switch(((QKeyEvent*)e)->key()) {
+      switch(static_cast<QKeyEvent*>(e)->key()) {
       case Qt::Key_Left:
         mMouseTranslate(editPosition[0]-1, editPosition[1], glMainWidget);
         break;
@@ -525,7 +525,7 @@ void MouseSelectionEditor::mMouseTranslate(double newX, double newY, GlMainWidge
   Observable::holdObservers();
   initProxies(glMainWidget);
   Coord v0(0,0,0);
-  Coord v1((double)(editPosition[0] - newX), -(double)(editPosition[1] - newY),0);
+  Coord v1(editPosition[0] - newX, -(editPosition[1] - newY), 0);
   v0 = glMainWidget->getScene()->getGraphCamera().viewportTo3DWorld(v0);
   v1 = glMainWidget->getScene()->getGraphCamera().viewportTo3DWorld(glMainWidget->screenToViewport(v1));
   v1 -= v0;

--- a/library/tulip-gui/src/MouseSelector.cpp
+++ b/library/tulip-gui/src/MouseSelector.cpp
@@ -285,7 +285,7 @@ bool MouseSelector::draw(GlMainWidget *glMainWidget) {
   glMatrixMode (GL_PROJECTION);
   glPushMatrix();
   glLoadIdentity ();
-  glOrtho(0.0, (GLdouble) glMainWidget->width(), 0.0, (GLdouble) glMainWidget->height(), -1, 1);
+  glOrtho(0, glMainWidget->width(), 0, glMainWidget->height(), -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
   glLoadIdentity();

--- a/library/tulip-gui/src/NodeLinkDiagramComponent.cpp
+++ b/library/tulip-gui/src/NodeLinkDiagramComponent.cpp
@@ -332,7 +332,7 @@ void NodeLinkDiagramComponent::loadGraphOnScene(Graph *graph) {
   if(_hasHulls)
     manager->setGraph(graph);
 
-  GlGraphComposite* oldGraphComposite=(GlGraphComposite *)(scene->getLayer("Main")->findGlEntity("graph"));
+  GlGraphComposite* oldGraphComposite=static_cast<GlGraphComposite *>(scene->getLayer("Main")->findGlEntity("graph"));
 
   if(!oldGraphComposite) {
     createScene(graph,DataSet());

--- a/library/tulip-gui/src/Perspective.cpp
+++ b/library/tulip-gui/src/Perspective.cpp
@@ -42,7 +42,7 @@ void Perspective::setInstance(Perspective* p) {
 
 Perspective::Perspective(const tlp::PluginContext* c) : _agentSocket(NULL), _maximised(false), _project(NULL), _mainWindow(NULL), _externalFile(QString()), _parameters(QVariantMap()) {
   if(c != NULL) {
-    const PerspectiveContext* perspectiveContext = dynamic_cast<const PerspectiveContext*>(c);
+    const PerspectiveContext* perspectiveContext = static_cast<const PerspectiveContext*>(c);
     _mainWindow = perspectiveContext->mainWindow;
     _project = perspectiveContext->project;
     _externalFile = perspectiveContext->externalFile;

--- a/library/tulip-gui/src/PluginManager.cpp
+++ b/library/tulip-gui/src/PluginManager.cpp
@@ -112,7 +112,7 @@ public:
     reply->open(QIODevice::ReadOnly);
     QByteArray contents = reply->readAll();
     reply->close();
-    parse((const unsigned char *) contents.constData(), contents.size());
+    parse(reinterpret_cast<const unsigned char *>(contents.constData()), contents.size());
     return _result;
   }
 

--- a/library/tulip-gui/src/QuickAccessBar.cpp
+++ b/library/tulip-gui/src/QuickAccessBar.cpp
@@ -474,7 +474,7 @@ void QuickAccessBarImpl::setEdgeBorderColor(const QColor& c) {
 void QuickAccessBarImpl::setAllValues(unsigned int eltType,
                                       PropertyInterface* prop) {
   QVariant val =
-    TulipItemDelegate::showEditorDialog((tlp::ElementType) eltType,
+    TulipItemDelegate::showEditorDialog(static_cast<tlp::ElementType>(eltType),
                                         prop, _mainView->graph(),
                                         delegate,
                                         _mainView->graphicsView()->window());

--- a/library/tulip-gui/src/SceneLayersModel.cpp
+++ b/library/tulip-gui/src/SceneLayersModel.cpp
@@ -61,11 +61,11 @@ QModelIndex SceneLayersModel::index(int row, int column,const QModelIndex &paren
   GlComposite* composite = NULL;
 
   if (!parent.parent().isValid())  {// 1st sublevel, parent is a layer
-    GlLayer *layer = reinterpret_cast<GlLayer*>(parent.internalPointer());
+    GlLayer *layer = static_cast<GlLayer*>(parent.internalPointer());
     composite = layer->getComposite();
   }
   else {  // Deeper sublevel, the parent is a composite
-    composite = reinterpret_cast<GlComposite*>(parent.internalPointer());
+    composite = static_cast<GlComposite*>(parent.internalPointer());
   }
 
   if (_scene->getGlGraphComposite() == composite)
@@ -115,7 +115,7 @@ QModelIndex SceneLayersModel::parent(const QModelIndex &child) const {
       return QModelIndex(); // Item was a layer, aka. a top level item.
   }
 
-  GlSimpleEntity* entity = reinterpret_cast<GlSimpleEntity*>(child.internalPointer());
+  GlSimpleEntity* entity = static_cast<GlSimpleEntity*>(child.internalPointer());
   GlComposite* parent = entity->getParent();
 
   if (parent == NULL)
@@ -153,14 +153,14 @@ int SceneLayersModel::rowCount(const QModelIndex &parent) const {
   }
 
   if (!parent.parent().isValid()) {// First sublevel: parent is a GlLayer
-    GlLayer* layer = reinterpret_cast<GlLayer*>(parent.internalPointer());
+    GlLayer* layer = static_cast<GlLayer*>(parent.internalPointer());
     return layer->getComposite()->getGlEntities().size();
   }
 
   if (GRAPH_COMPOSITE_IDS.contains(parent.internalId()))
     return 0;
 
-  GlSimpleEntity* entity = reinterpret_cast<GlSimpleEntity*>(parent.internalPointer());
+  GlSimpleEntity* entity = static_cast<GlSimpleEntity*>(parent.internalPointer());
 
   if (_scene->getGlGraphComposite() == entity)
     return GRAPH_COMPOSITE_IDS.size();
@@ -248,11 +248,11 @@ QVariant SceneLayersModel::data(const QModelIndex &index, int role) const {
   }
 
   if (!index.parent().isValid()) {
-    layer = reinterpret_cast<GlLayer*>(index.internalPointer());
+    layer = static_cast<GlLayer*>(index.internalPointer());
     entity = layer->getComposite();
   }
   else {
-    entity = reinterpret_cast<GlSimpleEntity*>(index.internalPointer());
+    entity = static_cast<GlSimpleEntity*>(index.internalPointer());
     parent = entity->getParent();
   }
 
@@ -297,7 +297,7 @@ bool SceneLayersModel::setData(const QModelIndex &index, const QVariant &value, 
     GlGraphRenderingParameters* p = _scene->getGlGraphComposite()->getRenderingParametersPointer();
 
     if (index.column() == 1) {
-      bool visible = value.value<int>() == (int)(Qt::Checked);
+      bool visible = value.value<int>() == int(Qt::Checked);
 
       if (id == NODES_ID)
         p->setDisplayNodes(visible);
@@ -313,7 +313,7 @@ bool SceneLayersModel::setData(const QModelIndex &index, const QVariant &value, 
         p->setViewMetaLabel(visible);
     }
     else if (index.column() == 2) {
-      int stencil = (value.value<int>() == (int)(Qt::Checked) ? FULL_STENCIL : NO_STENCIL);
+      int stencil = (value.value<int>() == int(Qt::Checked) ? FULL_STENCIL : NO_STENCIL);
 
       if (id == NODES_ID)
         p->setNodesStencil(stencil);
@@ -343,13 +343,13 @@ bool SceneLayersModel::setData(const QModelIndex &index, const QVariant &value, 
   GlLayer* layer = NULL;
 
   if (!index.parent().isValid()) {
-    layer = reinterpret_cast<GlLayer*>(index.internalPointer());
+    layer = static_cast<GlLayer*>(index.internalPointer());
     entity = layer->getComposite();
   }
   else
-    entity = reinterpret_cast<GlSimpleEntity*>(index.internalPointer());
+    entity = static_cast<GlSimpleEntity*>(index.internalPointer());
 
-  bool val = value.value<int>() == (int)Qt::Checked;
+  bool val = value.value<int>() == int(Qt::Checked);
 
   if (index.column() == 1) {
     if (layer)

--- a/library/tulip-gui/src/SnapshotDialog.cpp
+++ b/library/tulip-gui/src/SnapshotDialog.cpp
@@ -223,8 +223,8 @@ void SnapshotDialog::sizeSpinBoxValueChanged() {
     return;
   }
 
-  float viewRatio = static_cast<float>(ui->graphicsView->width()) / static_cast<float>(ui->graphicsView->height());
-  float imageRatio = static_cast<float>(ui->widthSpinBox->value()) / static_cast<float>(ui->heightSpinBox->value());
+  float viewRatio = float(ui->graphicsView->width()) / float(ui->graphicsView->height());
+  float imageRatio = float(ui->widthSpinBox->value()) / float(ui->heightSpinBox->value());
 
   // regenerate preview pixmap only if the aspect ratio changed
   if (imageRatio != ratio) {
@@ -240,7 +240,7 @@ void SnapshotDialog::sizeSpinBoxValueChanged() {
       pixmap = pixmap.scaled(ui->graphicsView->width()-2, (ui->graphicsView->width()-2)/imageRatio, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
 
-    ratio = static_cast<float>(ui->widthSpinBox->value())/ static_cast<float>(ui->heightSpinBox->value());
+    ratio = float(ui->widthSpinBox->value())/ float(ui->heightSpinBox->value());
 
     if (pixmapItem != NULL) {
       delete scene;

--- a/library/tulip-gui/src/StringsListSelectionWidget.cpp
+++ b/library/tulip-gui/src/StringsListSelectionWidget.cpp
@@ -88,7 +88,7 @@ void StringsListSelectionWidget::clearSelectedStringsList() {
 void StringsListSelectionWidget::setUnselectedStringsListLabel(
   const std::string &unselectedStringsListLabel) {
   if (listType == DOUBLE_LIST) {
-    ((DoubleStringsListSelectionWidget *) stringsListSelectionWidget)->setUnselectedStringsListLabel(
+    static_cast<DoubleStringsListSelectionWidget *>(stringsListSelectionWidget)->setUnselectedStringsListLabel(
       unselectedStringsListLabel);
   }
 }
@@ -96,7 +96,7 @@ void StringsListSelectionWidget::setUnselectedStringsListLabel(
 void StringsListSelectionWidget::setSelectedStringsListLabel(
   const std::string &selectedStringsListLabel) {
   if (listType == DOUBLE_LIST) {
-    ((DoubleStringsListSelectionWidget *) stringsListSelectionWidget)->setSelectedStringsListLabel(
+    static_cast<DoubleStringsListSelectionWidget *>(stringsListSelectionWidget)->setSelectedStringsListLabel(
       selectedStringsListLabel);
   }
 }

--- a/library/tulip-gui/src/TulipItemDelegate.cpp
+++ b/library/tulip-gui/src/TulipItemDelegate.cpp
@@ -153,7 +153,7 @@ void TulipItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
   if (bgColor.isValid() && bgColor.type() == QVariant::Color)
     painter->setBrush(bgColor.value<QColor>());
   else {
-    QTableView* tv = dynamic_cast<QTableView*>(parent());
+    QTableView* tv = static_cast<QTableView*>(parent());
     painter->setBrush((tv && tv->alternatingRowColors() && (index.row() % 2))
                       ? option.palette.alternateBase()
                       : option.palette.base());

--- a/library/tulip-gui/src/TulipItemEditorCreators.cpp
+++ b/library/tulip-gui/src/TulipItemEditorCreators.cpp
@@ -775,7 +775,7 @@ QWidget* EdgeShapeEditorCreator::createWidget(QWidget* parent) const {
 }
 void EdgeShapeEditorCreator::setEditorData(QWidget* editor, const QVariant& data, bool, Graph*) {
   QComboBox* combobox = static_cast<QComboBox*>(editor);
-  combobox->setCurrentIndex(combobox->findData(static_cast<int>(data.value<EdgeShape::EdgeShapes>())));
+  combobox->setCurrentIndex(combobox->findData(int(data.value<EdgeShape::EdgeShapes>())));
 }
 
 QVariant EdgeShapeEditorCreator::editorData(QWidget* editor,Graph*) {
@@ -831,7 +831,7 @@ QWidget* TulipLabelPositionEditorCreator::createWidget(QWidget* parent) const {
 }
 void TulipLabelPositionEditorCreator::setEditorData(QWidget* w, const QVariant& var,bool,tlp::Graph*) {
   QComboBox* comboBox = static_cast<QComboBox*>(w);
-  comboBox->setCurrentIndex((int)(var.value<LabelPosition::LabelPositions>()));
+  comboBox->setCurrentIndex(int(var.value<LabelPosition::LabelPositions>()));
 }
 QVariant TulipLabelPositionEditorCreator::editorData(QWidget* w,tlp::Graph*) {
   return QVariant::fromValue<LabelPosition::LabelPositions>(static_cast<LabelPosition::LabelPositions>(static_cast<QComboBox*>(w)->currentIndex()));

--- a/library/tulip-gui/src/TulipMetaTypes.cpp
+++ b/library/tulip-gui/src/TulipMetaTypes.cpp
@@ -147,7 +147,7 @@ QVariant TulipMetaTypes::dataTypeToQvariant(tlp::DataType *dm, const std::string
 
   if (type.compare(typeid(std::string).name()) == 0 && (name.startsWith("file::") || name.startsWith("anyfile::") || name.startsWith("dir::"))) {
     TulipFileDescriptor desc;
-    desc.absolutePath = tlpStringToQString(*(std::string*)dm->value);
+    desc.absolutePath = tlpStringToQString(*static_cast<std::string*>(dm->value));
     desc.type = name.startsWith("dir::")?TulipFileDescriptor::Directory:TulipFileDescriptor::File;
     desc.mustExist = !name.startsWith("any");
     return QVariant::fromValue<TulipFileDescriptor>(desc);
@@ -169,7 +169,7 @@ QVariant TulipMetaTypes::dataTypeToQvariant(tlp::DataType *dm, const std::string
     tlp::BooleanVectorType::RealType result;
 
     if (dm)
-      result = *((tlp::BooleanVectorType::RealType*)dm->value);
+      result = *(static_cast<tlp::BooleanVectorType::RealType*>(dm->value));
 
     return QVariant::fromValue<QVector<bool> >(QVector<bool>::fromStdVector(result));
   }

--- a/library/tulip-gui/src/TulipSettings.cpp
+++ b/library/tulip-gui/src/TulipSettings.cpp
@@ -266,11 +266,11 @@ void TulipSettings::setProxyEnabled(bool f) {
 }
 
 QNetworkProxy::ProxyType TulipSettings::proxyType() const {
-  return (QNetworkProxy::ProxyType)(value(TS_ProxyType).toInt());
+  return static_cast<QNetworkProxy::ProxyType>(value(TS_ProxyType).toInt());
 }
 
 void TulipSettings::setProxyType(QNetworkProxy::ProxyType t) {
-  setValue(TS_ProxyType,(int)t);
+  setValue(TS_ProxyType,int(t));
 }
 
 QString TulipSettings::proxyHost() const {
@@ -387,7 +387,7 @@ void TulipSettings::setViewOrtho(bool f) {
 }
 
 void TulipSettings::setFavoriteAlgorithms(const QSet<QString>& lst) {
-  setValue(TS_FavoriteAlgorithms,(QStringList)(lst.toList()));
+  setValue(TS_FavoriteAlgorithms,static_cast<QStringList>(lst.toList()));
 }
 
 bool TulipSettings::isResultPropertyStored() const {
@@ -417,11 +417,11 @@ unsigned int TulipSettings::logPluginCall() const {
 
     // ensure compatibility
     if (val)
-      ((TulipSettings *)this)->setValue(TS_LogPluginCall,
+      const_cast<TulipSettings *>(this)->setValue(TS_LogPluginCall,
                                         LogCallWithExecutionTime);
 
     // no longer used
-    ((TulipSettings *)this)->remove(TS_RunningTimeComputed);
+    const_cast<TulipSettings *>(this)->remove(TS_RunningTimeComputed);
   }
 
   return value(TS_LogPluginCall, NoLog).toUInt();

--- a/library/tulip-gui/src/VectorEditor.cpp
+++ b/library/tulip-gui/src/VectorEditor.cpp
@@ -64,7 +64,7 @@ void VectorEditor::add() {
     i->setData(Qt::DisplayRole, QVariant::fromValue(QString("edit this string")));
   }
   else
-    i->setData(Qt::DisplayRole, QVariant(_userType,(const void*)NULL));
+    i->setData(Qt::DisplayRole, QVariant(_userType,static_cast<const void*>(NULL)));
 
   // needed for color
   i->setSizeHint(QSize(i->sizeHint().width(), 15));

--- a/library/tulip-gui/src/Workspace.cpp
+++ b/library/tulip-gui/src/Workspace.cpp
@@ -345,7 +345,7 @@ void Workspace::updatePanels() {
   if (_currentPanelIndex<0)
     _currentPanelIndex=0;
 
-  if ((uint)_currentPanelIndex > _panels.size()-currentSlotsCount())
+  if (uint(_currentPanelIndex) > _panels.size()-currentSlotsCount())
     _currentPanelIndex = _panels.size()-currentSlotsCount();
 
   //   Fill up slots according to the current index until there is no panel to show
@@ -746,7 +746,7 @@ bool Workspace::isBottomFrameVisible() const {
 }
 
 void Workspace::swapPanelsRequested(WorkspacePanel* panel) {
-  WorkspacePanel* sourcePanel = dynamic_cast<WorkspacePanel*>(sender());
+  WorkspacePanel* sourcePanel = static_cast<WorkspacePanel*>(sender());
 
   if(sourcePanel) {
     _panels.swap(_panels.indexOf(sourcePanel), _panels.indexOf(panel));

--- a/library/tulip-ogdf/TulipToOGDF.cpp
+++ b/library/tulip-ogdf/TulipToOGDF.cpp
@@ -189,6 +189,6 @@ void TulipToOGDF::copyTlpNumericPropertyToOGDFNodeWeight(tlp::NumericProperty *m
 
   for (unsigned int i = 0; i < nbNodes; ++i) {
     ogdfAttributes.weight((*ogdfNodes)[i]) =
-      static_cast<int>(metric->getNodeDoubleValue(nodes[i]));
+      int(metric->getNodeDoubleValue(nodes[i]));
   }
 }

--- a/library/tulip-ogl/include/tulip/GlQuantitativeAxis.h
+++ b/library/tulip-ogl/include/tulip/GlQuantitativeAxis.h
@@ -68,7 +68,7 @@ public :
 
   void setAxisParameters(const int min, const int max, const unsigned int incrementStep,
                          const LabelPosition &axisGradsLabelsPosition = LEFT_OR_BELOW, const bool drawFirstLabel = true) {
-    setAxisParameters((long long) min, (long long) max, (unsigned long long) incrementStep, axisGradsLabelsPosition, drawFirstLabel);
+    setAxisParameters(static_cast<long long>(min), static_cast<long long>(max), static_cast<unsigned long long>(incrementStep), axisGradsLabelsPosition, drawFirstLabel);
   }
 
   void setNbGraduations(const unsigned int nbGraduations) {

--- a/library/tulip-ogl/include/tulip/GlScene.h
+++ b/library/tulip-ogl/include/tulip/GlScene.h
@@ -53,8 +53,8 @@ struct SelectedEntity {
     SIMPLE_ENTITY_SELECTED = 3
   };
 
-  SelectedEntity():simpleEntity(NULL),complexEntityId((unsigned int)(-1)),entityType(UNKNOW_SELECTED),complexEntityGraph(NULL) {}
-  SelectedEntity(GlSimpleEntity *entity):simpleEntity(entity),complexEntityId((unsigned int)(-1)),entityType(SIMPLE_ENTITY_SELECTED),complexEntityGraph(NULL) {}
+  SelectedEntity():simpleEntity(NULL),complexEntityId(uint(-1)),entityType(UNKNOW_SELECTED),complexEntityGraph(NULL) {}
+  SelectedEntity(GlSimpleEntity *entity):simpleEntity(entity),complexEntityId(uint(-1)),entityType(SIMPLE_ENTITY_SELECTED),complexEntityGraph(NULL) {}
   SelectedEntity(Graph *graph,unsigned int id,SelectedEntityType type):simpleEntity(NULL),complexEntityId(id),entityType(type),complexEntityGraph(graph) {}
 
   GlSimpleEntity *getSimpleEntity() const {

--- a/library/tulip-ogl/include/tulip/OpenGlConfigManager.h
+++ b/library/tulip-ogl/include/tulip/OpenGlConfigManager.h
@@ -26,7 +26,7 @@
 #include <map>
 #include <string>
 
-#define BUFFER_OFFSET(bytes) ((GLubyte*) NULL + (bytes))
+#define BUFFER_OFFSET(bytes) (static_cast<GLubyte*>(NULL) + (bytes))
 
 namespace tlp {
 

--- a/library/tulip-ogl/src/AbstractGlCurve.cpp
+++ b/library/tulip-ogl/src/AbstractGlCurve.cpp
@@ -516,7 +516,7 @@ void AbstractGlCurve::buildCurveVertexBuffers(const unsigned int nbCurvePoints, 
   curveVertexBuffersIndices[nbCurvePoints][3] = new GLushort[nbCurvePoints];
 
   for (unsigned int i = 0 ; i < nbCurvePoints ; ++i) {
-    float t =  i / static_cast<float>(nbCurvePoints - 1);
+    float t =  i / float(nbCurvePoints - 1);
     curveVertexBuffersData[nbCurvePoints][6*i] = t;
     curveVertexBuffersData[nbCurvePoints][6*i+1] = 1.0f;
     curveVertexBuffersData[nbCurvePoints][6*i+2] = t;
@@ -695,8 +695,8 @@ void AbstractGlCurve::drawCurve(std::vector<Coord> &controlPoints, const Color &
 
   if (texture != "") {
     unsigned int i = nbCurvePoints / 2;
-    Coord firstCurvePoint(computeCurvePointOnCPU(controlPoints, i / static_cast<float>(nbCurvePoints - 1)));
-    Coord nexCurvePoint(computeCurvePointOnCPU(controlPoints, (i+1) / static_cast<float>(nbCurvePoints - 1)));
+    Coord firstCurvePoint(computeCurvePointOnCPU(controlPoints, i / float(nbCurvePoints - 1)));
+    Coord nexCurvePoint(computeCurvePointOnCPU(controlPoints, (i+1) / float(nbCurvePoints - 1)));
     float dist = firstCurvePoint.dist(nexCurvePoint);
     texCoordFactor = dist / (startSize * 2.0f);
   }
@@ -714,8 +714,8 @@ void AbstractGlCurve::drawCurve(std::vector<Coord> &controlPoints, const Color &
 
     static bool vboOk = OpenGlConfigManager::getInst().hasVertexBufferObject();
 
-    pair<GlShaderProgram *, GlShaderProgram *> geometryShaders = std::make_pair((GlShaderProgram*)NULL,(GlShaderProgram*)NULL);
-    pair<GlShaderProgram *, GlShaderProgram *> geometryBillboardShaders = std::make_pair((GlShaderProgram*)NULL,(GlShaderProgram*)NULL);
+    pair<GlShaderProgram *, GlShaderProgram *> geometryShaders = std::make_pair(static_cast<GlShaderProgram *>(NULL), static_cast<GlShaderProgram *>(NULL));
+    pair<GlShaderProgram *, GlShaderProgram *> geometryBillboardShaders = std::make_pair(static_cast<GlShaderProgram *>(NULL), static_cast<GlShaderProgram *>(NULL));
 
     if (canUseGeometryShader && curvesGeometryShadersMap.find(curveShaderProgram->getName()) != curvesGeometryShadersMap.end()) {
       geometryShaders = curvesGeometryShadersMap[curveShaderProgram->getName()];
@@ -738,7 +738,7 @@ void AbstractGlCurve::drawCurve(std::vector<Coord> &controlPoints, const Color &
       currentActiveShader->getUniformFloatVariableValue("center", fisheyeCenter);
       currentActiveShader->getUniformFloatVariableValue("radius", &fisheyeRadius);
       currentActiveShader->getUniformFloatVariableValue("height", &fisheyeHeight);
-      currentActiveShader->getUniformIntVariableValue("fisheyeType", (int*)(&fisheyeType));
+      currentActiveShader->getUniformIntVariableValue("fisheyeType", &fisheyeType);
       currentActiveShader->desactivate();
     }
 
@@ -747,9 +747,6 @@ void AbstractGlCurve::drawCurve(std::vector<Coord> &controlPoints, const Color &
     if (controlPointsTexId == 0) {
       glGenTextures(1, &controlPointsTexId);
     }
-
-    vector<float> controlPointsData(1024*4, 0);
-
 
     glEnable(GL_TEXTURE_1D);
     glBindTexture(GL_TEXTURE_1D, controlPointsTexId);
@@ -788,7 +785,7 @@ void AbstractGlCurve::drawCurve(std::vector<Coord> &controlPoints, const Color &
 
 
     if (!geometryShaderActivated) {
-      curveShaderProgram->setUniformFloat("step", 1.0f / (static_cast<float>(nbCurvePoints) - 1.0f));
+      curveShaderProgram->setUniformFloat("step", 1.0f / (float(nbCurvePoints) - 1.0f));
     }
     else {
       curveShaderProgram->setUniformBool("topOutline", true);

--- a/library/tulip-ogl/src/Camera.cpp
+++ b/library/tulip-ogl/src/Camera.cpp
@@ -90,8 +90,8 @@ void Camera::rotate(float angle, float x, float y, float z) {
   Coord vEyes = eyes - center;
 
   // Calculate the sine and cosine of the angle once
-  float cosTheta = (float)cos(angle);
-  float sinTheta = (float)sin(angle);
+  float cosTheta = float(cos(angle));
+  float sinTheta = float(sin(angle));
 
   // Find the new x position for the new rotated point
   vNewEyes[0]  = (cosTheta + (1 - cosTheta) * x * x)       * vEyes[0];
@@ -329,19 +329,19 @@ void Camera::initModelView() {
     m[3][0] = m[3][1] = m[3][2] = 0.0;
     m[3][3] = 1.0;
 
-    glMultMatrixf((GLfloat*)&m);
+    glMultMatrixf(reinterpret_cast<GLfloat*>(&m));
     glTranslatef(-eyes[0], -eyes[1], -eyes[2]);
   }
 
-  glGetFloatv (GL_MODELVIEW_MATRIX, (GLfloat*)&modelviewMatrix);
-  glGetFloatv (GL_PROJECTION_MATRIX, (GLfloat*)&projectionMatrix);
+  glGetFloatv(GL_MODELVIEW_MATRIX, reinterpret_cast<GLfloat*>(&modelviewMatrix));
+  glGetFloatv(GL_PROJECTION_MATRIX, reinterpret_cast<GLfloat*>(&projectionMatrix));
 
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
   glLoadIdentity();
-  glMultMatrixf((GLfloat*)&projectionMatrix);
-  glMultMatrixf((GLfloat*)&modelviewMatrix);
-  glGetFloatv(GL_MODELVIEW_MATRIX, (GLfloat*)&transformMatrix);
+  glMultMatrixf(reinterpret_cast<GLfloat*>(&projectionMatrix));
+  glMultMatrixf(reinterpret_cast<GLfloat*>(&modelviewMatrix));
+  glGetFloatv(GL_MODELVIEW_MATRIX, reinterpret_cast<GLfloat*>(&transformMatrix));
   glPopMatrix();
   matrixCoherent=true;
 
@@ -404,8 +404,8 @@ void Camera::getProjAndMVMatrix(const Vector<int, 4>& viewport,Matrix<float, 4> 
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
   // We have a cast to remove const on this
-  ((Camera*)this)->initProjection(viewport);
-  ((Camera*)this)->initModelView();
+  const_cast<Camera*>(this)->initProjection(viewport);
+  const_cast<Camera*>(this)->initModelView();
   projectionMatrix=this->projectionMatrix;
   modelviewMatrix=this->modelviewMatrix;
   glMatrixMode(GL_PROJECTION);
@@ -420,8 +420,8 @@ void Camera::getTransformMatrix(const Vector<int, 4>& viewport,Matrix<float, 4> 
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
   // We have a cast to remove const on this
-  ((Camera*)this)->initProjection(viewport);
-  ((Camera*)this)->initModelView();
+  const_cast<Camera*>(this)->initProjection(viewport);
+  const_cast<Camera*>(this)->initModelView();
   transformMatrix=this->transformMatrix;
   glMatrixMode(GL_PROJECTION);
   glPopMatrix();
@@ -431,8 +431,8 @@ void Camera::getTransformMatrix(const Vector<int, 4>& viewport,Matrix<float, 4> 
 //====================================================
 Coord Camera::viewportTo3DWorld(const Coord &point) const {
   // We have a cast to remove const on this
-  ((Camera *)this)->initProjection();
-  ((Camera *)this)->initModelView();
+  const_cast<Camera *>(this)->initProjection();
+  const_cast<Camera *>(this)->initModelView();
 
   Vector<int, 4> viewport = getViewport();
 
@@ -449,8 +449,8 @@ Coord Camera::viewportTo3DWorld(const Coord &point) const {
 //====================================================
 Coord Camera::worldTo2DViewport(const Coord &obj) const {
   // We have a cast to remove const on this
-  ((Camera *)this)->initProjection();
-  ((Camera *)this)->initModelView();
+  const_cast<Camera *>(this)->initProjection();
+  const_cast<Camera *>(this)->initModelView();
 
   Vector<int, 4> viewport = getViewport();
   return projectPoint(obj, transformMatrix, viewport) - Coord(viewport[0], viewport[1]);

--- a/library/tulip-ogl/src/EdgeExtremityGlyph.cpp
+++ b/library/tulip-ogl/src/EdgeExtremityGlyph.cpp
@@ -24,8 +24,7 @@ using namespace tlp;
 
 EdgeExtremityGlyph::EdgeExtremityGlyph(const PluginContext* context) : edgeExtGlGraphInputData(NULL) {
   if(context != NULL) {
-    const GlyphContext* glyphContext = dynamic_cast<const GlyphContext*>(context);
-    assert(glyphContext != NULL);
+    const GlyphContext* glyphContext = static_cast<const GlyphContext*>(context);
     edgeExtGlGraphInputData = glyphContext->glGraphInputData;
   }
 }

--- a/library/tulip-ogl/src/EpsFunction.cpp
+++ b/library/tulip-ogl/src/EpsFunction.cpp
@@ -97,13 +97,13 @@ GLfloat *tlp::spewPrimitiveEPS(FILE * file, GLfloat * loc) {
   GLfloat xnext, ynext, rnext, gnext, bnext, distance;
   xnext=ynext=rnext=gnext=bnext=distance=0;
 
-  token = (int)*loc;
+  token = int(*loc);
   loc++;
 
   switch (token) {
   case GL_LINE_RESET_TOKEN:
   case GL_LINE_TOKEN:
-    vertex = (Feedback3Dcolor *) loc;
+    vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
 
     dr = vertex[1].red - vertex[0].red;
     dg = vertex[1].green - vertex[0].green;
@@ -124,7 +124,7 @@ GLfloat *tlp::spewPrimitiveEPS(FILE * file, GLfloat * loc) {
 #define EPS_SMOOTH_LINE_FACTOR 1  /* Upper for better smooth
       lines. */
       colormax = Max(absR, Max(absG, absB));
-      steps =(int) rint(Max(1.0, colormax * distance * EPS_SMOOTH_LINE_FACTOR));
+      steps =int(rint(Max(1.0, colormax * distance * EPS_SMOOTH_LINE_FACTOR)));
 
       xstep = dx / steps;
       ystep = dy / steps;
@@ -175,10 +175,10 @@ GLfloat *tlp::spewPrimitiveEPS(FILE * file, GLfloat * loc) {
     break;
 
   case GL_POLYGON_TOKEN:
-    nvertices =(int) *loc;
+    nvertices = int(*loc);
     loc++;
 
-    vertex = (Feedback3Dcolor *) loc;
+    vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
 
     if (nvertices > 0) {
       red = vertex[0].red;
@@ -228,7 +228,7 @@ GLfloat *tlp::spewPrimitiveEPS(FILE * file, GLfloat * loc) {
     break;
 
   case GL_POINT_TOKEN:
-    vertex = (Feedback3Dcolor *) loc;
+    vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
     fprintf(file, "%g %g %g setrgbcolor\n", vertex[0].red, vertex[0].green, vertex[0].blue);
     fprintf(file, "%g %g %g 0 360 arc fill\n\n", vertex[0].x, vertex[0].y, pointSize / 2.0);
     loc += 7;           /* Each vertex element in the feedback
@@ -264,8 +264,8 @@ typedef struct _DepthIndex {
 } DepthIndex;
 //====================================================
 int tlp::compare(const void *a, const void *b) {
-  DepthIndex *p1 = (DepthIndex *) a;
-  DepthIndex *p2 = (DepthIndex *) b;
+  const DepthIndex *p1 = static_cast<const DepthIndex *>(a);
+  const DepthIndex *p2 = static_cast<const DepthIndex *>(b);
   GLfloat diff = p2->depth - p1->depth;
 
   if (diff > 0.0) {
@@ -295,7 +295,7 @@ void tlp::spewSortedFeedback(FILE * file, GLint size, GLfloat * buffer) {
   loc = buffer;
 
   while (loc < end) {
-    token = (int)*loc;
+    token = int(*loc);
     loc++;
 
     switch (token) {
@@ -306,7 +306,7 @@ void tlp::spewSortedFeedback(FILE * file, GLint size, GLfloat * buffer) {
       break;
 
     case GL_POLYGON_TOKEN:
-      nvertices = (int)*loc;
+      nvertices = int(*loc);
       loc++;
       loc += (7 * nvertices);
       nprimitives++;
@@ -333,20 +333,20 @@ void tlp::spewSortedFeedback(FILE * file, GLint size, GLfloat * buffer) {
      entry per primitive.  This array is also where we keep the
      primitive's average depth.  There is one entry per
      primitive  in the feedback buffer. */
-  prims = (DepthIndex *) malloc(sizeof(DepthIndex) * nprimitives);
+  prims = static_cast<DepthIndex *>(malloc(sizeof(DepthIndex) * nprimitives));
 
   item = 0;
   loc = buffer;
 
   while (loc < end) {
     prims[item].ptr = loc;  /* Save this primitive's location. */
-    token = (int)*loc;
+    token = int(*loc);
     loc++;
 
     switch (token) {
     case GL_LINE_TOKEN:
     case GL_LINE_RESET_TOKEN:
-      vertex = (Feedback3Dcolor *) loc;
+      vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
       depthSum = vertex[0].z + vertex[1].z;
       prims[item].depth = depthSum / 2.0;
       loc += 14;
@@ -354,9 +354,9 @@ void tlp::spewSortedFeedback(FILE * file, GLint size, GLfloat * buffer) {
       break;
 
     case GL_POLYGON_TOKEN:
-      nvertices = (int)*loc;
+      nvertices = int(*loc);
       loc++;
-      vertex = (Feedback3Dcolor *) loc;
+      vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
       depthSum = vertex[0].z;
 
       for (i = 1; i < nvertices; i++) {
@@ -369,7 +369,7 @@ void tlp::spewSortedFeedback(FILE * file, GLint size, GLfloat * buffer) {
       break;
 
     case GL_POINT_TOKEN:
-      vertex = (Feedback3Dcolor *) loc;
+      vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
       prims[item].depth = vertex[0].z;
       loc += 7;
       item++;
@@ -489,7 +489,7 @@ void tlp::printBuffer(GLint size, GLfloat * buffer) {
   count = size;
 
   while (count) {
-    int token = (int)buffer[size - count];
+    int token = int(buffer[size - count]);
     count--;
 
     switch (token) {
@@ -518,7 +518,7 @@ void tlp::printBuffer(GLint size, GLfloat * buffer) {
 
     case GL_POLYGON_TOKEN:
       printf("GL_POLYGON_TOKEN\n");
-      int nvertices = (int)buffer[size - count];
+      int nvertices = int(buffer[size - count]);
       count--;
 
       for (; nvertices > 0; nvertices--) {

--- a/library/tulip-ogl/src/GlCPULODCalculator.cpp
+++ b/library/tulip-ogl/src/GlCPULODCalculator.cpp
@@ -87,7 +87,7 @@ void GlCPULODCalculator::compute(const Vector<int,4>& globalViewport,const Vecto
     Coord eye;
 
     if(camera->is3D()) {
-      eye=camera->getEyes() + ( camera->getEyes() - camera->getCenter() ) / (float)camera->getZoomFactor();
+      eye=camera->getEyes() + ( camera->getEyes() - camera->getCenter() ) / float(camera->getZoomFactor());
       computeFor3DCamera(&(*it),eye,transformMatrix,globalViewport,currentViewport);
     }
     else {

--- a/library/tulip-ogl/src/GlCatmullRomCurve.cpp
+++ b/library/tulip-ogl/src/GlCatmullRomCurve.cpp
@@ -151,7 +151,7 @@ void GlCatmullRomCurve::drawCurve(vector<Coord> &controlPoints, const Color &sta
     totalLength = 0.0f;
 
     for (size_t i = 1 ; i < controlPointsP->size() ; ++i) {
-      float dist = pow((float) (*controlPointsP)[i-1].dist((*controlPointsP)[i]), alpha);
+      float dist = pow((*controlPointsP)[i-1].dist((*controlPointsP)[i]), alpha);
       totalLength += dist;
     }
   }

--- a/library/tulip-ogl/src/GlColorScale.cpp
+++ b/library/tulip-ogl/src/GlColorScale.cpp
@@ -47,7 +47,7 @@ void GlColorScale::setColorScale(ColorScale * scale) {
 }
 
 void GlColorScale::treatEvent(const Event &evt) {
-  if (dynamic_cast<ColorScale *>(evt.sender()) && evt.type() == Event::TLP_MODIFICATION)
+  if (evt.type() == Event::TLP_MODIFICATION)
     updateDrawing();
 }
 

--- a/library/tulip-ogl/src/GlComplexPolygon.cpp
+++ b/library/tulip-ogl/src/GlComplexPolygon.cpp
@@ -17,6 +17,11 @@
  *
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include <GL/glew.h>
 
 // libtess2
@@ -620,3 +625,7 @@ void GlComplexPolygon::setWithXML(const string &inString,unsigned int &currentPo
   }
 }
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/library/tulip-ogl/src/GlConvexHull.cpp
+++ b/library/tulip-ogl/src/GlConvexHull.cpp
@@ -81,7 +81,7 @@ void GlConvexHull::draw(float,Camera *) {
       }
 
       //_points[i][2] = 0;
-      glVertex3fv((float *)&_points[i]);
+      glVertex3fv(reinterpret_cast<float *>(&_points[i]));
     }
 
     glEnd();
@@ -96,7 +96,7 @@ void GlConvexHull::draw(float,Camera *) {
       }
 
       //_points[i][2] = 0;
-      glVertex3fv((float *)&_points[i]);
+      glVertex3fv(reinterpret_cast<float *>(&_points[i]));
     }
 
     glEnd();

--- a/library/tulip-ogl/src/GlEPSFeedBackBuilder.cpp
+++ b/library/tulip-ogl/src/GlEPSFeedBackBuilder.cpp
@@ -84,18 +84,18 @@ void GlEPSFeedBackBuilder::begin(const Vector<int, 4> &viewport,GLfloat*,GLfloat
   stream_out << viewport[0] << " " << viewport[1] << " " << viewport[2] << " " << viewport[3] << " rectfill" << endl << endl;
 }
 void GlEPSFeedBackBuilder::colorInfo(GLfloat* data) {
-  fillColor[0]=(unsigned char)data[0];
-  fillColor[1]=(unsigned char)data[1];
-  fillColor[2]=(unsigned char)data[2];
-  fillColor[3]=(unsigned char)data[3];
-  strokeColor[0]=(unsigned char)data[4];
-  strokeColor[1]=(unsigned char)data[5];
-  strokeColor[2]=(unsigned char)data[6];
-  strokeColor[3]=(unsigned char)data[7];
-  textColor[0]=(unsigned char)data[8];
-  textColor[1]=(unsigned char)data[9];
-  textColor[2]=(unsigned char)data[10];
-  textColor[3]=(unsigned char)data[11];
+  fillColor[0]=uchar(data[0]);
+  fillColor[1]=uchar(data[1]);
+  fillColor[2]=uchar(data[2]);
+  fillColor[3]=uchar(data[3]);
+  strokeColor[0]=uchar(data[4]);
+  strokeColor[1]=uchar(data[5]);
+  strokeColor[2]=uchar(data[6]);
+  strokeColor[3]=uchar(data[7]);
+  textColor[0]=uchar(data[8]);
+  textColor[1]=uchar(data[9]);
+  textColor[2]=uchar(data[10]);
+  textColor[3]=uchar(data[11]);
 }
 void GlEPSFeedBackBuilder::beginGlGraph(GLfloat) {
 }
@@ -114,12 +114,12 @@ void GlEPSFeedBackBuilder::beginEdge(GLfloat) {
 void GlEPSFeedBackBuilder::endEdge() {
 }
 void GlEPSFeedBackBuilder::pointToken(GLfloat *data) {
-  Feedback3Dcolor *vertex = (Feedback3Dcolor *) data;
+  Feedback3Dcolor *vertex = reinterpret_cast<Feedback3Dcolor *>(data);
   stream_out << vertex[0].red << " " << vertex[0].green << " " << vertex[0].blue << " setrgbcolor" << endl;
   stream_out << vertex[0].x << " " <<  vertex[0].y << " " <<  pointSize / 2.0 << " 0 360 arc fill" << endl << endl;
 }
 void GlEPSFeedBackBuilder::lineToken(GLfloat *data) {
-  Feedback3Dcolor *vertex = (Feedback3Dcolor *) data;
+  Feedback3Dcolor *vertex = reinterpret_cast<Feedback3Dcolor *>(data);
   GLfloat dx, dy, dr, dg, db, absR, absG, absB, colormax;
   int steps;
   GLfloat xstep, ystep, rstep, gstep, bstep;
@@ -146,7 +146,7 @@ void GlEPSFeedBackBuilder::lineToken(GLfloat *data) {
 #define EPS_SMOOTH_LINE_FACTOR 1  /* Upper for better smooth
     lines. */
     colormax = Max(absR, Max(absG, absB));
-    steps =(int) rint(Max(1.0, colormax * distance * EPS_SMOOTH_LINE_FACTOR));
+    steps = int(rint(Max(1.0, colormax * distance * EPS_SMOOTH_LINE_FACTOR)));
 
     xstep = dx / steps;
     ystep = dy / steps;
@@ -196,9 +196,9 @@ void GlEPSFeedBackBuilder::lineResetToken(GLfloat *data) {
 }
 
 void GlEPSFeedBackBuilder::polygonToken(GLfloat *data) {
-  int nvertices =(int) *data;
+  int nvertices = int(*data);
   GLfloat red, green, blue;
-  Feedback3Dcolor *vertex = (Feedback3Dcolor *)(data+1);
+  Feedback3Dcolor *vertex = reinterpret_cast<Feedback3Dcolor *>(data+1);
 
   if (nvertices > 0) {
     red = vertex[0].red;

--- a/library/tulip-ogl/src/GlEdge.cpp
+++ b/library/tulip-ogl/src/GlEdge.cpp
@@ -252,7 +252,7 @@ void GlEdge::draw(float lod, const GlGraphInputData* data, Camera* camera) {
     glPassThrough(textColor[3]);
 
     glPassThrough(TLP_FB_BEGIN_EDGE);
-    glPassThrough(static_cast<float>(id)); //id of the node for the feed back mode
+    glPassThrough(float(id)); //id of the node for the feed back mode
   }
 
   bool hasBends(!bends.empty());
@@ -324,7 +324,7 @@ void GlEdge::draw(float lod, const GlGraphInputData* data, Camera* camera) {
   GlTextureManager::getInst().setAnimationFrame(data->getElementAnimationFrame()->getEdgeValue(e));
   //draw Edge
   drawEdge(srcCoord, tgtCoord, beginLineAnchor, endLineAnchor, bends, srcCol, tgtCol,camera->getCenter()-camera->getEyes(),data->parameters->isEdgeColorInterpolate() ,strokeColor,edgeSize,
-           data->getElementShape()->getEdgeValue(e), data->parameters->isEdge3D(), lodSize, edgeTexture, static_cast<float>(lineWidth));
+           data->getElementShape()->getEdgeValue(e), data->parameters->isEdge3D(), lodSize, edgeTexture, float(lineWidth));
   GlTextureManager::getInst().setAnimationFrame(0);
 
   if (data->parameters->getFeedbackRender()) {
@@ -537,12 +537,12 @@ void GlEdge::drawLabel(OcclusionTest* test, const GlGraphInputData* data, float 
 
   if (bends.empty()) {
     position = (srcCoord + tgtCoord) / 2.f;
-    angle=atan((tgtCoord[1]-srcCoord[1])/(tgtCoord[0]-srcCoord[0]))*static_cast<float>(180./M_PI);
+    angle=atan((tgtCoord[1]-srcCoord[1])/(tgtCoord[0]-srcCoord[0]))*float(180./M_PI);
   }
   else {
     if (bends.size() % 2 == 0) {
       position = (bends[bends.size() / 2 - 1] + bends[bends.size() / 2]) / 2.f;
-      angle=atan((bends[bends.size() / 2][1]-bends[bends.size() / 2 - 1][1])/(bends[bends.size() / 2][0]-bends[bends.size() / 2 - 1][0]))*static_cast<float>(180./M_PI);
+      angle=atan((bends[bends.size() / 2][1]-bends[bends.size() / 2 - 1][1])/(bends[bends.size() / 2][0]-bends[bends.size() / 2 - 1][0]))*float(180./M_PI);
     }
     else {
       position = bends[bends.size() / 2];
@@ -558,8 +558,8 @@ void GlEdge::drawLabel(OcclusionTest* test, const GlGraphInputData* data, float 
         secondVector=bends[bends.size() / 2]-tgtCoord;
       }
 
-      float firstAngle=atan(firstVector[1]/firstVector[0])*static_cast<float>(180./M_PI);
-      float secondAngle=atan(secondVector[1]/secondVector[0])*static_cast<float>(180./M_PI);
+      float firstAngle=atan(firstVector[1]/firstVector[0])*float(180./M_PI);
+      float secondAngle=atan(secondVector[1]/secondVector[0])*float(180./M_PI);
 
       Coord textDirection=firstVector+secondVector;
 
@@ -919,8 +919,8 @@ void GlEdge::displayArrowAndAdjustAnchor(const GlGraphInputData *data,
             srcTransformationMatrix, srcScalingMatrix);
 
         glPushMatrix();
-        glMultMatrixf((GLfloat *) &srcTransformationMatrix);
-        glMultMatrixf((GLfloat *) &srcScalingMatrix);
+        glMultMatrixf(reinterpret_cast<GLfloat *>(&srcTransformationMatrix));
+        glMultMatrixf(reinterpret_cast<GLfloat *>(&srcScalingMatrix));
         glDisable(GL_CULL_FACE);
         extremityGlyph->draw(e, source, color, borderColor, 100.);
         glEnable(GL_CULL_FACE);

--- a/library/tulip-ogl/src/GlFeedBackRecorder.cpp
+++ b/library/tulip-ogl/src/GlFeedBackRecorder.cpp
@@ -26,8 +26,8 @@ using namespace std;
 namespace tlp {
 
 static int compare(const void *a, const void *b) {
-  DepthIndex *p1 = (DepthIndex *) a;
-  DepthIndex *p2 = (DepthIndex *) b;
+  const DepthIndex *p1 = static_cast<const DepthIndex *>(a);
+  const DepthIndex *p2 = static_cast<const DepthIndex *>(b);
   GLfloat diff = p2->depth - p1->depth;
 
   if (diff > 0.0) {
@@ -79,7 +79,7 @@ void GlFeedBackRecorder::sortAndRecord(GLint size, GLfloat *feedBackBuffer) {
   loc = feedBackBuffer;
 
   while (loc < end) {
-    token = (int)*loc;
+    token = int(*loc);
     loc++;
 
     switch (token) {
@@ -90,7 +90,7 @@ void GlFeedBackRecorder::sortAndRecord(GLint size, GLfloat *feedBackBuffer) {
       break;
 
     case GL_POLYGON_TOKEN:
-      nvertices = (int)*loc;
+      nvertices = int(*loc);
       loc++;
       loc += (pointSize * nvertices);
       nprimitives++;
@@ -117,20 +117,20 @@ void GlFeedBackRecorder::sortAndRecord(GLint size, GLfloat *feedBackBuffer) {
      entry per primitive.  This array is also where we keep the
      primitive's average depth.  There is one entry per
      primitive  in the feedback buffer. */
-  prims = (DepthIndex *) malloc(sizeof(DepthIndex) * nprimitives);
+  prims = static_cast<DepthIndex *>(malloc(sizeof(DepthIndex) * nprimitives));
 
   item = 0;
   loc = feedBackBuffer;
 
   while (loc < end) {
     prims[item].ptr = loc;  /* Save this primitive's location. */
-    token = (int)*loc;
+    token = int(*loc);
     loc++;
 
     switch (token) {
     case GL_LINE_TOKEN:
     case GL_LINE_RESET_TOKEN:
-      vertex = (Feedback3Dcolor *) loc;
+      vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
       depthSum = vertex[0].z + vertex[1].z;
       prims[item].depth = depthSum / 2.0;
       loc += pointSize*2;
@@ -138,9 +138,9 @@ void GlFeedBackRecorder::sortAndRecord(GLint size, GLfloat *feedBackBuffer) {
       break;
 
     case GL_POLYGON_TOKEN:
-      nvertices = (int)*loc;
+      nvertices = int(*loc);
       loc++;
-      vertex = (Feedback3Dcolor *) loc;
+      vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
       depthSum = vertex[0].z;
 
       for (i = 1; i < nvertices; i++) {
@@ -153,7 +153,7 @@ void GlFeedBackRecorder::sortAndRecord(GLint size, GLfloat *feedBackBuffer) {
       break;
 
     case GL_POINT_TOKEN:
-      vertex = (Feedback3Dcolor *) loc;
+      vertex = reinterpret_cast<Feedback3Dcolor *>(loc);
       prims[item].depth = vertex[0].z;
       loc += pointSize;
       item++;
@@ -202,7 +202,7 @@ void GlFeedBackRecorder::record(GLint size, GLfloat *feedBackBuffer) {
 }
 
 GLfloat* GlFeedBackRecorder::recordPrimitive(GLfloat *loc) {
-  int token = (int)*loc;
+  int token = int(*loc);
   loc++;
 
   switch (token) {
@@ -216,7 +216,7 @@ GLfloat* GlFeedBackRecorder::recordPrimitive(GLfloat *loc) {
 
   case GL_POLYGON_TOKEN:
     int nvertices;
-    nvertices = (int)*loc;
+    nvertices = int(*loc);
     feedBackBuilder->polygonToken(loc);
     return loc+(pointSize * nvertices)+1;
 

--- a/library/tulip-ogl/src/GlGraphHighDetailsRenderer.cpp
+++ b/library/tulip-ogl/src/GlGraphHighDetailsRenderer.cpp
@@ -424,9 +424,9 @@ void GlGraphHighDetailsRenderer::draw(float,Camera* camera) {
 
         bb=it->boundingBox;
         Coord middle((bb[1]+bb[0])/2.f);
-        dist=(((double)middle[0])-((double)camPos[0]))*(((double)middle[0])-((double)camPos[0]));
-        dist+=(((double)middle[1])-((double)camPos[1]))*(((double)middle[1])-((double)camPos[1]));
-        dist+=(((double)middle[2])-((double)camPos[2]))*(((double)middle[2])-((double)camPos[2]));
+        dist=(double(middle[0])-double(camPos[0]))*(double(middle[0])-double(camPos[0]));
+        dist+=(double(middle[1])-double(camPos[1]))*(double(middle[1])-double(camPos[1]));
+        dist+=(double(middle[2])-double(camPos[2]))*(double(middle[2])-double(camPos[2]));
         entitiesSet.insert(EntityWithDistance(dist,&(*it),true));
       }
     }
@@ -443,9 +443,9 @@ void GlGraphHighDetailsRenderer::draw(float,Camera* camera) {
 
         bb = it->boundingBox;
         Coord middle((bb[0] + bb[1])/2.f);
-        dist=(((double)middle[0])-((double)camPos[0]))*(((double)middle[0])-((double)camPos[0]));
-        dist+=(((double)middle[1])-((double)camPos[1]))*(((double)middle[1])-((double)camPos[1]));
-        dist+=(((double)middle[2])-((double)camPos[2]))*(((double)middle[2])-((double)camPos[2]));
+        dist=(double(middle[0])-double(camPos[0]))*(double(middle[0])-double(camPos[0]));
+        dist+=(double(middle[1])-double(camPos[1]))*(double(middle[1])-double(camPos[1]));
+        dist+=(double(middle[2])-double(camPos[2]))*(double(middle[2])-double(camPos[2]));
         entitiesSet.insert(EntityWithDistance(dist,&(*it),false));
       }
     }
@@ -453,7 +453,7 @@ void GlGraphHighDetailsRenderer::draw(float,Camera* camera) {
     // Draw
     for(multiset<EntityWithDistance,entityWithDistanceCompare>::iterator it=entitiesSet.begin(); it!=entitiesSet.end(); ++it) {
       // Complex entities
-      ComplexEntityLODUnit *entity=(ComplexEntityLODUnit*)(it->entity);
+      ComplexEntityLODUnit *entity=static_cast<ComplexEntityLODUnit*>(it->entity);
 
 
       if(it->isNode) {
@@ -563,7 +563,7 @@ void GlGraphHighDetailsRenderer::selectEntities(Camera *camera,RenderingEntities
 
   //Allocate memory to store the result oh the selection
   GLuint (*selectBuf)[4] = new GLuint[size][4];
-  glSelectBuffer(size*4 , (GLuint *)selectBuf);
+  glSelectBuffer(size*4 , reinterpret_cast<GLuint *>(selectBuf));
   //Activate Open Gl Selection mode
   glRenderMode(GL_SELECT);
   glInitNames();
@@ -647,7 +647,7 @@ void GlGraphHighDetailsRenderer::drawLabelsForComplexEntities(bool drawSelected,
           // Not metric ordered
           if((!graph->isMetaNode(n) && viewNodeLabel) || graph->isMetaNode(n)) {
             glNode.id=n.id;
-            glNode.drawLabel(occlusionTest,inputData,lod,(Camera *)(layerLODUnit.camera));
+            glNode.drawLabel(occlusionTest,inputData,lod,layerLODUnit.camera);
           }
         }
         else {
@@ -669,7 +669,7 @@ void GlGraphHighDetailsRenderer::drawLabelsForComplexEntities(bool drawSelected,
 
       for(vector<pair<node,float> >::iterator it=nodesMetricOrdered.begin(); it!=nodesMetricOrdered.end(); ++it) {
         glNode.id=it->first.id;
-        glNode.drawLabel(occlusionTest,inputData,it->second,(Camera *)(layerLODUnit.camera));
+        glNode.drawLabel(occlusionTest,inputData,it->second,layerLODUnit.camera);
       }
     }
   }
@@ -695,7 +695,7 @@ void GlGraphHighDetailsRenderer::drawLabelsForComplexEntities(bool drawSelected,
         if(!metric) {
           // Not metric ordered
           glEdge.id=e.id;
-          glEdge.drawLabel(occlusionTest,inputData,it->lod,(Camera *)(layerLODUnit.camera));
+          glEdge.drawLabel(occlusionTest,inputData,it->lod,layerLODUnit.camera);
         }
         else {
           // Metric ordered
@@ -714,7 +714,7 @@ void GlGraphHighDetailsRenderer::drawLabelsForComplexEntities(bool drawSelected,
 
       for(vector<pair<edge,float> >::iterator it=edgesMetricOrdered.begin(); it!=edgesMetricOrdered.end(); ++it) {
         glEdge.id=it->first.id;
-        glEdge.drawLabel(occlusionTest,inputData,it->second,(Camera *)(layerLODUnit.camera));
+        glEdge.drawLabel(occlusionTest,inputData,it->second,layerLODUnit.camera);
       }
     }
   }

--- a/library/tulip-ogl/src/GlGraphInputData.cpp
+++ b/library/tulip-ogl/src/GlGraphInputData.cpp
@@ -75,9 +75,9 @@ public:
     graph->addListener(this);
   }
   void treatEvent(const Event& evt) {
-    Graph* g = dynamic_cast<Graph *>(evt.sender());
+    Graph* g = static_cast<Graph *>(evt.sender());
 
-    if (g && (graph == g) && evt.type() == Event::TLP_DELETE) {
+    if (graph == g && evt.type() == Event::TLP_DELETE) {
       delete this;
     }
     else {

--- a/library/tulip-ogl/src/GlGraphLowDetailsRenderer.cpp
+++ b/library/tulip-ogl/src/GlGraphLowDetailsRenderer.cpp
@@ -89,7 +89,8 @@ void GlGraphLowDetailsRenderer::initEdgesArray() {
       tmp *= 1./(bends.size() + 2);
       tmp *= j+1;
       tmp += ca;
-      colors[i_col++] = Color((int)tmp[0], (int)tmp[1], (int)tmp[2], (int)tmp[3]);
+      colors[i_col++] = Color(uchar(tmp[0]), uchar(tmp[1]),
+                              uchar(tmp[2]), uchar(tmp[3]));
       indices[i_indices++] = i_point;
       indices[i_indices++] = i_point;
       points[i_point][0] = bends[j][0];

--- a/library/tulip-ogl/src/GlGraphRenderingParameters.cpp
+++ b/library/tulip-ogl/src/GlGraphRenderingParameters.cpp
@@ -231,7 +231,7 @@ unsigned int GlGraphRenderingParameters::getLabelsBorder() const {
     return -_labelsDensity;
 }
 void GlGraphRenderingParameters::setLabelsBorder(const unsigned int border) {
-  _labelsDensity = -static_cast<int>(border);
+  _labelsDensity = -int(border);
 }
 //====================================================
 bool GlGraphRenderingParameters::isViewMetaLabel()const {

--- a/library/tulip-ogl/src/GlLabel.cpp
+++ b/library/tulip-ogl/src/GlLabel.cpp
@@ -16,7 +16,15 @@
  * See the GNU General Public License for more details.
  *
  */
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 #include <FTGL/ftgl.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #include <tulip/GlLabel.h>
 #include <tulip/Coord.h>
@@ -130,7 +138,7 @@ void GlLabel::setText(const string& text) {
   if (font->Error())
     return;
 
-  if(font->FaceSize()!=(unsigned int)fontSize) {
+  if(font->FaceSize()!=uint(fontSize)) {
     font->FaceSize(fontSize);
     borderFont->FaceSize(fontSize);
   }
@@ -387,8 +395,8 @@ void GlLabel::draw(float, Camera *camera) {
       hModified-=labelsDensity;
     }
     else {
-      wModified=w-w*(((float)labelsDensity)/(100.));
-      hModified=h-h*(((float)labelsDensity)/(100.));
+      wModified=w-w*(float(labelsDensity)/100);
+      hModified=h-h*(float(labelsDensity)/100);
     }
 
     switch(alignment) {
@@ -439,15 +447,15 @@ void GlLabel::draw(float, Camera *camera) {
 
     Matrix<float, 4> modelviewMatrix, projectionMatrix, transformMatrix;
 
-    glGetFloatv (GL_MODELVIEW_MATRIX, (GLfloat*)&modelviewMatrix);
-    glGetFloatv (GL_PROJECTION_MATRIX, (GLfloat*)&projectionMatrix);
+    glGetFloatv(GL_MODELVIEW_MATRIX, reinterpret_cast<GLfloat*>(&modelviewMatrix));
+    glGetFloatv(GL_PROJECTION_MATRIX, reinterpret_cast<GLfloat*>(&projectionMatrix));
 
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
-    glMultMatrixf((GLfloat*)&projectionMatrix);
-    glMultMatrixf((GLfloat*)&modelviewMatrix);
-    glGetFloatv(GL_MODELVIEW_MATRIX, (GLfloat*)&transformMatrix);
+    glMultMatrixf(reinterpret_cast<GLfloat*>(&projectionMatrix));
+    glMultMatrixf(reinterpret_cast<GLfloat*>(&modelviewMatrix));
+    glGetFloatv(GL_MODELVIEW_MATRIX, reinterpret_cast<GLfloat*>(&transformMatrix));
     glPopMatrix();
 
     BoundingBox bbTmp;
@@ -514,15 +522,15 @@ void GlLabel::draw(float, Camera *camera) {
 
     Matrix<float, 4> modelviewMatrix, projectionMatrix, transformMatrix;
 
-    glGetFloatv (GL_MODELVIEW_MATRIX, (GLfloat*)&modelviewMatrix);
-    glGetFloatv (GL_PROJECTION_MATRIX, (GLfloat*)&projectionMatrix);
+    glGetFloatv(GL_MODELVIEW_MATRIX, reinterpret_cast<GLfloat*>(&modelviewMatrix));
+    glGetFloatv(GL_PROJECTION_MATRIX, reinterpret_cast<GLfloat*>(&projectionMatrix));
 
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
-    glMultMatrixf((GLfloat*)&projectionMatrix);
-    glMultMatrixf((GLfloat*)&modelviewMatrix);
-    glGetFloatv(GL_MODELVIEW_MATRIX, (GLfloat*)&transformMatrix);
+    glMultMatrixf(reinterpret_cast<GLfloat*>(&projectionMatrix));
+    glMultMatrixf(reinterpret_cast<GLfloat*>(&modelviewMatrix));
+    glGetFloatv(GL_MODELVIEW_MATRIX, reinterpret_cast<GLfloat*>(&transformMatrix));
     glPopMatrix();
 
     MatrixGL invTransformMatrix(transformMatrix);
@@ -546,19 +554,19 @@ void GlLabel::draw(float, Camera *camera) {
     switch(alignment) {
 
     case LabelPosition::Left:
-      billboardedTranlation=unprojectPoint(((Coord)billboardedBB.center())+Coord(-billboardedBB.width()/2.,0,0),invTransformMatrix,camera->getViewport())-baseCenter;
+      billboardedTranlation=unprojectPoint(billboardedBB.center()+Coord(-billboardedBB.width()/2.,0,0),invTransformMatrix,camera->getViewport())-baseCenter;
       break;
 
     case LabelPosition::Right:
-      billboardedTranlation=unprojectPoint(((Coord)billboardedBB.center())+Coord(billboardedBB.width()/2.,0,0),invTransformMatrix,camera->getViewport())-baseCenter;
+      billboardedTranlation=unprojectPoint(billboardedBB.center()+Coord(billboardedBB.width()/2.,0,0),invTransformMatrix,camera->getViewport())-baseCenter;
       break;
 
     case LabelPosition::Top:
-      billboardedTranlation=unprojectPoint(((Coord)billboardedBB.center())+Coord(0,billboardedBB.height()/2.,0),invTransformMatrix,camera->getViewport())-baseCenter;
+      billboardedTranlation=unprojectPoint(billboardedBB.center()+Coord(0,billboardedBB.height()/2.,0),invTransformMatrix,camera->getViewport())-baseCenter;
       break;
 
     case LabelPosition::Bottom:
-      billboardedTranlation=unprojectPoint(((Coord)billboardedBB.center())+Coord(0,-billboardedBB.height()/2.,0),invTransformMatrix,camera->getViewport())-baseCenter;
+      billboardedTranlation=unprojectPoint(billboardedBB.center()+Coord(0,-billboardedBB.height()/2.,0),invTransformMatrix,camera->getViewport())-baseCenter;
       break;
 
     default:
@@ -569,8 +577,8 @@ void GlLabel::draw(float, Camera *camera) {
 
     //Billboard computation
     float mdlM[16];
-    glGetFloatv( GL_MODELVIEW_MATRIX, mdlM );
-    glMatrixMode( GL_MODELVIEW );
+    glGetFloatv(GL_MODELVIEW_MATRIX, mdlM);
+    glMatrixMode(GL_MODELVIEW);
 
     mdlM[0]  = 1.;
     mdlM[5]  = 1.;
@@ -578,7 +586,7 @@ void GlLabel::draw(float, Camera *camera) {
     mdlM[1] = mdlM[2] = 0.0f;
     mdlM[4] = mdlM[6] = 0.0f;
     mdlM[8] = mdlM[9] = 0.0f;
-    glLoadMatrixf( mdlM );
+    glLoadMatrixf(mdlM);
   }
 
   glScalef(scaleToApply,scaleToApply,1);

--- a/library/tulip-ogl/src/GlLines.cpp
+++ b/library/tulip-ogl/src/GlLines.cpp
@@ -109,7 +109,7 @@ void GlLines::glDrawBezierCurve(const Coord &startPoint,const vector<Coord> &ben
 
   for (unsigned int i = 0; i <= steps; i++) {
     setColor(colorStart);
-    glEvalCoord1f((GLfloat) i/steps);
+    glEvalCoord1f(i/GLfloat(steps));
 
     for (unsigned int j=0; j<4; j++)
       colorStart[j]+=colorDelta[j];
@@ -184,7 +184,7 @@ void GlLines::glDrawSplineCurve(const Coord &startPoint,const vector<Coord> &ben
 
     for (unsigned int i = 0; i <= steps; i++) {
       setColor(colorStart);
-      glEvalCoord1f((GLfloat) i/steps);
+      glEvalCoord1f(i/GLfloat(steps));
 
       for (unsigned int j=0; j<4; j++)
         colorStart[j]+=colorDelta[j];
@@ -230,7 +230,7 @@ void GlLines::glDrawSplineCurve(const Coord &startPoint,const vector<Coord> &ben
 
     for (unsigned int i = 0; i <= steps; i++) {
       setColor(colorStart);
-      glEvalCoord1f((GLfloat) i/steps);
+      glEvalCoord1f(i/GLfloat(steps));
 
       for (unsigned int j=0; j<4; j++)
         colorStart[j]+=colorDelta[j];
@@ -255,7 +255,7 @@ void GlLines::glDrawSplineCurve(const Coord &startPoint,const vector<Coord> &ben
 
     for (unsigned int i = 0; i <= steps; i++) {
       setColor(colorStart);
-      glEvalCoord1f((GLfloat) i/steps);
+      glEvalCoord1f(i/GLfloat(steps));
 
       for (unsigned int j=0; j<4; j++)
         colorStart[j]+=colorDelta[j];

--- a/library/tulip-ogl/src/GlMetaNodeRenderer.cpp
+++ b/library/tulip-ogl/src/GlMetaNodeRenderer.cpp
@@ -106,10 +106,10 @@ void GlMetaNodeRenderer::render(node n,float,Camera* camera) {
   newCamera2.setEyes(newCamera2.getCenter()+Coord(0,0,1)*(newCamera2.getEyes()-newCamera2.getCenter()).norm());
   newCamera2.setUp(Coord(0,1,0));
 
-  Coord first=newCamera2.worldTo2DViewport((Coord)(bb[0]));
-  Coord second=newCamera2.worldTo2DViewport((Coord)(bb[1]));
+  Coord first=newCamera2.worldTo2DViewport(bb[0]);
+  Coord second=newCamera2.worldTo2DViewport(bb[1]);
 
-  Coord center=camera->worldTo2DViewport((Coord)(bb[0]+bb[1])/2.f);
+  Coord center=camera->worldTo2DViewport((bb[0]+bb[1])/2.f);
   Coord size=second-first;
 
   Vector<int,4> viewport;
@@ -173,8 +173,8 @@ GlScene *GlMetaNodeRenderer::createScene(Graph* metaGraph) const {
 
 void GlMetaNodeRenderer::treatEvent(const Event &e) {
   if(e.type() == Event::TLP_DELETE) {
-    delete _metaGraphToSceneMap[reinterpret_cast<Graph*>(e.sender())];
-    _metaGraphToSceneMap.erase(reinterpret_cast<Graph*>(e.sender()));
+    delete _metaGraphToSceneMap[static_cast<Graph*>(e.sender())];
+    _metaGraphToSceneMap.erase(static_cast<Graph*>(e.sender()));
   }
 }
 

--- a/library/tulip-ogl/src/GlOpenUniformCubicBSpline.cpp
+++ b/library/tulip-ogl/src/GlOpenUniformCubicBSpline.cpp
@@ -92,7 +92,7 @@ void GlOpenUniformCubicBSpline::setCurveVertexShaderRenderingSpecificParameters(
 void GlOpenUniformCubicBSpline::drawCurve(std::vector<Coord> &controlPoints, const Color &startColor, const Color &endColor, const float startSize, const float endSize, const unsigned int nbCurvePoints) {
 
   nbKnots = controlPoints.size() + curveDegree + 1;
-  stepKnots = 1.0f / ((static_cast<float>(nbKnots) - 2.0f * (static_cast<float>(curveDegree) + 1.0f)) + 2.0f - 1.0f);
+  stepKnots = 1.0f / ((float(nbKnots) - 2.0f * (float(curveDegree) + 1.0f)) + 2.0f - 1.0f);
 
   if (controlPoints.size() < (curveDegree + 1)) {
     static GlBezierCurve curve;

--- a/library/tulip-ogl/src/GlPolyQuad.cpp
+++ b/library/tulip-ogl/src/GlPolyQuad.cpp
@@ -101,9 +101,9 @@ void GlPolyQuad::draw(float, Camera *) {
 
     if (nbSubdivisionsPerSegment == 1) {
 
-      texCoordsArray.push_back(static_cast<GLfloat>(i));
+      texCoordsArray.push_back(GLfloat(i));
       texCoordsArray.push_back(0.0f);
-      texCoordsArray.push_back(static_cast<GLfloat>(i));
+      texCoordsArray.push_back(GLfloat(i));
       texCoordsArray.push_back(1.0f);
       colorsArray.push_back(startColor);
       colorsArray.push_back(startColor);
@@ -121,18 +121,18 @@ void GlPolyQuad::draw(float, Camera *) {
 
         unsigned int n = i * nbSubdivisionsPerSegment + j;
 
-        Coord v1 = polyQuadEdges[2*i] + (j / static_cast<float>(nbSubdivisionsPerSegment - 1)) * (polyQuadEdges[2*(i+1)] - polyQuadEdges[2*i]);
-        Coord v2 = polyQuadEdges[2*i+1] + (j / static_cast<float>(nbSubdivisionsPerSegment - 1)) * (polyQuadEdges[2*(i+1)+1] - polyQuadEdges[2*i+1]);
+        Coord v1 = polyQuadEdges[2*i] + (j / float(nbSubdivisionsPerSegment - 1)) * (polyQuadEdges[2*(i+1)] - polyQuadEdges[2*i]);
+        Coord v2 = polyQuadEdges[2*i+1] + (j / float(nbSubdivisionsPerSegment - 1)) * (polyQuadEdges[2*(i+1)+1] - polyQuadEdges[2*i+1]);
         vertexArray.push_back(v1);
         vertexArray.push_back(v2);
 
         float texCoordFactor = ((polyQuadEdges[2*i].dist(polyQuadEdges[2*i+2])) / (nbSubdivisionsPerSegment - 1)) / (polyQuadEdges[2*i].dist(polyQuadEdges[2*i+1]));
-        texCoordsArray.push_back(static_cast<GLfloat>(i) + static_cast<GLfloat>(j) * texCoordFactor);
+        texCoordsArray.push_back(GLfloat(i) + GLfloat(j) * texCoordFactor);
         texCoordsArray.push_back(0.0f);
-        texCoordsArray.push_back(static_cast<GLfloat>(i) + static_cast<GLfloat>(j) * texCoordFactor);
+        texCoordsArray.push_back(GLfloat(i) + GLfloat(j) * texCoordFactor);
         texCoordsArray.push_back(1.0f);
 
-        Vector<float, 4> color = startColor + (j / static_cast<float>(nbSubdivisionsPerSegment - 1)) * (endColor - startColor);
+        Vector<float, 4> color = startColor + (j / float(nbSubdivisionsPerSegment - 1)) * (endColor - startColor);
         colorsArray.push_back(color);
         colorsArray.push_back(color);
 
@@ -150,9 +150,9 @@ void GlPolyQuad::draw(float, Camera *) {
       quadIndices.push_back(2*(i+1)+1);
       outlineIndices[i+1] = 2*(i+1);
       outlineIndices[nbVertices - (i+2)] = 2*(i+1)+1;
-      texCoordsArray.push_back(static_cast<GLfloat>(i+1));
+      texCoordsArray.push_back(GLfloat(i+1));
       texCoordsArray.push_back(0.0f);
-      texCoordsArray.push_back(static_cast<GLfloat>(i+1));
+      texCoordsArray.push_back(GLfloat(i+1));
       texCoordsArray.push_back(1.0f);
       colorsArray.push_back(endColor);
       colorsArray.push_back(endColor);

--- a/library/tulip-ogl/src/GlProgressBar.cpp
+++ b/library/tulip-ogl/src/GlProgressBar.cpp
@@ -90,7 +90,7 @@ GlProgressBar::~GlProgressBar() {
 }
 
 void GlProgressBar::progress_handler(int step, int max_step) {
-  currentPercent = (unsigned int) (((double) ((double) step / (double) max_step)) * 100.);
+  currentPercent = uint((step / double(max_step)) * 100);
 
   GlSimpleEntity *previousBar = findGlEntity(PROGRESS_BAR_ID);
   GlSimpleEntity *previousComment = findGlEntity(COMMENT_ID);

--- a/library/tulip-ogl/src/GlQuadTreeLODCalculator.cpp
+++ b/library/tulip-ogl/src/GlQuadTreeLODCalculator.cpp
@@ -231,7 +231,7 @@ void GlQuadTreeLODCalculator::compute(const Vector<int,4>& globalViewport,const 
 
       if(camera->is3D()) {
         currentCamera=camera;
-        eye=camera->getEyes() + ( camera->getEyes() -camera->getCenter() ) / (float)camera->getZoomFactor();
+        eye=camera->getEyes() + (camera->getEyes() - camera->getCenter()) / float(camera->getZoomFactor());
         computeFor3DCamera(&(*it),eye,transformMatrix,globalViewport,currentViewport);
         quadTreesVectorPosition++;
       }
@@ -270,7 +270,7 @@ void GlQuadTreeLODCalculator::compute(const Vector<int,4>& globalViewport,const 
 
       if(camera->is3D()) {
         currentCamera=camera;
-        eye=camera->getEyes() + ( camera->getEyes() -camera->getCenter() ) / (float)camera->getZoomFactor();
+        eye=camera->getEyes() + (camera->getEyes() - camera->getCenter()) / float(camera->getZoomFactor());
         computeFor3DCamera(layerLODUnit,eye,transformMatrix,globalViewport,currentViewport);
         quadTreesVectorPosition++;
       }
@@ -561,7 +561,7 @@ void GlQuadTreeLODCalculator::treatEvent(const Event &ev) {
     setHaveToCompute();
   }
   else if (typeid(ev) == typeid(GraphEvent)) {
-    const GraphEvent* graphEvent = dynamic_cast<const GraphEvent*>(&ev);
+    const GraphEvent* graphEvent = static_cast<const GraphEvent*>(&ev);
 
     switch(graphEvent->getType()) {
     case GraphEvent::TLP_ADD_NODE:
@@ -589,7 +589,7 @@ void GlQuadTreeLODCalculator::treatEvent(const Event &ev) {
     }
   }
   else if(typeid(ev) == typeid(PropertyEvent)) {
-    const PropertyEvent* propertyEvent = dynamic_cast<const PropertyEvent*>(&ev);
+    const PropertyEvent* propertyEvent = static_cast<const PropertyEvent*>(&ev);
     PropertyInterface* property = propertyEvent->getProperty();
 
     switch(propertyEvent->getType()) {

--- a/library/tulip-ogl/src/GlQuantitativeAxis.cpp
+++ b/library/tulip-ogl/src/GlQuantitativeAxis.cpp
@@ -98,12 +98,12 @@ void GlQuantitativeAxis::buildAxisGraduations() {
   }
   else {
     if (min >= 1) {
-      minV = minLog = log(min) / log(static_cast<double>(logBase));
-      maxV = maxLog = log(max) / log(static_cast<double>(logBase));
+      minV = minLog = log(min) / log(double(logBase));
+      maxV = maxLog = log(max) / log(double(logBase));
     }
     else {
       minV = minLog = 0;
-      maxV = maxLog = log(1 + max - min) / log(static_cast<double>(logBase));
+      maxV = maxLog = log(1 + max - min) / log(double(logBase));
     }
   }
 
@@ -137,7 +137,7 @@ void GlQuantitativeAxis::buildAxisGraduations() {
       gradLabel = getStringFromNumber(i);
     }
     else {
-      double labelValue = pow(static_cast<double>(logBase), i);
+      double labelValue = pow(double(logBase), i);
 
       if (min < 1) {
         labelValue -= (1 - min);
@@ -198,7 +198,7 @@ Coord GlQuantitativeAxis::getAxisPointCoordForValue(double value) const {
       val += (1 - min);
     }
 
-    val = log(val) / log(static_cast<double>(logBase));
+    val = log(val) / log(double(logBase));
   }
 
   if (ascendingOrder) {
@@ -249,7 +249,7 @@ double GlQuantitativeAxis::getValueForAxisPoint(const Coord &axisPointCoord) {
   }
 
   if (logScale) {
-    value = pow(static_cast<double>(logBase), value);
+    value = pow(double(logBase), value);
 
     if (min < 1) {
       value -= (1 - min);

--- a/library/tulip-ogl/src/GlSVGFeedBackBuilder.cpp
+++ b/library/tulip-ogl/src/GlSVGFeedBackBuilder.cpp
@@ -49,18 +49,18 @@ void GlSVGFeedBackBuilder::begin(const Vector<int, 4> &viewport,GLfloat* clearCo
     graphId);*/
 }
 void GlSVGFeedBackBuilder::colorInfo(GLfloat* data) {
-  fillColor[0]=(unsigned char)data[0];
-  fillColor[1]=(unsigned char)data[1];
-  fillColor[2]=(unsigned char)data[2];
-  fillColor[3]=(unsigned char)data[3];
-  strokeColor[0]=(unsigned char)data[4];
-  strokeColor[1]=(unsigned char)data[5];
-  strokeColor[2]=(unsigned char)data[6];
-  strokeColor[3]=(unsigned char)data[7];
-  textColor[0]=(unsigned char)data[8];
-  textColor[1]=(unsigned char)data[9];
-  textColor[2]=(unsigned char)data[10];
-  textColor[3]=(unsigned char)data[11];
+  fillColor[0]=uchar(data[0]);
+  fillColor[1]=uchar(data[1]);
+  fillColor[2]=uchar(data[2]);
+  fillColor[3]=uchar(data[3]);
+  strokeColor[0]=uchar(data[4]);
+  strokeColor[1]=uchar(data[5]);
+  strokeColor[2]=uchar(data[6]);
+  strokeColor[3]=uchar(data[7]);
+  textColor[0]=uchar(data[8]);
+  textColor[1]=uchar(data[9]);
+  textColor[2]=uchar(data[10]);
+  textColor[3]=uchar(data[11]);
 }
 void GlSVGFeedBackBuilder::beginGlEntity(GLfloat data) {
   if(inGlEntity)
@@ -113,34 +113,34 @@ void GlSVGFeedBackBuilder::endEdge() {
   stream_out << "</g>" << endl;
 }
 void GlSVGFeedBackBuilder::pointToken(GLfloat *data) {
-  Feedback3DColor *vertex = (Feedback3DColor *)data;
+  Feedback3DColor *vertex = reinterpret_cast<Feedback3DColor *>(data);
   stream_out << "<circle cx=\"" << vertex->x
              << "\" cy=\"" << height-vertex->y
              << "\" r=\"" << pointSize
-             << "\" fill=\"rgb(" << (int)strokeColor.getR()
-             << ", " << (int)strokeColor.getG()
-             << ", " << (int)strokeColor.getB()
+             << "\" fill=\"rgb(" << int(strokeColor.getR())
+             << ", " << int(strokeColor.getG())
+             << ", " << int(strokeColor.getB())
              << ")\" fill-opacity=\"" << strokeColor.getA()/255.
-             << "\" stroke=\"rgb(" << (int)strokeColor.getR()
-             << ", " << (int)strokeColor.getG()
-             << ", " << (int)strokeColor.getB()
+             << "\" stroke=\"rgb(" << int(strokeColor.getR())
+             << ", " << int(strokeColor.getG())
+             << ", " << int(strokeColor.getB())
              << ")\" stroke-opacity=\"" << strokeColor.getA()/255.
              << "\"/>" << endl;
 }
 void GlSVGFeedBackBuilder::lineToken(GLfloat *data) {
-  Feedback3DColor *vertex1 = (Feedback3DColor *)data;
-  Feedback3DColor *vertex2 = (Feedback3DColor *)(data+7);
+  Feedback3DColor *vertex1 = reinterpret_cast<Feedback3DColor *>(data);
+  Feedback3DColor *vertex2 = reinterpret_cast<Feedback3DColor *>((data+7));
   stream_out << "<line x1=\"" << vertex1->x
              << "\" y1=\"" << height-vertex1->y
              << "\" x2=\"" << vertex2->x
              << "\" y2=\"" << height-vertex2->y
-             << "\" fill=\"rgb(" << (int)fillColor.getR()
-             << ", " << (int)fillColor.getG()
-             << ", " << (int)fillColor.getB()
+             << "\" fill=\"rgb(" << int(fillColor.getR())
+             << ", " << int(fillColor.getG())
+             << ", " << int(fillColor.getB())
              << ")\" fill-opacity=\"" << fillColor.getA()/255.
-             << "\" stroke=\"rgb(" << (int)strokeColor.getR()
-             << ", " << (int)strokeColor.getG()
-             << ", " << (int)strokeColor.getB()
+             << "\" stroke=\"rgb(" << int(strokeColor.getR())
+             << ", " << int(strokeColor.getG())
+             << ", " << int(strokeColor.getB())
              << ")\" stroke-opacity=\"" << strokeColor.getA()/255.
              << "\"/>" << endl;
 }
@@ -149,21 +149,21 @@ void GlSVGFeedBackBuilder::lineResetToken(GLfloat *data) {
 }
 void GlSVGFeedBackBuilder::polygonToken(GLfloat *data) {
   stream_out << "<polygon points=\"";
-  unsigned int nbvertices = (unsigned int)(*data);
+  unsigned int nbvertices = uint(*data);
 
   for(unsigned int i = 0; i < nbvertices; i++) {
-    Feedback3DColor *vertex = (Feedback3DColor *)(data+7*i+1);
+    Feedback3DColor *vertex = reinterpret_cast<Feedback3DColor *>(data+7*i+1);
     stream_out << ((i == 0) ? "" : " ") << vertex->x << "," << height-vertex->y;
   }
 
-  stream_out << "\" fill=\"rgb(" << (int)fillColor.getR()
-             << ", " << (int)fillColor.getG()
-             << ", " << (int)fillColor.getB()
+  stream_out << "\" fill=\"rgb(" << int(fillColor.getR())
+             << ", " << int(fillColor.getG())
+             << ", " << int(fillColor.getB())
              << ")\" fill-opacity=\"" << fillColor.getA()/255.
              << "\" stroke-opacity=\"0.0\""
-             << " stroke=\"rgb(" << (int)fillColor.getR()
-             << ", " << (int)fillColor.getG()
-             << ", " << (int)fillColor.getB()
+             << " stroke=\"rgb(" << int(fillColor.getR())
+             << ", " << int(fillColor.getG())
+             << ", " << int(fillColor.getB())
              << ")\"/>" << endl;
 }
 void GlSVGFeedBackBuilder::bitmapToken(GLfloat*) {

--- a/library/tulip-ogl/src/GlScene.cpp
+++ b/library/tulip-ogl/src/GlScene.cpp
@@ -235,15 +235,15 @@ void GlScene::draw() {
 
         bb = it->boundingBox;
         Coord middle((bb[1] + bb[0])/2.f);
-        dist=(((double)middle[0])-((double)camPos[0]))*(((double)middle[0])-((double)camPos[0]));
-        dist+=(((double)middle[1])-((double)camPos[1]))*(((double)middle[1])-((double)camPos[1]));
-        dist+=(((double)middle[2])-((double)camPos[2]))*(((double)middle[2])-((double)camPos[2]));
+        dist=(double(middle[0])-double(camPos[0]))*(double(middle[0])-double(camPos[0]));
+        dist+=(double(middle[1])-double(camPos[1]))*(double(middle[1])-double(camPos[1]));
+        dist+=(double(middle[2])-double(camPos[2]))*(double(middle[2])-double(camPos[2]));
         entitiesSet.insert(EntityWithDistance(dist,&(*it)));
       }
 
       for(multiset<EntityWithDistance,entityWithDistanceCompare>::iterator it=entitiesSet.begin(); it!=entitiesSet.end(); ++it) {
         // Simple entities
-        GlSimpleEntity *entity = (((SimpleEntityLODUnit*)(it->entity))->entity);
+        GlSimpleEntity *entity = static_cast<SimpleEntityLODUnit*>(it->entity)->entity;
         glStencilFunc(GL_LEQUAL,entity->getStencil(),0xFFFF);
         entity->draw(it->entity->lod,camera);
       }
@@ -486,7 +486,7 @@ void GlScene::computeAjustSceneToSize(int width, int height, Coord *center, Coor
       *center=Coord(0,0,0);
 
     if(sceneRadius)
-      *sceneRadius=static_cast<float>(sqrt(300.0));
+      *sceneRadius=float(sqrt(300.0));
 
     if(eye && center && sceneRadius) {
       *eye=Coord(0, 0, *sceneRadius);
@@ -525,37 +525,37 @@ void GlScene::computeAjustSceneToSize(int width, int height, Coord *center, Coor
 
   if(dx<dy) {
     if(wdx<hdy) {
-      sceneRadiusTmp=static_cast<float>(dx);
+      sceneRadiusTmp=float(dx);
 
       if(yWhiteFactor)
-        *yWhiteFactor=static_cast<float>((1.-(dy/(sceneRadiusTmp*(height/width))))/2.);
+        *yWhiteFactor=float((1.-(dy/(sceneRadiusTmp*(height/width))))/2.);
     }
     else {
       if (width < height)
-        sceneRadiusTmp=static_cast<float>(dx*wdx/hdy);
+        sceneRadiusTmp=float(dx*wdx/hdy);
       else
-        sceneRadiusTmp=static_cast<float>(dy);
+        sceneRadiusTmp=float(dy);
 
       if(xWhiteFactor) {
-        *xWhiteFactor=static_cast<float>((1.-(dx/sceneRadiusTmp))/2.);
+        *xWhiteFactor=float((1.-(dx/sceneRadiusTmp))/2.);
       }
     }
   }
   else {
     if(wdx>hdy) {
-      sceneRadiusTmp=static_cast<float>(dy);
+      sceneRadiusTmp=float(dy);
 
       if(xWhiteFactor)
-        *xWhiteFactor=static_cast<float>((1.-(dx/(sceneRadiusTmp*(width/height))))/2.);
+        *xWhiteFactor=float((1.-(dx/(sceneRadiusTmp*(width/height))))/2.);
     }
     else {
       if (height < width)
-        sceneRadiusTmp=static_cast<float>(dy*hdy/wdx);
+        sceneRadiusTmp=float(dy*hdy/wdx);
       else
-        sceneRadiusTmp=static_cast<float>(dx);
+        sceneRadiusTmp=float(dx);
 
       if(yWhiteFactor)
-        *yWhiteFactor=static_cast<float>((1.-(dy/sceneRadiusTmp))/2.);
+        *yWhiteFactor=float((1.-(dy/sceneRadiusTmp))/2.);
     }
   }
 
@@ -610,8 +610,8 @@ void GlScene::zoomXY(int step, const int x, const int y) {
 
   if (step < 0) step *= -1;
 
-  int factX = (int)(step*(double(viewport[2])/2.0-x)/ 7.0);
-  int factY = (int)(step*(double(viewport[3])/2.0-y)/ 7.0);
+  int factX = int(step*(double(viewport[2])/2.0-x)/ 7.0);
+  int factY = int(step*(double(viewport[3])/2.0-y)/ 7.0);
   translateCamera(factX,-factY,0);
 }
 
@@ -628,7 +628,7 @@ void GlScene::translateCamera(const int x, const int y, const int z) {
   for(vector<pair<string, GlLayer *> >::iterator it=layersList.begin(); it!=layersList.end(); ++it) {
     if(it->second->getCamera().is3D() && (!it->second->useSharedCamera())) {
       Coord v1(0, 0, 0);
-      Coord v2(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+      Coord v2(x, y, z);
       v1 = it->second->getCamera().viewportTo3DWorld(v1);
       v2 = it->second->getCamera().viewportTo3DWorld(v2);
       Coord move = v2 - v1;
@@ -657,9 +657,9 @@ void GlScene::zoomFactor(float factor) {
 void GlScene::rotateScene(const int x, const int y, const int z) {
   for(vector<pair<string, GlLayer *> >::iterator it=layersList.begin(); it!=layersList.end(); ++it) {
     if(it->second->getCamera().is3D() && (!it->second->useSharedCamera())) {
-      it->second->getCamera().rotate(static_cast<float>(x/360.0 * M_PI), 1.0f, 0, 0);
-      it->second->getCamera().rotate(static_cast<float>(y/360.0 * M_PI), 0, 1.0f, 0);
-      it->second->getCamera().rotate(static_cast<float>(z/360.0 * M_PI), 0, 0, 1.0f);
+      it->second->getCamera().rotate(float(x/360.0 * M_PI), 1.0f, 0, 0);
+      it->second->getCamera().rotate(float(y/360.0 * M_PI), 0, 1.0f, 0);
+      it->second->getCamera().rotate(float(z/360.0 * M_PI), 0, 0, 1.0f);
     }
   }
 }
@@ -735,7 +735,7 @@ bool GlScene::selectEntities(RenderingEntitiesFlag type,int x, int y, int w, int
 
   GlLODCalculator *selectLODCalculator= layerInScene?lodCalculator:lodCalculator->clone();
 
-  selectLODCalculator->setRenderingEntitiesFlag((RenderingEntitiesFlag)(RenderingAll | RenderingWithoutRemove));
+  selectLODCalculator->setRenderingEntitiesFlag(static_cast<RenderingEntitiesFlag>(RenderingAll | RenderingWithoutRemove));
   selectLODCalculator->clear();
 
   //Collect entities if needed
@@ -783,7 +783,7 @@ bool GlScene::selectEntities(RenderingEntitiesFlag type,int x, int y, int w, int
 
     //Allocate memory to store the result of the selection
     GLuint (*selectBuf)[4] = new GLuint[size][4];
-    glSelectBuffer(size*4 , (GLuint *)selectBuf);
+    glSelectBuffer(size*4 , reinterpret_cast<GLuint *>(selectBuf));
     //Activate Open Gl Selection mode
     glRenderMode(GL_SELECT);
     glInitNames();
@@ -796,7 +796,7 @@ bool GlScene::selectEntities(RenderingEntitiesFlag type,int x, int y, int w, int
     glLoadIdentity();
     int newX = x + w/2;
     int newY = viewport[3] - (y + h/2);
-    pickMatrix(newX, newY, w, h, (GLint *)&viewport);
+    pickMatrix(newX, newY, w, h, reinterpret_cast<GLint *>(&viewport));
 
     camera->initProjection(false);
 
@@ -879,7 +879,7 @@ void GlScene::outputSVG(unsigned int size,const string& filename) {
   GLfloat clearColor[4];
   GLfloat lineWidth;
   GLfloat pointSize;
-  GLfloat* buffer = (GLfloat *)calloc(size, sizeof(GLfloat));
+  GLfloat* buffer = static_cast<GLfloat *>(calloc(size, sizeof(GLfloat)));
   glFeedbackBuffer(size, GL_3D_COLOR, buffer);
   glRenderMode(GL_FEEDBACK);
   glGraphComposite->getInputData()->parameters->setFeedbackRender(true);
@@ -929,7 +929,7 @@ void GlScene::outputEPS(unsigned int size,const string& filename) {
   GLfloat clearColor[4];
   GLfloat lineWidth;
   GLfloat pointSize;
-  GLfloat* buffer = (GLfloat *)calloc(size, sizeof(GLfloat));
+  GLfloat* buffer = static_cast<GLfloat *>(calloc(size, sizeof(GLfloat)));
   glFeedbackBuffer(size, GL_3D_COLOR, buffer);
   glRenderMode(GL_FEEDBACK);
   glGraphComposite->getInputData()->parameters->setFeedbackRender(true);
@@ -972,7 +972,7 @@ void GlScene::outputEPS(unsigned int size,const string& filename) {
 }
 //====================================================
 unsigned char * GlScene::getImage() {
-  unsigned char *image = (unsigned char *)malloc(viewport[2]*viewport[3]*3*sizeof(unsigned char));
+  unsigned char *image = static_cast<unsigned char *>(malloc(viewport[2]*viewport[3]*3*sizeof(unsigned char)));
   draw();
   glFlush();
   glFinish();

--- a/library/tulip-ogl/src/GlSceneZoomAndPan.cpp
+++ b/library/tulip-ogl/src/GlSceneZoomAndPan.cpp
@@ -43,7 +43,7 @@ GlSceneZoomAndPan::GlSceneZoomAndPan(GlScene *glScene, const BoundingBox &boundi
   zoomAreaWidth = boundingBox[1][0] - boundingBox[0][0];
   zoomAreaHeight = boundingBox[1][1] - boundingBox[0][1];
 
-  float aspectRatio = viewport[2] / static_cast<float>(viewport[3]);
+  float aspectRatio = viewport[2] / float(viewport[3]);
 
   if (zoomAreaWidth > (aspectRatio * zoomAreaHeight)) {
     w0 = sceneBB[1][0] - sceneBB[0][0];
@@ -98,7 +98,7 @@ void GlSceneZoomAndPan::setAdditionalGlSceneAnimation(AdditionalGlSceneAnimation
 
 void GlSceneZoomAndPan::zoomAndPanAnimationStep(int animationStep) {
   if (doZoomAndPan) {
-    double t = (double) animationStep / (double) nbAnimationSteps;
+    double t = animationStep / double(nbAnimationSteps);
     double s = t * S;
     double u = 0, w = 0, f = 0;
 
@@ -136,7 +136,7 @@ void GlSceneZoomAndPan::zoomAndPanAnimationStep(int animationStep) {
       }
     }
 
-    camera.setCenter(camCenterStart + (camCenterEnd - camCenterStart) * static_cast<float>(f));
+    camera.setCenter(camCenterStart + (camCenterEnd - camCenterStart) * float(f));
     camera.setEyes(Coord(0, 0, camera.getSceneRadius()));
     camera.setEyes(camera.getEyes() + camera.getCenter());
     camera.setUp(Coord(0, 1., 0));
@@ -147,7 +147,7 @@ void GlSceneZoomAndPan::zoomAndPanAnimationStep(int animationStep) {
     float bbHeightViewport = abs(bbViewportSecond.getY() - bbViewportFirst.getY());
     double newZoomFactor = 0.0;
 
-    float aspectRatio = viewport[2] / static_cast<float>(viewport[3]);
+    float aspectRatio = viewport[2] / float(viewport[3]);
 
     if (zoomAreaWidth > (zoomAreaHeight * aspectRatio)) {
       newZoomFactor = viewport[2] / bbWidthViewport;

--- a/library/tulip-ogl/src/GlShaderProgram.cpp
+++ b/library/tulip-ogl/src/GlShaderProgram.cpp
@@ -69,12 +69,12 @@ static void readShaderSourceFile(const string &vertexShaderSourceFilePath, char 
   }
 
   ifs->seekg (0, ios::end);
-  unsigned int length = static_cast<unsigned int>(ifs->tellg());
+  unsigned int length = uint(ifs->tellg());
   ifs->seekg (0, ios::beg);
 
   *shader = new char[length+1];
 
-  ifs->read ((char *)*shader,length);
+  ifs->read (*shader,length);
   (*shader)[length] = '\0';
   delete ifs;
 }
@@ -121,7 +121,7 @@ void GlShader::compileFromSourceFile(const std::string &shaderSrcFilename) {
 }
 
 void GlShader::compileShaderObject(const char *shaderSrc) {
-  glShaderSource(shaderObjectId, 1,(const char **) &shaderSrc, NULL);
+  glShaderSource(shaderObjectId, 1, &shaderSrc, NULL);
   glCompileShader(shaderObjectId);
   GLint compileStatus;
   glGetShaderiv(shaderObjectId, GL_COMPILE_STATUS, &compileStatus);
@@ -304,7 +304,7 @@ void GlShaderProgram::setUniformFloat(const std::string &variableName, const flo
 }
 
 void GlShaderProgram::setUniformVec2Float(const std::string &variableName, const Vector<float, 2> &vec2f) {
-  setUniformVec2FloatArray(variableName, 1, (float *) &vec2f);
+  setUniformVec2FloatArray(variableName, 1, reinterpret_cast<const float *>(&vec2f));
 }
 
 void GlShaderProgram::setUniformVec2Float(const std::string &variableName, const float f1, const float f2) {
@@ -313,7 +313,7 @@ void GlShaderProgram::setUniformVec2Float(const std::string &variableName, const
 }
 
 void GlShaderProgram::setUniformVec3Float(const std::string &variableName, const Vector<float, 3> &vec3f) {
-  setUniformVec3FloatArray(variableName, 1, (float *) &vec3f);
+  setUniformVec3FloatArray(variableName, 1, reinterpret_cast<const float *>(&vec3f));
 }
 
 void GlShaderProgram::setUniformVec3Float(const std::string &variableName, const float f1, const float f2, const float f3) {
@@ -322,7 +322,7 @@ void GlShaderProgram::setUniformVec3Float(const std::string &variableName, const
 }
 
 void GlShaderProgram::setUniformVec4Float(const std::string &variableName, const Vector<float, 4> &vec4f) {
-  setUniformVec4FloatArray(variableName, 1, (float *) &vec4f);
+  setUniformVec4FloatArray(variableName, 1, reinterpret_cast<const float *>(&vec4f));
 }
 
 void GlShaderProgram::setUniformVec4Float(const std::string &variableName, const float f1, const float f2, const float f3, const float f4) {
@@ -379,7 +379,7 @@ void GlShaderProgram::setUniformInt(const std::string &variableName, const int i
 }
 
 void GlShaderProgram::setUniformVec2Int(const std::string &variableName, const Vector<int, 2> &vec2i) {
-  setUniformVec2IntArray(variableName, 1, (int *) &vec2i);
+  setUniformVec2IntArray(variableName, 1, reinterpret_cast<const int *>(&vec2i));
 }
 
 void GlShaderProgram::setUniformVec2Int(const std::string &variableName, const int i1, const int i2) {
@@ -388,7 +388,7 @@ void GlShaderProgram::setUniformVec2Int(const std::string &variableName, const i
 }
 
 void GlShaderProgram::setUniformVec3Int(const std::string &variableName, const Vector<int, 3> &vec3i) {
-  setUniformVec3IntArray(variableName, 1, (int *) &vec3i);
+  setUniformVec3IntArray(variableName, 1, reinterpret_cast<const int* >(&vec3i));
 }
 
 void GlShaderProgram::setUniformVec3Int(const std::string &variableName, const int i1, const int i2, const int i3) {
@@ -397,7 +397,7 @@ void GlShaderProgram::setUniformVec3Int(const std::string &variableName, const i
 }
 
 void GlShaderProgram::setUniformVec4Int(const std::string &variableName, const Vector<int, 4> &vec4i) {
-  setUniformVec4IntArray(variableName, 1, (int *) &vec4i);
+  setUniformVec4IntArray(variableName, 1, reinterpret_cast<const int *>(&vec4i));
 }
 
 void GlShaderProgram::setUniformVec4Int(const std::string &variableName, const int i1, const int i2, const int i3, const int i4) {
@@ -411,7 +411,7 @@ void GlShaderProgram::setUniformBool(const std::string &variableName, const bool
 }
 
 void GlShaderProgram::setUniformVec2Bool(const std::string &variableName, const Array<bool, 2> &vec2b) {
-  setUniformVec2IntArray(variableName, 1, (int *) &vec2b);
+  setUniformVec2IntArray(variableName, 1, reinterpret_cast<const int *>(&vec2b));
 }
 
 void GlShaderProgram::setUniformVec2Bool(const std::string &variableName, const bool b1, const bool b2) {
@@ -420,7 +420,7 @@ void GlShaderProgram::setUniformVec2Bool(const std::string &variableName, const 
 }
 
 void GlShaderProgram::setUniformVec3Bool(const std::string &variableName, const Array<bool, 3> &vec3b) {
-  setUniformVec3IntArray(variableName, 1, (int *) &vec3b);
+  setUniformVec3IntArray(variableName, 1, reinterpret_cast<const int *>(&vec3b));
 }
 
 void GlShaderProgram::setUniformVec3Bool(const std::string &variableName, const bool b1, const bool b2, const bool b3) {
@@ -429,7 +429,7 @@ void GlShaderProgram::setUniformVec3Bool(const std::string &variableName, const 
 }
 
 void GlShaderProgram::setUniformVec4Bool(const std::string &variableName, const Array<bool, 4> &vec4b) {
-  setUniformVec4IntArray(variableName, 1, (int *) &vec4b);
+  setUniformVec4IntArray(variableName, 1, reinterpret_cast<const int *>(&vec4b));
 }
 
 void GlShaderProgram::setUniformVec4Bool(const std::string &variableName, const bool b1, const bool b2, const bool b3, const bool b4) {
@@ -552,7 +552,7 @@ void GlShaderProgram::setAttributeColor(const std::string &variableName, const C
 
 template <unsigned int SIZE>
 void GlShaderProgram::setUniformFloatArray(const std::string &variableName, const Vector<float, SIZE> &vecf) {
-  setUniformFloatArray(variableName, SIZE, (float *)vecf);
+  setUniformFloatArray(variableName, SIZE, reinterpret_cast<const float *>(vecf));
 }
 
 void GlShaderProgram::setUniformFloatArray(const std::string &variableName, const unsigned int fCount, const float *f) {
@@ -665,12 +665,12 @@ void GlShaderProgram::setUniformMat4FloatArray(const std::string &variableName, 
 
 template <unsigned int SIZE>
 void GlShaderProgram::setUniformIntArray(const std::string &variableName, const Vector<int, SIZE> &veci) {
-  setUniformIntArray(variableName, SIZE, (int *)&veci);
+  setUniformIntArray(variableName, SIZE, reinterpret_cast<const int *>(&veci));
 }
 
 void GlShaderProgram::setUniformIntArray(const std::string &variableName, const unsigned int iCount, const int *i) {
   GLint loc = getUniformVariableLocation(variableName);
-  glUniform1iv(loc, iCount, (const GLint*)i);
+  glUniform1iv(loc, iCount, static_cast<const GLint*>(i));
 }
 
 template <unsigned int SIZE>
@@ -682,7 +682,7 @@ void GlShaderProgram::setUniformVec2IntArray(const std::string &variableName, co
 
 void GlShaderProgram::setUniformVec2IntArray(const std::string &variableName, const unsigned int vec2iCount, const int *i) {
   GLint loc = getUniformVariableLocation(variableName);
-  glUniform2iv(loc, vec2iCount,(const GLint*)i);
+  glUniform2iv(loc, vec2iCount, static_cast<const GLint*>(i));
 }
 
 template <unsigned int SIZE>
@@ -694,7 +694,7 @@ void GlShaderProgram::setUniformVec3IntArray(const std::string &variableName, co
 
 void GlShaderProgram::setUniformVec3IntArray(const std::string &variableName, const unsigned int vec3iCount, const int *i) {
   GLint loc = getUniformVariableLocation(variableName);
-  glUniform3iv(loc, vec3iCount, (const GLint*)i);
+  glUniform3iv(loc, vec3iCount, static_cast<const GLint*>(i));
 }
 
 template <unsigned int SIZE>
@@ -706,50 +706,50 @@ void GlShaderProgram::setUniformVec4IntArray(const std::string &variableName, co
 
 void GlShaderProgram::setUniformVec4IntArray(const std::string &variableName, const unsigned int vec4iCount, const int *i) {
   GLint loc = getUniformVariableLocation(variableName);
-  glUniform4iv(loc, vec4iCount, (const GLint*)i);
+  glUniform4iv(loc, vec4iCount, static_cast<const GLint*>(i));
 }
 
 
 template <unsigned int SIZE>
 void GlShaderProgram::setUniformBoolArray(const std::string &variableName, const Array<bool, SIZE> &vecb) {
-  setUniformIntArray(variableName, SIZE, (int *) &vecb);
+  setUniformIntArray(variableName, SIZE, reinterpret_cast<const int *>(&vecb));
 }
 
 void GlShaderProgram::setUniformBoolArray(const std::string &variableName, const unsigned int bCount, const bool *b) {
-  setUniformIntArray(variableName, bCount, (int *) b);
+  setUniformIntArray(variableName, bCount, reinterpret_cast<const int *>(b));
 }
 
 template <unsigned int SIZE>
 void GlShaderProgram::setUniformVec2BoolArray(const std::string &variableName, const Array<Array<bool, 2>, SIZE> &vecvec2b) {
   bool *vvData = getVectorOfVectorData(vecvec2b);
-  setUniformVec2IntArray(variableName, SIZE, (int *) vvData);
+  setUniformVec2IntArray(variableName, SIZE, reinterpret_cast<const int *>(vvData));
   delete [] vvData;
 }
 
 void GlShaderProgram::setUniformVec2BoolArray(const std::string &variableName, const unsigned int vec2bCount, const bool *b) {
-  setUniformVec2IntArray(variableName, vec2bCount, (int *) b);
+  setUniformVec2IntArray(variableName, vec2bCount, reinterpret_cast<const int *>(b));
 }
 
 template <unsigned int SIZE>
 void GlShaderProgram::setUniformVec3BoolArray(const std::string &variableName, const Array<Array<bool, 3>, SIZE> &vecvec3b) {
   bool *vvData = getVectorOfVectorData(vecvec3b);
-  setUniformVec3IntArray(variableName, SIZE, (int *) vvData);
+  setUniformVec3IntArray(variableName, SIZE, reinterpret_cast<const int *>(vvData));
   delete [] vvData;
 }
 
 void GlShaderProgram::setUniformVec3BoolArray(const std::string &variableName, const unsigned int vec3bCount, const bool *b) {
-  setUniformVec3IntArray(variableName, vec3bCount, (int *) b);
+  setUniformVec3IntArray(variableName, vec3bCount, reinterpret_cast<const int *>(b));
 }
 
 template <unsigned int SIZE>
 void GlShaderProgram::setUniformVec4BoolArray(const std::string &variableName, const Array<Array<bool, 4>, SIZE> &vecvec4b) {
   bool *vvData = getVectorOfVectorData(vecvec4b);
-  setUniformVec4IntArray(variableName, SIZE, (int *) vvData);
+  setUniformVec4IntArray(variableName, SIZE, reinterpret_cast<const int *>(vvData));
   delete [] vvData;
 }
 
 void GlShaderProgram::setUniformVec4BoolArray(const std::string &variableName, const unsigned int vec4bCount, const bool *b) {
-  setUniformVec4IntArray(variableName, vec4bCount, (int *) b);
+  setUniformVec4IntArray(variableName, vec4bCount, reinterpret_cast<const int *>(b));
 }
 
 void GlShaderProgram::getUniformFloatVariableValue(const std::string &variableName, float *value) {
@@ -759,7 +759,7 @@ void GlShaderProgram::getUniformFloatVariableValue(const std::string &variableNa
 
 void GlShaderProgram::getUniformIntVariableValue(const std::string &variableName, int *value) {
   GLint loc = getUniformVariableLocation(variableName);
-  glGetUniformiv(programObjectId, loc, (GLint *)value);
+  glGetUniformiv(programObjectId, loc, static_cast<GLint *>(value));
 }
 
 void GlShaderProgram::getUniformBoolVariableValue(const std::string &variableName, bool *value) {

--- a/library/tulip-ogl/src/GlStar.cpp
+++ b/library/tulip-ogl/src/GlStar.cpp
@@ -56,7 +56,7 @@ void GlStar::computeStar() {
 
   BoundingBox box;
   vector<Coord> points;
-  float delta = (2.0f * M_PI) / (float)numberOfStarPoints;
+  float delta = float(2.0 * M_PI / numberOfStarPoints);
 
   for (unsigned int i=0; i < numberOfStarPoints; ++i) {
     float deltaX = cos(i * delta + startAngle);

--- a/library/tulip-ogl/src/GlTLPFeedBackBuilder.cpp
+++ b/library/tulip-ogl/src/GlTLPFeedBackBuilder.cpp
@@ -23,7 +23,7 @@ namespace tlp {
 void GlTLPFeedBackBuilder::passThroughToken(GLfloat *data) {
   if(!needData) {
 
-    switch ((int)(*data)) {
+    switch (int(*data)) {
 
     case TLP_FB_COLOR_INFO :
       inColorInfo=true;

--- a/library/tulip-ogl/src/GlTextureManager.cpp
+++ b/library/tulip-ogl/src/GlTextureManager.cpp
@@ -161,6 +161,10 @@ static bool loadBMP(const string &filename, TextureInfo *texture) {
   return true;
 }
 //====================================================================
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 static bool loadJPEG(const string &filename, TextureInfo *texture) {
   FILE *file;
 #ifndef _MSC_VER
@@ -208,7 +212,7 @@ static bool loadJPEG(const string &filename, TextureInfo *texture) {
 
   while (cinfo.output_scanline < cinfo.output_height) {
     jpeg_read_scanlines(&cinfo, &row_pointer, 1);
-    memcpy((void *) &(texture->data[(cinfo.output_height - cinfo.output_scanline) * 3 * cinfo.output_width]), row_pointer, (texture->width) * 3);
+    memcpy(&(texture->data[(cinfo.output_height - cinfo.output_scanline) * 3 * cinfo.output_width]), row_pointer, (texture->width) * 3);
   }
 
   delete [] row_pointer;
@@ -217,6 +221,9 @@ static bool loadJPEG(const string &filename, TextureInfo *texture) {
   fclose(file);
   return true;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 //====================================================================
 static bool loadPNG(const string &filename, TextureInfo *texture) {
   FILE *file;
@@ -243,7 +250,7 @@ static bool loadPNG(const string &filename, TextureInfo *texture) {
 
   if (!info_ptr) {
     tlp::error() << "Error reading file: " << filename << std::endl;
-    png_destroy_read_struct(&png_ptr, (png_infopp)NULL, (png_infopp)NULL);
+    png_destroy_read_struct(&png_ptr, static_cast<png_infopp>(NULL), static_cast<png_infopp>(NULL));
     fclose(file);
     return false;
   }
@@ -252,7 +259,7 @@ static bool loadPNG(const string &filename, TextureInfo *texture) {
 
   if (!end_info) {
     tlp::error() << "Error reading file: " << filename << std::endl;
-    png_destroy_read_struct(&png_ptr, &info_ptr,  (png_infopp)NULL);
+    png_destroy_read_struct(&png_ptr, &info_ptr,  static_cast<png_infopp>(NULL));
     fclose(file);
     return false;
   }
@@ -285,7 +292,7 @@ static bool loadPNG(const string &filename, TextureInfo *texture) {
   png_bytep* row_pointers = new png_bytep[texture->height];
 
   for (unsigned int i=0; i < texture->height; ++i)
-    row_pointers[i] = (png_bytep) &(texture->data[linestride*(texture->height-1-i)]);
+    row_pointers[i] = static_cast<png_bytep>(&(texture->data[linestride*(texture->height-1-i)]));
 
   png_set_strip_16(png_ptr);  //force 8 bits/channel
   png_set_gray_to_rgb(png_ptr); //force RGB
@@ -436,8 +443,8 @@ bool GlTextureLoader::loadTexture(const string& filename,
                                   GlTexture &texture) {
   string extension = filename.substr(filename.find_last_of('.') + 1);
 
-  for (int i=0; i < (int)extension.length(); ++i)
-    extension[i] = (char) toupper(extension[i]);
+  for (unsigned int i=0; i < extension.length(); ++i)
+    extension[i] = static_cast<char>(toupper(extension[i]));
 
   TextureLoader_t *loader = NULL;
 

--- a/library/tulip-ogl/src/GlTools.cpp
+++ b/library/tulip-ogl/src/GlTools.cpp
@@ -151,7 +151,7 @@ void glTest(const string &message) {
 }
 //====================================================
 void setColor(const Color &c) {
-  glColor4ubv((unsigned char *) &c);
+  glColor4ubv(reinterpret_cast<const unsigned char *>(&c));
 }
 //====================================================
 void setColor(GLfloat *c) {
@@ -160,10 +160,10 @@ void setColor(GLfloat *c) {
 //====================================================
 void setMaterial(const Color &c) {
   float colorMat[4];
-  colorMat[0] = ((float)c[0])/255.0;
-  colorMat[1] = ((float)c[1])/255.0;
-  colorMat[2] = ((float)c[2])/255.0;
-  colorMat[3] = ((float)c[3])/255.0;
+  colorMat[0] = c[0]/255.f;
+  colorMat[1] = c[1]/255.f;
+  colorMat[2] = c[2]/255.f;
+  colorMat[3] = c[3]/255.f;
   setColor(c);
   glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, colorMat);
 }
@@ -349,7 +349,7 @@ float calculateAABBSize(const BoundingBox& bb,const Coord& eye,const Matrix<floa
     return -1;
 
   for(int i=0; i<num; i++) {
-    dst[i] = projectPoint(src[(int)hullVertexTable[pos][i+1]],transformMatrix,globalViewport);
+    dst[i] = projectPoint(src[int(hullVertexTable[pos][i+1])],transformMatrix,globalViewport);
     dst[i][1] = globalViewport[1] + globalViewport[3] - (dst[i][1] - globalViewport[1]);
   }
 

--- a/library/tulip-ogl/src/GlVertexArrayManager.cpp
+++ b/library/tulip-ogl/src/GlVertexArrayManager.cpp
@@ -834,7 +834,7 @@ void GlVertexArrayManager::activateQuadEdgeDisplay(GlEdge *edge, bool selected) 
   unsigned int bottomOutlineIndicesIdx = edgeToBottomOulineIndexVector[edge->id];
   unsigned int topOutlineIndicesIdx = edgeToTopOutlineIndexVector[edge->id];
 
-  float borderWidth = static_cast<float>(inputData->getElementBorderWidth()->getEdgeValue(tlp::edge(edge->id)));
+  float borderWidth = float(inputData->getElementBorderWidth()->getEdgeValue(tlp::edge(edge->id)));
 
   if(numberOfVertices==0)
     return;
@@ -905,7 +905,7 @@ void GlVertexArrayManager::activateQuadEdgeDisplay(GlEdge *edge, bool selected) 
 void GlVertexArrayManager::activatePointEdgeDisplay(GlEdge *edge,bool selected) {
   unsigned int index=edgeToPointIndexVector[edge->id];
 
-  if(index==(unsigned int)(-1))
+  if(index==uint(-1))
     return;
 
   if(!selected) {
@@ -919,7 +919,7 @@ void GlVertexArrayManager::activatePointEdgeDisplay(GlEdge *edge,bool selected) 
 void GlVertexArrayManager::activatePointNodeDisplay(GlNode *node, bool selected) {
   unsigned int index=nodeToPointIndexVector[node->id];
 
-  if(index==(unsigned int)(-1))
+  if(index==uint(-1))
     return;
 
   if(!selected) {

--- a/library/tulip-ogl/src/Glyph.cpp
+++ b/library/tulip-ogl/src/Glyph.cpp
@@ -25,8 +25,7 @@ using namespace std;
 
 Glyph::Glyph(const tlp::PluginContext* context) : glGraphInputData(NULL) {
   if(context != NULL) {
-    const GlyphContext* glyphContext = dynamic_cast<const GlyphContext*>(context);
-    assert(glyphContext != NULL);
+    const GlyphContext* glyphContext = static_cast<const GlyphContext*>(context);
     glGraphInputData = glyphContext->glGraphInputData;
   }
 }

--- a/library/tulip-python/bindings/stl/std_list.sip
+++ b/library/tulip-python/bindings/stl/std_list.sip
@@ -94,7 +94,7 @@ template<TYPE *>
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
     int state;
     PyObject *item = PyList_GET_ITEM(sipPy, i);
-    TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(item, kpTypeDef, NULL, SIP_NOT_NONE, &state, sipIsErr));
+    TYPE* p = static_cast<TYPE*>(sipConvertToType(item, kpTypeDef, NULL, SIP_NOT_NONE, &state, sipIsErr));
     
     if (*sipIsErr) {
       sipReleaseType(p, kpTypeDef, state);
@@ -181,7 +181,7 @@ template<TYPE>
   std::list<TYPE> *l = new std::list<TYPE>();
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
     int state;
-    TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(PyList_GET_ITEM(sipPy, i), kpTypeDef, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    TYPE* p = static_cast<TYPE*>(sipConvertToType(PyList_GET_ITEM(sipPy, i), kpTypeDef, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
     
     if (*sipIsErr) {
       sipReleaseType(p, kpTypeDef, state);
@@ -306,7 +306,7 @@ template<TYPE>
   std::list<float> *v = new std::list<float>();
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
     PyObject *f = PyNumber_Float(PyList_GET_ITEM(sipPy, i));
-    v->push_back(static_cast<float>(PyFloat_AsDouble(f)));
+    v->push_back(float(PyFloat_AsDouble(f)));
     Py_XDECREF(f);
   }
 
@@ -369,13 +369,13 @@ template<TYPE>
     std::list<int> *v = new std::list<int>();
     for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
 #if PY_MAJOR_VERSION >= 3
-      v->push_back(static_cast<int>(PyLong_AsLong(PyList_GET_ITEM(sipPy, i))));
+      v->push_back(int(PyLong_AsLong(PyList_GET_ITEM(sipPy, i))));
 #else
       PyObject *item = PyList_GET_ITEM(sipPy, i);
       if (PyLong_Check(item)) {
-        v->push_back(static_cast<int>(PyLong_AsLong(item)));
+        v->push_back(int(PyLong_AsLong(item)));
       } else {
-        v->push_back(static_cast<int>(PyInt_AsLong(item)));
+        v->push_back(int(PyInt_AsLong(item)));
       }
 #endif
     }
@@ -439,13 +439,13 @@ template<TYPE>
     std::list<unsigned int> *v = new std::list<unsigned int>();
     for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
 #if PY_MAJOR_VERSION >= 3
-      v->push_back(static_cast<unsigned int>(PyLong_AsUnsignedLong(PyList_GET_ITEM(sipPy, i))));
+      v->push_back(uint(PyLong_AsUnsignedLong(PyList_GET_ITEM(sipPy, i))));
 #else
       PyObject *item = PyList_GET_ITEM(sipPy, i);
       if (PyLong_Check(item)) {
-        v->push_back(static_cast<unsigned int>(PyLong_AsUnsignedLong(item)));
+        v->push_back(uint(PyLong_AsUnsignedLong(item)));
       } else {
-        v->push_back(static_cast<unsigned int>(PyInt_AsUnsignedLongMask(item)));
+        v->push_back(uint(PyInt_AsUnsignedLongMask(item)));
       }
 #endif
     }

--- a/library/tulip-python/bindings/stl/std_map.sip
+++ b/library/tulip-python/bindings/stl/std_map.sip
@@ -67,8 +67,8 @@ template<T1, T2>
     int t1State = 0;
     int t2State = 0;
     
-    T1 *t1 = reinterpret_cast<T1 *>(sipConvertToType(key, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
-    T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(val, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
+    T1 *t1 = static_cast<T1 *>(sipConvertToType(key, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
+    T2 *t2 = static_cast<T2 *>(sipConvertToType(val, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
     
     if (*sipIsErr) {
       delete map;
@@ -185,8 +185,8 @@ template<T1, T2>
     int t1State = 0;
     int t2State = 0;
     
-    T1 *t1 = reinterpret_cast<T1 *>(sipConvertToType(key, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
-    T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(val, kpTypeDef2, NULL, SIP_NOT_NONE, &t2State, sipIsErr));
+    T1 *t1 = static_cast<T1 *>(sipConvertToType(key, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
+    T2 *t2 = static_cast<T2 *>(sipConvertToType(val, kpTypeDef2, NULL, SIP_NOT_NONE, &t2State, sipIsErr));
     
     if (*sipIsErr) {
       delete map;
@@ -299,7 +299,7 @@ template<T2>
     int t2State = 0;
     
     float t1 = PyFloat_AsDouble(key);
-    T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(val, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
+    T2 *t2 = static_cast<T2 *>(sipConvertToType(val, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
     
     if (*sipIsErr) {
       delete map;		

--- a/library/tulip-python/bindings/stl/std_pair.sip
+++ b/library/tulip-python/bindings/stl/std_pair.sip
@@ -68,8 +68,8 @@ template<T1, T2>
   int t1State = 0;
   int t2State = 0;
 
-  T1 *t1 = reinterpret_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
-  T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
+  T1 *t1 = static_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
+  T2 *t2 = static_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
 
   if (*sipIsErr) {
     sipReleaseType(t1, kpTypeDef1, t1State);
@@ -185,8 +185,8 @@ template<T1*, T2*>
   int t1State = 0;
   int t2State = 0;
 
-  T1 *t1 = reinterpret_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, NULL, SIP_NOT_NONE, &t1State, sipIsErr));
-  T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, NULL, SIP_NOT_NONE, &t2State, sipIsErr));
+  T1 *t1 = static_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, NULL, SIP_NOT_NONE, &t1State, sipIsErr));
+  T2 *t2 = static_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, NULL, SIP_NOT_NONE, &t2State, sipIsErr));
 
   if (*sipIsErr) {
     sipReleaseType(t1, kpTypeDef1, t1State);
@@ -300,8 +300,8 @@ template<T1*, T2>
   int t1State = 0;
   int t2State = 0;
 
-  T1 *t1 = reinterpret_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, NULL, SIP_NOT_NONE, &t1State, sipIsErr));
-  T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
+  T1 *t1 = static_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, NULL, SIP_NOT_NONE, &t1State, sipIsErr));
+  T2 *t2 = static_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, sipTransferObj, SIP_NOT_NONE, &t2State, sipIsErr));
 
   if (*sipIsErr) {
     sipReleaseType(t1, kpTypeDef1, t1State);
@@ -415,8 +415,8 @@ template<T1, T2*>
   int t1State = 0;
   int t2State = 0;
 
-  T1 *t1 = reinterpret_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
-  T2 *t2 = reinterpret_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, NULL, SIP_NOT_NONE, &t2State, sipIsErr));
+  T1 *t1 = static_cast<T1 *>(sipConvertToType(itm1, kpTypeDef1, sipTransferObj, SIP_NOT_NONE, &t1State, sipIsErr));
+  T2 *t2 = static_cast<T2 *>(sipConvertToType(itm2, kpTypeDef2, NULL, SIP_NOT_NONE, &t2State, sipIsErr));
 
   if (*sipIsErr) {
     sipReleaseType(t1, kpTypeDef1, t1State);

--- a/library/tulip-python/bindings/stl/std_set.sip
+++ b/library/tulip-python/bindings/stl/std_set.sip
@@ -101,7 +101,7 @@ template<TYPE>
   PyObject *item = NULL;
   while (item = PyIter_Next(iterator)) {
     int state;
-    TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(item, kpTypeDef, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    TYPE* p = static_cast<TYPE*>(sipConvertToType(item, kpTypeDef, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr) {
       Py_DECREF(item);
@@ -199,7 +199,7 @@ template<TYPE*>
   PyObject *item = NULL;
   while (item = PyIter_Next(iterator)) {
     int state;
-    TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(item, kpTypeDef, NULL, SIP_NOT_NONE, &state, sipIsErr));
+    TYPE* p = static_cast<TYPE*>(sipConvertToType(item, kpTypeDef, NULL, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr) {
       Py_DECREF(item);
@@ -338,7 +338,7 @@ template<TYPE*>
   PyObject *item = NULL;
   while (item = PyIter_Next(iterator)) {
     PyObject *f = PyNumber_Float(item);
-    s->insert(static_cast<float>(PyFloat_AsDouble(f)));
+    s->insert(float(PyFloat_AsDouble(f)));
     Py_XDECREF(f);
     Py_DECREF(item);
   }
@@ -406,12 +406,12 @@ template<TYPE*>
   PyObject *item = NULL;
   while (item = PyIter_Next(iterator)) {
 #if PY_MAJOR_VERSION >= 3
-    s->insert(static_cast<int>(PyLong_AsLong(item)));
+    s->insert(int(PyLong_AsLong(item)));
 #else
     if (PyLong_Check(item)) {
-      s->insert(static_cast<int>(PyLong_AsLong(item)));
+      s->insert(int(PyLong_AsLong(item)));
     } else {
-      s->insert(static_cast<int>(PyInt_AsLong(item)));
+      s->insert(int(PyInt_AsLong(item)));
     }
 #endif
     Py_DECREF(item);
@@ -554,12 +554,12 @@ template<TYPE*>
   PyObject *item = NULL;
   while (item = PyIter_Next(iterator)) {
 #if PY_MAJOR_VERSION >= 3
-    s->insert(static_cast<unsigned int>(PyLong_AsUnsignedLong(item)));
+    s->insert(uint(PyLong_AsUnsignedLong(item)));
 #else
     if (PyLong_Check(item)) {
-      s->insert(static_cast<unsigned int>(PyLong_AsUnsignedLong(item)));
+      s->insert(uint(PyLong_AsUnsignedLong(item)));
     } else {
-      s->insert(static_cast<unsigned int>(PyInt_AsUnsignedLongMask(item)));
+      s->insert(uint(PyInt_AsUnsignedLongMask(item)));
     }
 #endif
     Py_DECREF(item);

--- a/library/tulip-python/bindings/stl/std_vector.sip
+++ b/library/tulip-python/bindings/stl/std_vector.sip
@@ -102,7 +102,7 @@ template<TYPE>
   v->reserve(PyList_GET_SIZE(sipPy));
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
     int state;
-    TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(PyList_GET_ITEM(sipPy, i), kpTypeDef, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    TYPE* p = static_cast<TYPE*>(sipConvertToType(PyList_GET_ITEM(sipPy, i), kpTypeDef, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr) {
       sipReleaseType(p, kpTypeDef, state);
@@ -190,7 +190,7 @@ template<TYPE*>
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
     int state;
     PyObject *item = PyList_GET_ITEM(sipPy, i);
-    TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(item, kpTypeDef, NULL, SIP_NOT_NONE, &state, sipIsErr));
+    TYPE* p = static_cast<TYPE*>(sipConvertToType(item, kpTypeDef, NULL, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr) {
       sipReleaseType(p, kpTypeDef, state);
@@ -316,7 +316,7 @@ template<TYPE*>
   v->reserve(PyList_GET_SIZE(sipPy));
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
     PyObject *f = PyNumber_Float(PyList_GET_ITEM(sipPy, i));
-    v->push_back(static_cast<float>(PyFloat_AsDouble(f)));
+    v->push_back(float(PyFloat_AsDouble(f)));
     Py_XDECREF(f);
   }
 
@@ -379,13 +379,13 @@ template<TYPE*>
   v->reserve(PyList_GET_SIZE(sipPy));
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
 #if PY_MAJOR_VERSION >= 3
-    v->push_back(static_cast<int>(PyLong_AsLong(PyList_GET_ITEM(sipPy, i))));
+    v->push_back(int(PyLong_AsLong(PyList_GET_ITEM(sipPy, i))));
 #else
     PyObject *item = PyList_GET_ITEM(sipPy, i);
     if (PyLong_Check(item)) {
-      v->push_back(static_cast<int>(PyLong_AsLong(item)));
+      v->push_back(int(PyLong_AsLong(item)));
     } else {
-      v->push_back(static_cast<int>(PyInt_AsLong(item)));
+      v->push_back(int(PyInt_AsLong(item)));
     }
 #endif
   }
@@ -449,13 +449,13 @@ template<TYPE*>
   v->reserve(PyList_GET_SIZE(sipPy));
   for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
 #if PY_MAJOR_VERSION >= 3
-    v->push_back(static_cast<unsigned int>(PyLong_AsUnsignedLong(PyList_GET_ITEM(sipPy, i))));
+    v->push_back(uint(PyLong_AsUnsignedLong(PyList_GET_ITEM(sipPy, i))));
 #else
     PyObject *item = PyList_GET_ITEM(sipPy, i);
     if (PyLong_Check(item)) {
-        v->push_back(static_cast<unsigned int>(PyLong_AsUnsignedLong(item)));
+        v->push_back(uint(PyLong_AsUnsignedLong(item)));
     } else {
-        v->push_back(static_cast<unsigned int>(PyInt_AsUnsignedLongMask(item)));
+        v->push_back(uint(PyInt_AsUnsignedLongMask(item)));
     }
 #endif
   }

--- a/library/tulip-python/bindings/tulip-core/Algorithm.sip
+++ b/library/tulip-python/bindings/tulip-core/Algorithm.sip
@@ -105,7 +105,7 @@ and the second one can be used to provide an error message
       if (entry.first.length() > filesPrefixes[i].length() && entry.first.substr(0, filesPrefixes[i].length()) == filesPrefixes[i]) {
         std::string paramName = entry.first.substr(filesPrefixes[i].length());
         if (!sipCpp->dataSet->exist(paramName)) {
-          sipCpp->dataSet->set(paramName, *(reinterpret_cast<std::string*>(entry.second->value)));
+          sipCpp->dataSet->set(paramName, *(static_cast<std::string*>(entry.second->value)));
         }
       }
     }

--- a/library/tulip-python/bindings/tulip-core/Color.sip
+++ b/library/tulip-python/bindings/tulip-core/Color.sip
@@ -69,19 +69,19 @@ class Color {
     unsigned char a = 255;
 
   #if PY_MAJOR_VERSION >= 3
-    r = static_cast<unsigned char>(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 0)));
-    g = static_cast<unsigned char>(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 1)));
-    b = static_cast<unsigned char>(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 2)));
+    r = uchar(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 0)));
+    g = uchar(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 1)));
+    b = uchar(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 2)));
     if (PyList_GET_SIZE(sipPy) > 3)
-      a = static_cast<unsigned char>(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 3)));
+      a = uchar(PyLong_AsLong(PyTuple_GET_ITEM(sipPy, 3)));
   #else
 
     static struct {
       unsigned char operator()(PyObject *item) const {
         if (PyLong_Check(item)) {
-          return static_cast<unsigned char>(PyLong_AsLong(item));
+          return uchar(PyLong_AsLong(item));
         } else {
-          return static_cast<unsigned char>(PyInt_AsLong(item));
+          return uchar(PyInt_AsLong(item));
         }
       }
     } toUnsignedChar;

--- a/library/tulip-python/bindings/tulip-core/ColorScale.sip
+++ b/library/tulip-python/bindings/tulip-core/ColorScale.sip
@@ -75,7 +75,7 @@ class ColorScale {
     std::map<float, tlp::Color> colorMap;
     while (PyDict_Next(sipPy, &pos, &key, &val)) {
       double step = PyFloat_AsDouble(key);
-      tlp::Color *color = reinterpret_cast<tlp::Color*>(sipConvertToType(val, sipFindType("tlp::Color"), Py_None, SIP_NOT_NONE, &state, &err));
+      tlp::Color *color = static_cast<tlp::Color*>(sipConvertToType(val, sipFindType("tlp::Color"), Py_None, SIP_NOT_NONE, &state, &err));
       colorMap[step] = *color;
     }
     *sipCppPtr = new tlp::ColorScale();
@@ -84,12 +84,12 @@ class ColorScale {
     std::vector<tlp::Color> colors;
     for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i) {
       PyObject *item = PyList_GET_ITEM(sipPy, i);
-      tlp::Color *color = reinterpret_cast<tlp::Color*>(sipConvertToType(item, sipFindType("tlp::Color"), Py_None, SIP_NOT_NONE, &state, &err));
+      tlp::Color *color = static_cast<tlp::Color*>(sipConvertToType(item, sipFindType("tlp::Color"), Py_None, SIP_NOT_NONE, &state, &err));
       colors.push_back(*color);
     }
     *sipCppPtr = new tlp::ColorScale(colors);
   } else {
-    *sipCppPtr = new tlp::ColorScale(*reinterpret_cast<tlp::ColorScale*>(sipConvertToType(sipPy, sipFindType("tlp::ColorScale"), sipTransferObj, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
+    *sipCppPtr = new tlp::ColorScale(*static_cast<tlp::ColorScale*>(sipConvertToType(sipPy, sipFindType("tlp::ColorScale"), sipTransferObj, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
   }
 
   if (!*sipCppPtr) {

--- a/library/tulip-python/bindings/tulip-core/DataSet.sip
+++ b/library/tulip-python/bindings/tulip-core/DataSet.sip
@@ -37,7 +37,7 @@ PyObject* convertTlpDataSetToPyDict(const tlp::DataSet &dataSet, PyObject *dict)
     PyObject *key = sipConvertFromNewType(new std::string(entry.first), sipFindType("std::string"), NULL);
     PyObject *val = NULL;
     if (entry.second->getTypeName() == std::string(typeid(tlp::StringCollection).name())) {
-      tlp::StringCollection *sc = reinterpret_cast<tlp::StringCollection*>(entry.second->value);
+      tlp::StringCollection *sc = static_cast<tlp::StringCollection*>(entry.second->value);
       val = sipConvertFromNewType(new std::string(sc->getCurrentString()), sipFindType("std::string"), NULL);
     } else {
       val = getPyObjectFromDataType(entry.second);
@@ -58,7 +58,7 @@ extern tlp::DataSet* convertPyDictToTlpDataSet(PyObject *dict, tlp::DataSet *ref
   }
   enableErrorMessages(false);
   while (PyDict_Next(dict, &pos, &key, &val)) {
-    std::string *keyStr = reinterpret_cast<std::string*>(sipConvertToType(key, sipFindType("std::string"), Py_None, SIP_NOT_NONE, &state, &err));
+    std::string *keyStr = static_cast<std::string*>(sipConvertToType(key, sipFindType("std::string"), Py_None, SIP_NOT_NONE, &state, &err));
     tlp::DataType *dataType = NULL;
     if (refDataSet) {
       dataType = refDataSet->getData(*keyStr);
@@ -85,7 +85,7 @@ bool setDataSetEntryFromPyObject(tlp::DataSet *dataSet, const std::string &key, 
 #else
   PyString_Check(value)) {
 #endif
-    tlp::StringCollection *sc = reinterpret_cast<tlp::StringCollection*>(dataType->value);
+    tlp::StringCollection *sc = static_cast<tlp::StringCollection*>(dataType->value);
 #if PY_MAJOR_VERSION >= 3
     std::string entry(convertPythonUnicodeObjectToStdString(value));
 #else
@@ -168,7 +168,7 @@ struct DataSet /TypeHint="Dict[str, Any]", TypeHintValue="{}"/ {
   if (PyDict_Check(sipPy)) {
     *sipCppPtr = convertPyDictToTlpDataSet(sipPy);
   } else {
-    *sipCppPtr = new tlp::DataSet(*reinterpret_cast<tlp::DataSet*>(sipConvertToType(sipPy, sipFindType("tlp::DataSet"), sipTransferObj, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
+    *sipCppPtr = new tlp::DataSet(*static_cast<tlp::DataSet*>(sipConvertToType(sipPy, sipFindType("tlp::DataSet"), sipTransferObj, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
   }
 
   if (!*sipCppPtr) {

--- a/library/tulip-python/bindings/tulip-core/ExportModule.sip
+++ b/library/tulip-python/bindings/tulip-core/ExportModule.sip
@@ -142,7 +142,7 @@ to indicate if the export was successful.
       if (entry.first.length() > filesPrefixes[i].length() && entry.first.substr(0, filesPrefixes[i].length()) == filesPrefixes[i]) {
         std::string paramName = entry.first.substr(filesPrefixes[i].length());
         if (!sipCpp->dataSet->exist(paramName)) {
-          sipCpp->dataSet->set(paramName, *(reinterpret_cast<std::string*>(entry.second->value)));
+          sipCpp->dataSet->set(paramName, *(static_cast<std::string*>(entry.second->value)));
         }
       }
     }

--- a/library/tulip-python/bindings/tulip-core/Graph.sip
+++ b/library/tulip-python/bindings/tulip-core/Graph.sip
@@ -150,7 +150,7 @@ void updateWrappedDataSetAfterAlgorithmCall(tlp::DataSet *algorithmOutputDataset
   if (inputDataSetWrapper && PyDict_Check(inputDataSetWrapper)) {
     convertTlpDataSetToPyDict(*algorithmOutputDataset, inputDataSetWrapper);
   } else if (inputDataSetWrapper) {
-    tlp::DataSet *wrappedDs = reinterpret_cast<tlp::DataSet*>(sipGetAddress(reinterpret_cast<sipSimpleWrapper *>(inputDataSetWrapper)));
+    tlp::DataSet *wrappedDs = static_cast<tlp::DataSet*>(sipGetAddress(reinterpret_cast<sipSimpleWrapper *>(inputDataSetWrapper)));
     std::pair<std::string, tlp::DataType*> entry;
     forEach(entry, algorithmOutputDataset->getValues()) {
       wrappedDs->setData(entry.first, entry.second);

--- a/library/tulip-python/bindings/tulip-core/ImportModule.sip
+++ b/library/tulip-python/bindings/tulip-core/ImportModule.sip
@@ -130,7 +130,7 @@ to indicate if the import was successful.
       if (entry.first.length() > filesPrefixes[i].length() && entry.first.substr(0, filesPrefixes[i].length()) == filesPrefixes[i]) {
         std::string paramName = entry.first.substr(filesPrefixes[i].length());
         if (!sipCpp->dataSet->exist(paramName)) {
-          sipCpp->dataSet->set(paramName, *(reinterpret_cast<std::string*>(entry.second->value)));
+          sipCpp->dataSet->set(paramName, *(static_cast<std::string*>(entry.second->value)));
         }
       }
     }

--- a/library/tulip-python/bindings/tulip-core/Module.sip
+++ b/library/tulip-python/bindings/tulip-core/Module.sip
@@ -191,16 +191,16 @@ VEC_TYPE *convertToVec3fType(PyObject *pyObj, float zVal = 0) {
   bool isList = PyList_Check(pyObj);
 
   PyObject *f = PyNumber_Float(isList ? PyList_GET_ITEM(pyObj, 0) : PyTuple_GET_ITEM(pyObj, 0));
-  x = static_cast<float>(PyFloat_AsDouble(f));
+  x = float(PyFloat_AsDouble(f));
   Py_XDECREF(f);
 
   f = PyNumber_Float(isList ? PyList_GET_ITEM(pyObj, 1) : PyTuple_GET_ITEM(pyObj, 1));
-  y = static_cast<float>(PyFloat_AsDouble(f));
+  y = float(PyFloat_AsDouble(f));
   Py_XDECREF(f);
 
   if ((isList && PyList_GET_SIZE(pyObj) > 2) || PyTuple_GET_SIZE(pyObj) > 2) {
     f = PyNumber_Float(isList ? PyList_GET_ITEM(pyObj, 2) : PyTuple_GET_ITEM(pyObj, 2));
-    z = static_cast<float>(PyFloat_AsDouble(f));
+    z = float(PyFloat_AsDouble(f));
     Py_XDECREF(f);
   }
 

--- a/library/tulip-python/bindings/tulip-core/Size.sip
+++ b/library/tulip-python/bindings/tulip-core/Size.sip
@@ -92,11 +92,11 @@ class PySize : tlp::Vec3f /PyName=Size, TypeHint="tlp.Size"/ {
   int state=0, err=0;
 
   if (sipCanConvertToType(sipPy, sipFindType("tlp::PySize"), SIP_NOT_NONE|SIP_NO_CONVERTORS)) {
-    *sipCppPtr = new tlp::PySize(*reinterpret_cast<tlp::PySize*>(sipConvertToType(sipPy, sipFindType("tlp::PySize"), Py_None, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
+    *sipCppPtr = new tlp::PySize(*static_cast<tlp::PySize*>(sipConvertToType(sipPy, sipFindType("tlp::PySize"), Py_None, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
   } else if (PyList_Check(sipPy) || PyTuple_Check(sipPy)) {
     *sipCppPtr = convertToVec3fType<tlp::PySize>(sipPy, 1);
   } else {
-    *sipCppPtr = new tlp::PySize(*reinterpret_cast<tlp::Vec3f*>(sipConvertToType(sipPy, sipFindType("tlp::Vec3f"), Py_None, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
+    *sipCppPtr = new tlp::PySize(*static_cast<tlp::Vec3f*>(sipConvertToType(sipPy, sipFindType("tlp::Vec3f"), Py_None, SIP_NOT_NONE|SIP_NO_CONVERTORS, &state, &err)));
   }
 
   return sipGetState(sipTransferObj);

--- a/library/tulip-python/bindings/tulip-core/TlpTools.sip
+++ b/library/tulip-python/bindings/tulip-core/TlpTools.sip
@@ -83,7 +83,7 @@ tlp::DataSet getDefaultPluginParameters(const std::string &pluginName, tlp::Grap
       for (size_t i = 0 ; i < filesPrefixes.size() ; ++i) {
         if (entry.first.length() > filesPrefixes[i].length() && entry.first.substr(0, filesPrefixes[i].length()) == filesPrefixes[i]) {
           std::string paramName = entry.first.substr(filesPrefixes[i].length());
-          result.set(paramName, *(reinterpret_cast<std::string*>(entry.second->value)));
+          result.set(paramName, *(static_cast<std::string*>(entry.second->value)));
           result.remove(entry.first);
         }
       }

--- a/library/tulip-python/include/tulip/PythonCppTypesConverter.h
+++ b/library/tulip-python/include/tulip/PythonCppTypesConverter.h
@@ -94,7 +94,7 @@ public:
     void *cppObjPointer = convertSipWrapperToCppType(pyObject, className);
 
     if (cppObjPointer) {
-      cppObject = *reinterpret_cast<T*>(cppObjPointer);
+      cppObject = *static_cast<T*>(cppObjPointer);
       return true;
     }
 
@@ -114,7 +114,7 @@ public:
     void *cppObjPointer = convertSipWrapperToCppType(pyObject, className, true);
 
     if (cppObjPointer) {
-      cppObject = reinterpret_cast<T*>(cppObjPointer);
+      cppObject = static_cast<T*>(cppObjPointer);
       return true;
     }
 

--- a/library/tulip-python/include/tulip/PythonIncludes.h
+++ b/library/tulip-python/include/tulip/PythonIncludes.h
@@ -69,9 +69,9 @@
 static const sipAPIDef *getSipAPI() {
 #if defined(SIP_USE_PYCAPSULE)
 #ifdef TULIP_SIP
-  return (const sipAPIDef *)PyCapsule_Import("tulipsip._C_API", 0);
+  return static_cast<const sipAPIDef *>(PyCapsule_Import("tulipsip._C_API", 0));
 #else
-  return (const sipAPIDef *)PyCapsule_Import("sip._C_API", 0);
+  return static_cast<const sipAPIDef *>(PyCapsule_Import("sip._C_API", 0);
 #endif
 #else
   PyObject *sip_module;
@@ -102,7 +102,7 @@ static const sipAPIDef *getSipAPI() {
     return NULL;
 
   /* Get the actual pointer from the object. */
-  return (const sipAPIDef *)PyCObject_AsVoidPtr(c_api);
+  return static_cast<const sipAPIDef *>(PyCObject_AsVoidPtr(c_api));
 #endif
 }
 

--- a/library/tulip-python/src/ConsoleUtilsModule.cpp
+++ b/library/tulip-python/src/ConsoleUtilsModule.cpp
@@ -17,6 +17,11 @@
  *
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "tulip/PythonIncludes.h"
 #include "tulip/PythonInterpreter.h"
 
@@ -39,9 +44,9 @@ typedef struct {
 static void
 consoleutils_ConsoleOutput_dealloc(consoleutils_ConsoleOutput* self) {
 #if PY_MAJOR_VERSION >= 3
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
 #else
-  self->ob_type->tp_free((PyObject*)self);
+  self->ob_type->tp_free(reinterpret_cast<PyObject*>(self));
 #endif
 }
 
@@ -119,7 +124,7 @@ consoleutils_ConsoleOutput_enableConsoleOutput(PyObject *self, PyObject *o) {
   if(!PyArg_ParseTuple(o, "i", &i))
     return NULL;
 
-  ((consoleutils_ConsoleOutput *)self)->writeToConsole = i > 0;
+  reinterpret_cast<consoleutils_ConsoleOutput *>(self)->writeToConsole = i > 0;
 
   Py_RETURN_NONE;
 }
@@ -149,15 +154,15 @@ static PyMemberDef consoleutils_ConsoleOutput_members[] = {
 
 static PyMethodDef consoleutils_ConsoleOutput_methods[] = {
   {
-    "write", (PyCFunction) consoleutils_ConsoleOutput_write, METH_VARARGS,
+    "write", static_cast<PyCFunction>(consoleutils_ConsoleOutput_write), METH_VARARGS,
     "Post output to the scripting engine"
   },
   {
-    "enableConsoleOutput", (PyCFunction) consoleutils_ConsoleOutput_enableConsoleOutput, METH_VARARGS,
+    "enableConsoleOutput", static_cast<PyCFunction>(consoleutils_ConsoleOutput_enableConsoleOutput), METH_VARARGS,
     "enable / disable console output"
   },
   {
-    "flush", (PyCFunction) consoleutils_ConsoleOutput_flush, METH_VARARGS,
+    "flush", static_cast<PyCFunction>(consoleutils_ConsoleOutput_flush), METH_VARARGS,
     ""
   },
   {0, 0, 0, 0}  /* Sentinel */
@@ -173,7 +178,7 @@ static PyTypeObject consoleutils_ConsoleOutputType = {
   "consoleutils.ConsoleOutput",             /*tp_name*/
   sizeof(consoleutils_ConsoleOutput),             /*tp_basicsize*/
   0,                         /*tp_itemsize*/
-  (destructor)consoleutils_ConsoleOutput_dealloc, /*tp_dealloc*/
+  reinterpret_cast<destructor>(consoleutils_ConsoleOutput_dealloc), /*tp_dealloc*/
   0,                         /*tp_print*/
   0,                         /*tp_getattr*/
   0,                         /*tp_setattr*/
@@ -204,7 +209,7 @@ static PyTypeObject consoleutils_ConsoleOutputType = {
   0,                         /* tp_descr_get */
   0,                         /* tp_descr_set */
   0,                         /* tp_dictoffset */
-  (initproc)consoleutils_ConsoleOutput_init,      /* tp_init */
+  reinterpret_cast<initproc>(consoleutils_ConsoleOutput_init),      /* tp_init */
   0,                         /* tp_alloc */
   consoleutils_ConsoleOutput_new,                 /* tp_new */
   0,
@@ -229,17 +234,15 @@ typedef struct {
 static void
 consoleutils_ConsoleInput_dealloc(consoleutils_ConsoleInput* self) {
 #if PY_MAJOR_VERSION >= 3
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
 #else
-  self->ob_type->tp_free((PyObject*)self);
+  self->ob_type->tp_free(reinterpret_cast<PyObject*>(self));
 #endif
 }
 
 static PyObject *
 consoleutils_ConsoleInput_new(PyTypeObject *type, PyObject *, PyObject *) {
-  consoleutils_ConsoleInput *self;
-  self = reinterpret_cast<consoleutils_ConsoleInput *>(type->tp_alloc(type, 0));
-  return reinterpret_cast<PyObject *>(self);
+  return type->tp_alloc(type, 0);
 }
 
 static int
@@ -266,7 +269,7 @@ static PyMemberDef consoleutils_ConsoleInput_members[] = {
 
 static PyMethodDef consoleutils_ConsoleInput_methods[] = {
   {
-    "readline", (PyCFunction) consoleutils_ConsoleInput_readline, METH_VARARGS,
+    "readline", static_cast<PyCFunction>(consoleutils_ConsoleInput_readline), METH_VARARGS,
     "read an input line from the console"
   },
   {0, 0, 0, 0}  /* Sentinel */
@@ -282,7 +285,7 @@ static PyTypeObject consoleutils_ConsoleInputType = {
   "consoleutils.ConsoleInput",             /*tp_name*/
   sizeof(consoleutils_ConsoleInput),             /*tp_basicsize*/
   0,                         /*tp_itemsize*/
-  (destructor)consoleutils_ConsoleInput_dealloc, /*tp_dealloc*/
+  reinterpret_cast<destructor>(consoleutils_ConsoleInput_dealloc), /*tp_dealloc*/
   0,                         /*tp_print*/
   0,                         /*tp_getattr*/
   0,                         /*tp_setattr*/
@@ -313,7 +316,7 @@ static PyTypeObject consoleutils_ConsoleInputType = {
   0,                         /* tp_descr_get */
   0,                         /* tp_descr_set */
   0,                         /* tp_dictoffset */
-  (initproc)consoleutils_ConsoleInput_init,      /* tp_init */
+  reinterpret_cast<initproc>(consoleutils_ConsoleInput_init),      /* tp_init */
   0,                         /* tp_alloc */
   consoleutils_ConsoleInput_new,                 /* tp_new */
   0,
@@ -371,3 +374,7 @@ initconsoleutils(void) {
   Py_INCREF(cit);
   PyModule_AddObject(m, "ConsoleInput", cit);
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/library/tulip-python/src/PythonCodeEditor.cpp
+++ b/library/tulip-python/src/PythonCodeEditor.cpp
@@ -82,11 +82,11 @@ private:
 
 AutoCompletionList::AutoCompletionList(PythonCodeEditor *parent) : QListWidget(parent), _codeEditor(parent) {
 #if defined(__APPLE__)
-  setWindowFlags((Qt::WindowFlags) Qt::Popup|Qt::FramelessWindowHint);
+  setWindowFlags(static_cast<Qt::WindowFlags>(Qt::Popup|Qt::FramelessWindowHint));
 #elif QT_VERSION >= 0x040500
-  setWindowFlags((Qt::WindowFlags) Qt::ToolTip);
+  setWindowFlags(static_cast<Qt::WindowFlags>(Qt::ToolTip));
 #else
-  setWindowFlags((Qt::WindowFlags) Qt::Tool|Qt::FramelessWindowHint);
+  setWindowFlags(static_cast<Qt::WindowFlags>(Qt::Tool|Qt::FramelessWindowHint));
 #endif
   setAttribute(Qt::WA_StaticContents);
   setFrameShape(StyledPanel);
@@ -605,8 +605,8 @@ void PythonCodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event) {
 
   QTextBlock block = firstVisibleBlock();
   int blockNumber = block.blockNumber();
-  int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
-  int bottom = top + static_cast<int>(blockBoundingRect(block).height());
+  int top = int(blockBoundingGeometry(block).translated(contentOffset()).top());
+  int bottom = top + int(blockBoundingRect(block).height());
 
   while (block.isValid() && top <= event->rect().bottom()) {
     if (block.isVisible() && bottom >= event->rect().top()) {
@@ -620,7 +620,7 @@ void PythonCodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event) {
 
     block = block.next();
     top = bottom;
-    bottom = top + static_cast<int>(blockBoundingRect(block).height());
+    bottom = top + int(blockBoundingRect(block).height());
     ++blockNumber;
   }
 }
@@ -672,9 +672,9 @@ void PythonCodeEditor::paintEvent(QPaintEvent *event) {
 
   if (isTooltipActive()) {
     QTextBlock tooltipBlock = document()->findBlockByNumber(_toolTipPos.x());
-    int top = static_cast<int>(blockBoundingGeometry(tooltipBlock).translated(contentOffset()).top());
-    int left = static_cast<int>(blockBoundingGeometry(tooltipBlock).translated(contentOffset()).left());
-    int bottom = top + static_cast<int>(blockBoundingRect(tooltipBlock).height());
+    int top = int(blockBoundingGeometry(tooltipBlock).translated(contentOffset()).top());
+    int left = int(blockBoundingGeometry(tooltipBlock).translated(contentOffset()).left());
+    int bottom = top + int(blockBoundingRect(tooltipBlock).height());
     QString blockText = tooltipBlock.text();
 
     for (int i = 0 ; i < _toolTipPos.y() ; ++i) {
@@ -724,9 +724,9 @@ void PythonCodeEditor::paintEvent(QPaintEvent *event) {
   }
 
   QTextBlock block = firstVisibleBlock();
-  int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
+  int top = int(blockBoundingGeometry(block).translated(contentOffset()).top());
 
-  int bottom = top + static_cast<int>(blockBoundingRect(block).height());
+  int bottom = top + int(blockBoundingRect(block).height());
 
   QPen pen;
   pen.setStyle(Qt::DotLine);
@@ -758,7 +758,7 @@ void PythonCodeEditor::paintEvent(QPaintEvent *event) {
 
     block = block.next();
     top = bottom;
-    bottom = top + static_cast<int>(blockBoundingRect(block).height());
+    bottom = top + int(blockBoundingRect(block).height());
   }
 }
 
@@ -1262,9 +1262,9 @@ void PythonCodeEditor::updateAutoCompletionListPosition() {
   if (!_autoCompletionList->isVisible())
     return;
 
-  int left = static_cast<int>(blockBoundingGeometry(textCursor().block()).translated(contentOffset()).left());
-  int top = static_cast<int>(blockBoundingGeometry(textCursor().block()).translated(contentOffset()).top());
-  int bottom = top + static_cast<int>(blockBoundingRect(textCursor().block()).height());
+  int left = int(blockBoundingGeometry(textCursor().block()).translated(contentOffset()).left());
+  int top = int(blockBoundingGeometry(textCursor().block()).translated(contentOffset()).top());
+  int bottom = top + int(blockBoundingRect(textCursor().block()).height());
   QString textBeforeCursor = textCursor().block().text().mid(0, textCursor().position() - textCursor().block().position());
   int pos = lineNumberAreaWidth() + left + 1;
   int stop = 0;

--- a/library/tulip-python/src/PythonCppTypesConverter.cpp
+++ b/library/tulip-python/src/PythonCppTypesConverter.cpp
@@ -17,6 +17,11 @@
  *
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "tulip/PythonIncludes.h"
 #include "tulip/PythonCppTypesConverter.h"
 
@@ -283,15 +288,15 @@ T *getCppPointerFromPyObject(PyObject *pyObj) {
 
 #define CHECK_BASE_CPP_TYPE_CONVERSION(T)\
     if (!pyObj && dataType && dataType->getTypeName() == std::string(typeid(T).name())) {\
-        pyObj = getPyObjectFromCppObject(*(reinterpret_cast<T*>(dataType->value)));\
+        pyObj = getPyObjectFromCppObject(*(static_cast<T*>(dataType->value)));\
     }\
 
 #define CHECK_SIP_CPP_TYPE_CONVERSION(T)\
     if (!pyObj && dataType && dataType->getTypeName() == std::string(typeid(T).name())) {\
         if (noCopy) {\
-            pyObj = getPyObjectFromCppObject(reinterpret_cast<T*>(dataType->value));\
+            pyObj = getPyObjectFromCppObject(static_cast<T*>(dataType->value));\
         } else {\
-            pyObj = getPyObjectFromCppObject(*(reinterpret_cast<T*>(dataType->value)));\
+            pyObj = getPyObjectFromCppObject(*(static_cast<T*>(dataType->value)));\
         }\
     }\
 
@@ -408,7 +413,7 @@ PyObject *getPyObjectFromDataType(const tlp::DataType *dataType, bool noCopy) {
 
 #define CHECK_SIP_ENUM_CONVERSION(SIP_TYPE_STR)\
     if (sipCanConvertToEnum(pyObj, sipFindType(SIP_TYPE_STR))) {\
-     valSetter.setValue(static_cast<int>(PyLong_AsLong(pyObj)));\
+     valSetter.setValue(int(PyLong_AsLong(pyObj)));\
       return true;\
     }\
 
@@ -443,7 +448,7 @@ bool setCppValueFromPyObject(PyObject *pyObj, ValueSetter &valSetter, tlp::DataT
     long val = getCppObjectFromPyObject<long>(pyObj);
 
     if (dataType && dataType->getTypeName() == std::string(typeid(int).name())) {
-      valSetter.setValue(static_cast<int>(val));
+      valSetter.setValue(int(val));
     }
     else if (dataType && dataType->getTypeName() == std::string(typeid(unsigned int).name())) {
       valSetter.setValue(getCppObjectFromPyObject<unsigned int>(pyObj));
@@ -455,13 +460,13 @@ bool setCppValueFromPyObject(PyObject *pyObj, ValueSetter &valSetter, tlp::DataT
       valSetter.setValue(getCppObjectFromPyObject<unsigned long>(pyObj));
     }
     else if (dataType && dataType->getTypeName() == std::string(typeid(float).name())) {
-      valSetter.setValue(static_cast<float>(val));
+      valSetter.setValue(float(val));
     }
     else if (dataType && dataType->getTypeName() == std::string(typeid(double).name())) {
-      valSetter.setValue(static_cast<double>(val));
+      valSetter.setValue(double(val));
     }
     else {
-      valSetter.setValue(static_cast<int>(val));
+      valSetter.setValue(int(val));
     }
 
     return true;
@@ -473,7 +478,7 @@ bool setCppValueFromPyObject(PyObject *pyObj, ValueSetter &valSetter, tlp::DataT
     long val = getCppObjectFromPyObject<long>(pyObj);
 
     if (dataType && dataType->getTypeName() == std::string(typeid(int).name())) {
-      valSetter.setValue(static_cast<int>(val));
+      valSetter.setValue(int(val));
     }
     else if (dataType && dataType->getTypeName() == std::string(typeid(unsigned int).name())) {
       valSetter.setValue(getCppObjectFromPyObject<unsigned int>(pyObj));
@@ -485,13 +490,13 @@ bool setCppValueFromPyObject(PyObject *pyObj, ValueSetter &valSetter, tlp::DataT
       valSetter.setValue(getCppObjectFromPyObject<unsigned long>(pyObj));
     }
     else if (dataType && dataType->getTypeName() == std::string(typeid(float).name())) {
-      valSetter.setValue(static_cast<float>(val));
+      valSetter.setValue(float(val));
     }
     else if (dataType && dataType->getTypeName() == std::string(typeid(double).name())) {
-      valSetter.setValue(static_cast<double>(val));
+      valSetter.setValue(double(val));
     }
     else {
-      valSetter.setValue(static_cast<int>(val));
+      valSetter.setValue(int(val));
     }
 
     return true;
@@ -671,3 +676,7 @@ bool setCppValueFromPyObject(PyObject *pyObj, ValueSetter &valSetter, tlp::DataT
 
   return false;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/library/tulip-python/src/PythonInterpreter.cpp
+++ b/library/tulip-python/src/PythonInterpreter.cpp
@@ -17,6 +17,11 @@
  *
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "tulip/PythonIncludes.h"
 #include "tulip/PythonInterpreter.h"
 #include "ConsoleHandlers.h"
@@ -419,7 +424,7 @@ PythonInterpreter::~PythonInterpreter() {
       runString("import sip; sys.stdout.write(sip.__file__)");
 #endif
       QString sipModulePath = consoleOuputString;
-      sipQtAPI **sipQtSupport = reinterpret_cast<sipQtAPI **>(QLibrary::resolve(sipModulePath, "sipQtSupport"));
+      sipQtAPI **sipQtSupport = static_cast<sipQtAPI **>(QLibrary::resolve(sipModulePath, "sipQtSupport"));
 
       if (sipQtSupport)
         *sipQtSupport = NULL;
@@ -1101,3 +1106,7 @@ void PythonInterpreter::clearTracebacks() {
   pythonCode += "sys.last_traceback = None\n";
   runString(pythonCode);
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/library/tulip-python/src/PythonShellWidget.cpp
+++ b/library/tulip-python/src/PythonShellWidget.cpp
@@ -147,7 +147,7 @@ void PythonShellWidget::keyPressEvent(QKeyEvent * e) {
       setSelection(lines()-1, 0, lines()-1, lineLength(lines()-1));
       removeSelectedText();
 
-      if (_currentHistoryPos < static_cast<int>(_history.size() -  1) && _history.size() > 0) {
+      if (_currentHistoryPos < int(_history.size() -  1) && _history.size() > 0) {
         ++_currentHistoryPos;
         insert(_currentPs + _history[_currentHistoryPos]);
       }

--- a/library/tulip-python/src/PythonTabWidget.cpp
+++ b/library/tulip-python/src/PythonTabWidget.cpp
@@ -46,12 +46,12 @@ void PythonTabWidget::paintEvent(QPaintEvent * event) {
 
   painter.setPen(_textColor);
 #ifndef __APPLE__
-  painter.setFont(QFont("Arial", static_cast<int>(10 * tabBar()->height() / 27.0)));
+  painter.setFont(QFont("Arial", int(10 * tabBar()->height() / 27.0)));
 #else
-  painter.setFont(QFont("Arial", static_cast<int>(12 * tabBar()->height() / 27.0)));
+  painter.setFont(QFont("Arial", int(12 * tabBar()->height() / 27.0)));
 #endif
-  int imageWidth = static_cast<int>(25 * tabBar()->height() / 27.0);
-  int labelWidth = static_cast<int>(80 * tabBar()->height() / 27.0);
+  int imageWidth = int(25 * tabBar()->height() / 27.0);
+  int labelWidth = int(80 * tabBar()->height() / 27.0);
   int offset = tabBar()->height() - imageWidth;
   QRectF rect(width()-(imageWidth+labelWidth), tabBar()->pos().y()+offset/2, imageWidth, imageWidth);
   QRectF rect2(width()-labelWidth, tabBar()->pos().y(), labelWidth, tabBar()->height());

--- a/library/tulip-python/src/TulipUtilsModule.cpp
+++ b/library/tulip-python/src/TulipUtilsModule.cpp
@@ -17,6 +17,11 @@
  *
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "tulip/PythonIncludes.h"
 #include "tulip/PythonInterpreter.h"
 
@@ -68,7 +73,7 @@ tuliputils_runGraphScript(PyObject *, PyObject *args) {
         int err = 0;
 
         // Unwrapping C++ instance
-        tlp::Graph *graph = reinterpret_cast<tlp::Graph *>(sipConvertToType(o, kpTypeDef, NULL, SIP_NOT_NONE, &state, &err));
+        tlp::Graph *graph = static_cast<tlp::Graph *>(sipConvertToType(o, kpTypeDef, NULL, SIP_NOT_NONE, &state, &err));
 
         if (!PythonInterpreter::getInstance()->runGraphScript(scriptName, "main", graph)) {
           PyErr_SetString(PyExc_Exception, (std::string("An exception occurred when executing the ") + std::string(s) + " script").c_str());
@@ -155,3 +160,6 @@ inittuliputils(void) {
 #endif
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/plugins/clustering/ConvolutionClustering.cpp
+++ b/plugins/clustering/ConvolutionClustering.cpp
@@ -43,9 +43,9 @@ double g(int k,double width,double amplitude) {
     return 0;
   else {
     if (k<0)
-      return ((double)k*slope+amplitude); //partie croissante du signal triangulaire
+      return k*slope+amplitude; //partie croissante du signal triangulaire
     else
-      return ((double)-k*slope+amplitude); //partie décroissante du signal triangulaire
+      return -k*slope+amplitude; //partie décroissante du signal triangulaire
   }
 }
 //================================================================================
@@ -86,7 +86,7 @@ list<int> ConvolutionClustering::getLocalMinimum() {
       if (slopeSens==false) {
         int local = localMinimum.back();
 
-        if ((int) i - local < width/2) {
+        if (int(i) - local < width/2) {
           localMinimum.pop_back();
           localMinimum.push_back((i+local)/2);
         }
@@ -144,7 +144,7 @@ void ConvolutionClustering::autoSetParameter() {
     lastValue=(*itMap).first;
   }
 
-  histosize=(int)((metric->getNodeDoubleMax()-metric->getNodeDoubleMin())/deltaXMin);
+  histosize = int((metric->getNodeDoubleMax()-metric->getNodeDoubleMin())/deltaXMin);
 
   if (histosize > 16384) histosize = 16384; //histosize = histosize <? 16384;
 
@@ -156,7 +156,7 @@ void ConvolutionClustering::autoSetParameter() {
   //width=(int)(deltaXMax*histosize/(metric->getNodeMax()-metric->getNodeMin()));
   //width=(int)(deltaXMin*histosize/(metric->getNodeMax()-metric->getNodeMin()));
   deltaSum /= histo.size();
-  width=(int)(deltaSum*histosize/(metric->getNodeDoubleMax()-metric->getNodeDoubleMin()));
+  width = int(deltaSum*histosize/(metric->getNodeDoubleMax()-metric->getNodeDoubleMin()));
   //===============================================================================
   //Find good threshold
   //make the average of all local minimum
@@ -184,7 +184,7 @@ void ConvolutionClustering::autoSetParameter() {
     }
   }
 
-  threshold=(int)(sum/nbElement);
+  threshold=int(sum/nbElement);
 }
 //================================================================================
 vector<double> *ConvolutionClustering::getHistogram() {
@@ -195,7 +195,7 @@ vector<double> *ConvolutionClustering::getHistogram() {
 
   node n;
   forEach(n, graph->getNodes()) {
-    int tmp=(int)((metric->getNodeDoubleValue(n) - minVal) * (double)histosize /
+    int tmp=int((metric->getNodeDoubleValue(n) - minVal) * histosize /
                   maxMinRange);
 
     if (histogramOfValues.find(tmp) == histogramOfValues.end())
@@ -232,7 +232,7 @@ void ConvolutionClustering::getClusters(const std::vector<int> &ranges) {
   double minVal = metric->getNodeDoubleMin();
   double maxMinRange = metric->getNodeDoubleMax() - minVal;
   forEach(n,graph->getNodes()) {
-    int tmp = getInterval((int)((metric->getNodeDoubleValue(n) - minVal)*(double)histosize / maxMinRange), ranges);
+    int tmp = getInterval(int((metric->getNodeDoubleValue(n) - minVal) * histosize / maxMinRange), ranges);
     result->setNodeValue(n,tmp);
   }
 }

--- a/plugins/clustering/ConvolutionClusteringSetup.cpp
+++ b/plugins/clustering/ConvolutionClusteringSetup.cpp
@@ -64,26 +64,26 @@ public:
 
     //les 20 de plus permetront de placer des l�gendes sur les axes.
     double scale = double(histogram.size())/64.0;
-    int legendWidth = (int)(20.0*scale);
-    int borderWidth = (int)(10.0*scale);
-    int axisWidth = (int)(15.0*scale);
+    int legendWidth = int(20.0*scale);
+    int borderWidth = int(10.0*scale);
+    int axisWidth = int(15.0*scale);
     painter.setWindow( 0, 0, 2*histogram.size()+legendWidth, histogram.size()+legendWidth ); // defines coordinate system
     painter.fillRect(0, 0,
                      2*histogram.size()+legendWidth, histogram.size()+legendWidth ,
                      QBrush(QColor(255,255,255)));
     // draw bars
     QColor c;
-    double histoScale = double(histogram.size()) / theMax;
+    double histoScale = histogram.size() / theMax;
 
     for (unsigned int i=0; i<histogram.size(); i++ ) {
-      c.setHsv( (int) ((double)i*360.0/(double)histogram.size()) , 255, 255 );
+      c.setHsv(int(i * 360.0 / histogram.size()) , 255, 255 );
       painter.setBrush( c );
       int height;
 
       if (setupDialog->getLogarithmicScale())
-        height = (int)(log10(1.0 + double(histogram[i])) *histoScale );
+        height = int(log10(1.0 + histogram[i]) * histoScale );
       else
-        height = (int)(double(histogram[i]) * histoScale);
+        height = int(histogram[i] * histoScale);
 
       if (height < 1) height = 1;
 

--- a/plugins/clustering/EqualValueClustering.cpp
+++ b/plugins/clustering/EqualValueClustering.cpp
@@ -68,7 +68,7 @@ bool EqualValueClustering::run() {
 
   // try to work with NumericProperty
   if (dynamic_cast<NumericProperty*>(property))
-    return computeClusters((NumericProperty *) property,
+    return computeClusters(static_cast<NumericProperty *>(property),
                            onNodes, connected);
 
   return computeClusters(property, onNodes, connected);

--- a/plugins/clustering/QuotientClustering.cpp
+++ b/plugins/clustering/QuotientClustering.cpp
@@ -203,9 +203,9 @@ public:
     // set specific meta value calculators
     // for most properties
     DoubleProperty::PredefinedMetaValueCalculator nodeFn =
-      (DoubleProperty::PredefinedMetaValueCalculator ) nodeFunctions.getCurrent();
+      static_cast<DoubleProperty::PredefinedMetaValueCalculator>(nodeFunctions.getCurrent());
     DoubleProperty::PredefinedMetaValueCalculator edgeFn =
-      (DoubleProperty::PredefinedMetaValueCalculator) edgeFunctions.getCurrent();
+      static_cast<DoubleProperty::PredefinedMetaValueCalculator>(edgeFunctions.getCurrent());
     QuotientLabelCalculator viewLabelCalc(metaLabel, useSubGraphName);
     TLP_HASH_MAP<PropertyInterface*, PropertyInterface::MetaValueCalculator *> prevCalcs;
     string pName;
@@ -218,12 +218,12 @@ public:
 
       if (dynamic_cast<DoubleProperty *>(prop)) {
         prevCalcs[prop] = prop->getMetaValueCalculator();
-        ((DoubleProperty *)prop)->setMetaValueCalculator(nodeFn, edgeFn);
+        static_cast<DoubleProperty *>(prop)->setMetaValueCalculator(nodeFn, edgeFn);
       }
 
       if (pName == "viewLabel") {
         prevCalcs[prop] = prop->getMetaValueCalculator();
-        ((StringProperty*) prop)->setMetaValueCalculator(&viewLabelCalc);
+        static_cast<StringProperty*>(prop)->setMetaValueCalculator(&viewLabelCalc);
       }
     }
     // compute meta nodes, edges and associated meta values

--- a/plugins/colors/DoubleStringsListRelationDialog.cpp
+++ b/plugins/colors/DoubleStringsListRelationDialog.cpp
@@ -45,8 +45,8 @@ DoubleStringsListRelationDialog::DoubleStringsListRelationDialog(const std::vect
   connect(_ui->downButton,SIGNAL(clicked()),this,SLOT(downButtonClicked()));
   connect(_ui->upButtonColor,SIGNAL(clicked()),this,SLOT(upButtonColorClicked()));
   connect(_ui->downButtonColor,SIGNAL(clicked()),this,SLOT(downButtonColorClicked()));
-  connect(((QAbstractSlider*)(_ui->firstListWidget->verticalScrollBar())),SIGNAL(valueChanged(int)),this,SLOT(scrollBarValueChanged(int)));
-  connect(((QAbstractSlider*)(_ui->secondListWidget->verticalScrollBar())),SIGNAL(valueChanged(int)),this,SLOT(scrollBarValueChanged(int)));
+  connect(_ui->firstListWidget->verticalScrollBar(),SIGNAL(valueChanged(int)),this,SLOT(scrollBarValueChanged(int)));
+  connect(_ui->secondListWidget->verticalScrollBar(),SIGNAL(valueChanged(int)),this,SLOT(scrollBarValueChanged(int)));
 }
 
 DoubleStringsListRelationDialog::~DoubleStringsListRelationDialog() {

--- a/plugins/export/GMLExport.cpp
+++ b/plugins/export/GMLExport.cpp
@@ -106,9 +106,9 @@ public:
         printSize(os,sizes->getNodeValue(itn));
         os << "type \"rectangle\"" << endl;
         os << "width 0.12" << endl;
-        os << "fill \"#"<< hex << setfill('0') << setw(2) <<(int)colors->getNodeValue(itn).getR()
-           << hex << setfill('0') << setw(2) <<(int)colors->getNodeValue(itn).getG()
-           << hex << setfill('0') << setw(2) <<(int)colors->getNodeValue(itn).getB() << "\""<< endl;
+        os << "fill \"#"<< hex << setfill('0') << setw(2) << int(colors->getNodeValue(itn).getR())
+           << hex << setfill('0') << setw(2) << int(colors->getNodeValue(itn).getG())
+           << hex << setfill('0') << setw(2) << int(colors->getNodeValue(itn).getB()) << "\""<< endl;
 
         //      os << "outline \"#"<< hex << setfill('0') << setw(2) <<(int)colors->getNodeValue(itn).getR()
         //         << hex << setfill('0') << setw(2) <<(int)colors->getNodeValue(itn).getG()

--- a/plugins/export/SVGExport/ExportSvg.cpp
+++ b/plugins/export/SVGExport/ExportSvg.cpp
@@ -42,7 +42,7 @@ using namespace tlp;
 namespace {
 QString tlpColor2SvgColor(const Color &color) {
   //converting color to SVG
-  return QString("rgb(")+QString::number(static_cast<int>(color.getR()))+","+QString::number(static_cast<int>(color.getG()))+","+QString::number(static_cast<int>(color.getB()))+")";
+  return QString("rgb(")+QString::number(int(color.getR()))+","+QString::number(int(color.getG()))+","+QString::number(int(color.getB()))+")";
 }
 
 QString tlpAlphaColor2Opacity(const Color &color) {

--- a/plugins/export/SVGExport/Shape.cpp
+++ b/plugins/export/SVGExport/Shape.cpp
@@ -168,12 +168,12 @@ void ExtremityShape::Sphere(QXmlStreamWriter& res, const tlp::Color& color, bool
 
   res.writeStartElement("stop");
   res.writeAttribute("offset","0%");
-  res.writeAttribute("stop-color",QString("rgb(")+QString::number(static_cast<int>(color.getR()))+","+QString::number(static_cast<int>(color.getG()))+","+QString::number(static_cast<int>(color.getB()))+")");
+  res.writeAttribute("stop-color",QString("rgb(")+QString::number(int(color.getR()))+","+QString::number(int(color.getG()))+","+QString::number(int(color.getB()))+")");
   res.writeEndElement();
 
-  unsigned colorR = static_cast<unsigned>(color.getR());
-  unsigned colorG = static_cast<unsigned>(color.getG());
-  unsigned colorB = static_cast<unsigned>(color.getB());
+  unsigned char colorR = color.getR();
+  unsigned char colorG = color.getG();
+  unsigned char colorB = color.getB();
   QString Rcolor(QString::number(colorR - colorR/8));
   QString Gcolor(QString::number(colorG - colorG/8));
   QString Bcolor(QString::number(colorB - colorB/8));
@@ -259,12 +259,12 @@ void ExtremityShape::GlowSphere(QXmlStreamWriter& res, const tlp::Color& color, 
 
   res.writeStartElement("stop");
   res.writeAttribute("offset","0%");
-  res.writeAttribute("stop-color",QString("rgb(")+QString::number(static_cast<int>(color.getR()))+","+QString::number(static_cast<int>(color.getG()))+","+QString::number(static_cast<int>(color.getB()))+")");
+  res.writeAttribute("stop-color",QString("rgb(")+QString::number(int(color.getR()))+","+QString::number(int(color.getG()))+","+QString::number(int(color.getB()))+")");
   res.writeEndElement();
 
-  unsigned colorR = static_cast<unsigned>(color.getR());
-  unsigned colorG = static_cast<unsigned>(color.getG());
-  unsigned colorB = static_cast<unsigned>(color.getB());
+  unsigned char colorR = color.getR();
+  unsigned char colorG = color.getG();
+  unsigned char colorB = color.getB();
   QString Rcolor = QString::number(colorR - colorR/8);
   QString Gcolor = QString::number(colorG - colorG/8);
   QString Bcolor = QString::number(colorB - colorB/8);

--- a/plugins/general/EdgeBundling/EdgeBundling.cpp
+++ b/plugins/general/EdgeBundling/EdgeBundling.cpp
@@ -18,7 +18,7 @@
  */
 #ifdef _OPENMP
 #include <omp.h>
-#define MAX_THREADS (unsigned int) omp_get_max_threads()
+#define MAX_THREADS uint(omp_get_max_threads())
 #else
 #define MAX_THREADS 1
 #endif
@@ -442,7 +442,7 @@ bool EdgeBundling::run() {
       pair<node, node> ends = graph->ends(e);
       const Coord &a = layout->getNodeValue(ends.first);
       const Coord &b = layout->getNodeValue(ends.second);
-      double abNorm = (double) (a-b).norm();
+      double abNorm = (a-b).norm();
       double initialWeight = pow(abNorm, longEdges);
 
       if (ntype.getEdgeValue(e) == 2 && !edgeNodeOverlap)

--- a/plugins/glyph/fonticon.cpp
+++ b/plugins/glyph/fonticon.cpp
@@ -18,8 +18,15 @@
  */
 #include <GL/glew.h>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 #include <FTVectoriser.h>
 #include <FTLibrary.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #include <tulip/Glyph.h>
 #include <tulip/EdgeExtremityGlyph.h>
@@ -135,7 +142,7 @@ private:
 
     float size = 20;
 
-    err = FT_Set_Char_Size(face, static_cast<int>(size * HRES), 0, DPI * HRES, DPI * HRES);
+    err = FT_Set_Char_Size(face, int(size * HRES), 0, DPI * HRES, DPI * HRES);
 
     if (err) {
       return;

--- a/plugins/glyph/roundedbox.cpp
+++ b/plugins/glyph/roundedbox.cpp
@@ -306,7 +306,7 @@ void RoundedBox::draw(node n, float lod) {
 
   // don't use geometry shader rendering on MacOS as that feature does seem stable on that platform
 #ifndef __APPLE__
-  static string glVendor(((const char*)glGetString(GL_VENDOR)));
+  static string glVendor((reinterpret_cast<const char*>(glGetString(GL_VENDOR))));
   static bool glVendorOk = (glVendor.find("NVIDIA")!=string::npos) || (glVendor.find("ATI")!=string::npos);
 
   if (roundedBoxShader == NULL && glVendorOk && GlShaderProgram::shaderProgramsSupported() && GlShaderProgram::geometryShaderSupported()) {

--- a/plugins/import/BibTeX/ImportBibTeX.cpp
+++ b/plugins/import/BibTeX/ImportBibTeX.cpp
@@ -98,7 +98,7 @@ static string& forceUtf8String(string& str) {
         (i + 1) < str.size() &&
         // begin of a 2 chars utf8 sequence
         // skip next char if it is valid utf8
-        ((unsigned char) str[i + 1] >  '\177') &&
+        (uchar(str[i + 1]) >  '\177') &&
         (str[i + 1] < '\300')) {
       ++i;
       continue;
@@ -109,9 +109,9 @@ static string& forceUtf8String(string& str) {
         (i + 2) < str.size() &&
         // begin of a 3 chars utf8 sequence
         // skip next 2 chars if it is valid utf8
-        ((unsigned char) str[i + 1] > '\177') &&
+        (uchar(str[i + 1]) > '\177') &&
         (str[i + 1] < '\300') &&
-        ((unsigned char) str[i + 2] > '\177') &&
+        (uchar(str[i + 2]) > '\177') &&
         (str[i + 2] < '\300')) {
       i+=2;
       continue;
@@ -1503,7 +1503,7 @@ public :
       unsigned int i = 0;
 
       for(; it != itEnd; ++it, ++i) {
-        xdkbib::FileEntry& fe = (xdkbib::FileEntry&) *it;
+        xdkbib::FileEntry& fe = const_cast<xdkbib::FileEntry&>(*it);
 
         node publi;
 
@@ -1589,12 +1589,12 @@ public :
 
             if (pos != string::npos) {
               authorsComments = fe.comment().substr(pos + 7);
-              labriAuthors = (char *) authorsComments.c_str();
+              labriAuthors = const_cast<char *>(authorsComments.c_str());
               pos = fe.comment().find("LaBRI: ", pos + 7);
 
               if (pos != string::npos) {
                 teamsComments = fe.comment().substr(pos + 7);
-                labriTeams = (char *) teamsComments.c_str();
+                labriTeams = const_cast<char *>(teamsComments.c_str());
               }
             }
 
@@ -1629,7 +1629,7 @@ public :
               bool labriAuthor = labriAuthors && j == labriIndex;
 
               if (labriAuthor) {
-                indices.push_back((int) labriIndex);
+                indices.push_back(int(labriIndex));
                 char* token = strtok_r(NULL, " \n", &authorsPtr);
                 labriIndex = token ? (atoi(token) - 1) : 0;
               }

--- a/plugins/import/FileSystem.cpp
+++ b/plugins/import/FileSystem.cpp
@@ -253,7 +253,7 @@ private:
     _lastModifiedDates->setNodeValue(n,tlp::QStringToTlpString(info.lastModified().toString()));
     _lastReadDates->setNodeValue(n,tlp::QStringToTlpString(info.lastRead().toString()));
     _owners->setNodeValue(n,tlp::QStringToTlpString(info.owner()));
-    _permissions->setNodeValue(n,(int)(info.permissions()));
+    _permissions->setNodeValue(n,int(info.permissions()));
     _suffixes->setNodeValue(n,tlp::QStringToTlpString(info.suffix()));
     _sizes->setNodeValue(n,info.size());
 

--- a/plugins/import/GEXFImport.cpp
+++ b/plugins/import/GEXFImport.cpp
@@ -250,7 +250,7 @@ public :
     else
       pn = nodesMap[pid];
 
-    Graph* sg = (Graph*) nodeToSubgraph.get(pn.id);
+    Graph* sg = nodeToSubgraph.get(pn.id);
 
     if (sg == NULL) {
       // add a subgraph for the fake meta node
@@ -258,7 +258,7 @@ public :
       // record pn as its fake meta node
       sg->setAttribute<node>("meta-node", pn);
       // and vice-versa
-      nodeToSubgraph.set(pn.id, (size_t) sg);
+      nodeToSubgraph.set(pn.id, sg);
     }
 
     // add n in the subgraph found
@@ -313,9 +313,8 @@ public :
           a = xmlReader.attributes().value("a").toString().toFloat();
         }
 
-        viewColor->setNodeValue(n, Color((unsigned char) r, (unsigned char) g,
-                                         (unsigned char) b,
-                                         (unsigned char) (a * 255)));
+        viewColor->setNodeValue(n, Color(uchar(r), uchar(g),
+                                         uchar(b), uchar(a * 255)));
       }
       // parse node coordinates
       else if (xmlReader.isStartElement() && xmlReader.qualifiedName() == "viz:position") {
@@ -349,7 +348,7 @@ public :
       }
       // check for subgraph
       else if (xmlReader.isStartElement() && xmlReader.qualifiedName() == "nodes") {
-        Graph* sg = (Graph *) nodeToSubgraph.get(n.id);
+        Graph* sg = nodeToSubgraph.get(n.id);
 
         if (sg == NULL) {
           // add subgraph
@@ -357,7 +356,7 @@ public :
           // record the current node as its fake meta node
           sg->setAttribute<node>("meta-node", n);
           // and vice-versa
-          nodeToSubgraph.set(n.id, (size_t) sg);
+          nodeToSubgraph.set(n.id, sg);
         }
 
         // create its nodes
@@ -454,7 +453,7 @@ public :
 
       while(itn.hasNext()) {
         node n = itn.next();
-        Graph* msg = (Graph*) nodeToSubgraph.get(n.id);
+        Graph* msg = nodeToSubgraph.get(n.id);
 
         if (msg) {
           // if the current node is a fake meta node
@@ -507,7 +506,7 @@ public :
 
       while(itn.hasNext()) {
         node n = itn.next();
-        Graph* msg = (Graph*) nodeToSubgraph.get(n.id);
+        Graph* msg = nodeToSubgraph.get(n.id);
 
         if (msg != NULL) {
           // n is a fake meta node
@@ -617,7 +616,7 @@ private :
   IntegerProperty *viewShape;
   // to register the subgraph corresponding
   // to a fake meta node
-  MutableContainer<size_t> nodeToSubgraph;
+  MutableContainer<Graph *> nodeToSubgraph;
 
   bool nodesHaveCoordinates;
 

--- a/plugins/import/GMLImport.cpp
+++ b/plugins/import/GMLImport.cpp
@@ -282,7 +282,7 @@ struct GMLNodeGraphicsBuilder:public GMLTrue {
     if (st == "fill") {
       // parse color in format #rrggbb
       if (str[0] == '#' && str.length() == 7) {
-        char *c_str = (char *) str.c_str() + 1;
+        char *c_str = const_cast<char *>(str.c_str()) + 1;
 
         for (int i = 0; i < 3; i++, c_str++) {
           unsigned char value = 0;

--- a/plugins/import/ImportPajek.cpp
+++ b/plugins/import/ImportPajek.cpp
@@ -151,7 +151,7 @@ public :
     const char* ptr = str.c_str();
     char* endPtr;
     long int value = strtol(ptr, &endPtr, 10);
-    i = (unsigned int) value;
+    i = uint(value);
     return (value >= 0) && (*endPtr == 0);
   }
 
@@ -159,7 +159,7 @@ public :
     const char* ptr = str.c_str();
     char* endPtr;
     double d = strtod(ptr, &endPtr);
-    f = (float) d;
+    f = float(d);
     return (*endPtr == 0);
   }
 

--- a/plugins/import/ImportUCINET.cpp
+++ b/plugins/import/ImportUCINET.cpp
@@ -45,7 +45,7 @@ bool getUnsignedInt(unsigned int& i, const string& str) {
   const char* ptr = str.c_str();
   char* endPtr;
   long int value = strtol(ptr, &endPtr, 10);
-  i = (unsigned int) value;
+  i = uint(value);
   return (value >= 0) && (*endPtr == 0);
 }
 
@@ -493,7 +493,7 @@ public :
 
       if (nocasecmp(token, "row")) {
         // 'row' found
-        if (embedding & (unsigned int) DL_ROWS) {
+        if (embedding & uint(DL_ROWS)) {
           error << "invalid specification for parameter ROWS";
           return false;
         }
@@ -514,7 +514,7 @@ public :
             return false;
           }
 
-          embedding += (unsigned int) DL_ROWS;
+          embedding += uint(DL_ROWS);
           continue;
         }
 
@@ -537,7 +537,7 @@ public :
       if (nocasecmp(token, "col") ||
           nocasecmp(token, "column")) {
         // 'col' or 'column' found
-        if (embedding & (unsigned int) DL_COLS)
+        if (embedding & uint(DL_COLS))
           return false;
 
         if (!nextToken(str, " \r\t,", token, pos)
@@ -689,7 +689,7 @@ public :
       label->setNodeValue(nodes[offset + current], labels[i]);
       // and memorize the corresponding uppercase label for each node
       std::transform(labels[i].begin(), labels[i].end(),
-                     labels[i].begin(), (int (*) (int)) std::toupper);
+                     labels[i].begin(), static_cast<int (*) (int)>(std::toupper));
       labelsHMap[labels[i]] = nodes[offset + current];
     }
 
@@ -703,7 +703,7 @@ public :
   void checkColumnLabels(vector<std::string>& tokens, unsigned int &ir,
                          unsigned int &ic, unsigned int &i,
                          const vector<node>& nodes) {
-    if (ir == 0 && embedding & (unsigned int) DL_COLS) {
+    if (ir == 0 && embedding & uint(DL_COLS)) {
       StringProperty* label = graph->getProperty<StringProperty>("viewLabel");
 
       // first nc tokens are for labels of the part 1 of the graph
@@ -713,7 +713,7 @@ public :
 
       if (ic == nc) {
         // all columns labels have been read
-        embedding -= (unsigned int) DL_COLS;
+        embedding -= uint(DL_COLS);
         ic = 0;
       }
     }
@@ -734,7 +734,7 @@ public :
 
     string upcasetoken(token);
     transform(token.begin(), token.end(),
-              upcasetoken.begin(), (int (*) (int)) std::toupper);
+              upcasetoken.begin(), static_cast<int (*) (int)>(std::toupper));
 
     if (n/*embedding == DL_ALL*/) { // 1-mode
       TLP_HASH_MAP<std::string, node>::iterator it =

--- a/plugins/import/SmallWorldGraph.cpp
+++ b/plugins/import/SmallWorldGraph.cpp
@@ -99,7 +99,7 @@ public:
     const vector<node>& nodes = graph->nodes();
 
     for (unsigned int i=0; i<nbNodes; ++i) {
-      newLayout->setNodeValue(nodes[i],Coord(static_cast<float>(randomInteger(WIDTH)), static_cast<float>(randomInteger(HEIGHT)), 0));
+      newLayout->setNodeValue(nodes[i],Coord(float(randomInteger(WIDTH)), float(randomInteger(HEIGHT)), 0));
     }
 
     //double minSize = DBL_MAX;
@@ -113,7 +113,7 @@ public:
           //minSize = std::min(distance, minSize);
 
           //newSize->setAllNodeValue(Size(minSize/2.0, minSize/2.0, 1));
-          if ( distance  < (double)maxDistance)
+          if ( distance  < maxDistance)
             graph->addEdge(nodes[i],nodes[j]);
           else if (!longEdge && enableLongEdge) {
             double distrand = randomDouble();

--- a/plugins/import/SocialNetwork/BuWangZhouModel.cpp
+++ b/plugins/import/SocialNetwork/BuWangZhouModel.cpp
@@ -109,13 +109,13 @@ public:
         pr_sum = 0;
 
         for(random_node=0; random_node<nodes[random_type].size() ; random_node++)
-          k_sum += (double)graph->deg(nodes[random_type][random_node]);
+          k_sum += graph->deg(nodes[random_type][random_node]);
 
         pr = tlp::randomDouble();
         random_node = 0;
 
         while (pr_sum<pr && nodes[random_type].size()>(random_node+1)) {
-          pr_sum += (double)graph->deg(nodes[random_type][random_node])/k_sum;
+          pr_sum += graph->deg(nodes[random_type][random_node])/k_sum;
           random_node++;
         }
 

--- a/plugins/import/SocialNetwork/Catanzaro.cpp
+++ b/plugins/import/SocialNetwork/Catanzaro.cpp
@@ -99,7 +99,7 @@ struct Catanzaro:public ImportModule {
       double k_sum = 0;
 
       for(j=0; j<i ; j++) {
-        k_sum += (double)graph->deg(nodes[j]);
+        k_sum += graph->deg(nodes[j]);
       }
 
       for(j=0; j<m ; j++) {
@@ -109,11 +109,11 @@ struct Catanzaro:public ImportModule {
         unsigned int u = 0;
 
         while (pr_sum<pr && u<(i-1)) {
-          pr_sum += (double)graph->deg(nodes[u])/(k_sum+j);
+          pr_sum += graph->deg(nodes[u])/(k_sum+j);
           ++u;
         }
 
-        if(((double)rand()/(double)RAND_MAX)<=p) { // PA
+        if(tlp::randomDouble()<=p) { // PA
           if(!graph->hasEdge(nodes[i],nodes[u], false))
             graph->addEdge(nodes[i],nodes[u]);
         }
@@ -124,7 +124,7 @@ struct Catanzaro:public ImportModule {
 
           for(k=0; k<i ; ++k) {
             for(l=0; l<k ; ++l) {
-              k_sum += ((double)graph->deg(nodes[k])/(k_sum+j)) * exp(-fabs(double(graph->deg(nodes[k]))-double(graph->deg(nodes[l]))));
+              k_sum += graph->deg(nodes[k])/(k_sum+j) * exp(-fabs(double(graph->deg(nodes[k]))-double(graph->deg(nodes[l]))));
             }
           }
 
@@ -132,7 +132,7 @@ struct Catanzaro:public ImportModule {
 
           for(k=0; k<i ; ++k) {
             for(l=0; l<k ; ++l) {
-              pr_sum += ((double)graph->deg(nodes[k])/(k_sum+j)) * exp(-fabs(double(graph->deg(nodes[k]))-double(graph->deg(nodes[l]))));
+              pr_sum += graph->deg(nodes[k])/(k_sum+j) * exp(-fabs(double(graph->deg(nodes[k]))-double(graph->deg(nodes[l]))));
             }
 
             if (pr_sum>pr) {

--- a/plugins/import/SocialNetwork/FuLiao.cpp
+++ b/plugins/import/SocialNetwork/FuLiao.cpp
@@ -94,7 +94,7 @@ struct FuLiao:public ImportModule {
       double k_sum = 0;
 
       for(j=0; j<i ; ++j) {
-        k_sum += (double)graph->deg(nodes[j]);
+        k_sum += graph->deg(nodes[j]);
       }
 
       // add first edge

--- a/plugins/import/SocialNetwork/GuillaumeLatapyModel.cpp
+++ b/plugins/import/SocialNetwork/GuillaumeLatapyModel.cpp
@@ -85,7 +85,7 @@ struct GuillaumeLatapyModel:public ImportModule {
     vector<BottomNode>  vec_bottom_nodes(nbNodes);
     vector<TopNode>   vec_top_nodes(nbNodes);
 
-    unsigned int nbNodesSmallWorld = (unsigned int) ceil(0.8 * nbNodes);
+    unsigned int nbNodesSmallWorld = uint(ceil(0.8 * nbNodes));
     unsigned int nbNodesScaleFree = nbNodes - nbNodesSmallWorld;
     unsigned int maxDegreeSmallWorldNodes = 2;
     unsigned int numberOfEdges = 0;
@@ -102,7 +102,7 @@ struct GuillaumeLatapyModel:public ImportModule {
 
       if (i<nbNodesScaleFree)
         vec_bottom_nodes[i].degree =
-          (unsigned int) ceil((((((double)nbNodes)/2-10)/nbNodesScaleFree/2)*(i+1)));
+          uint(ceil(((nbNodes/2.0-10.0)/nbNodesScaleFree/2)*(i+1)));
       else
         vec_bottom_nodes[i].degree = maxDegreeSmallWorldNodes;
 
@@ -112,7 +112,7 @@ struct GuillaumeLatapyModel:public ImportModule {
 
     unsigned int degreeTop = numberOfEdges/nbNodes;
     unsigned int dixieme =
-      ((unsigned int) ceil((10.0 * numberOfEdges)/nbNodes))%10;
+      uint(ceil((10.0 * numberOfEdges)/nbNodes))%10;
 
     for (i=0; i<nbNodes-1; ++i) {
       if(i%10 >= dixieme)

--- a/plugins/import/SocialNetwork/HolmeKim.cpp
+++ b/plugins/import/SocialNetwork/HolmeKim.cpp
@@ -99,7 +99,7 @@ struct HolmeKim:public ImportModule {
       double k_sum = 0; // degree of present nodes
 
       for(unsigned int j=0; j<i ; ++j)
-        k_sum += (double)graph->deg(nodes[j]);
+        k_sum += graph->deg(nodes[j]);
 
       double proba = tlp::randomDouble();
 
@@ -110,7 +110,7 @@ struct HolmeKim:public ImportModule {
         double firstNeighbour = 0;
 
         while (pr_sum < pr && firstNeighbour <= i) {
-          pr_sum += (double)graph->deg(nodes[firstNeighbour])/(k_sum);
+          pr_sum += graph->deg(nodes[firstNeighbour])/k_sum;
           ++firstNeighbour;
         }
 
@@ -145,7 +145,7 @@ struct HolmeKim:public ImportModule {
         unsigned int rn = 0;
 
         while (pr_sum<pr && rn<(i-1)) {
-          pr_sum += (double)graph->deg(nodes[rn])/(k_sum);
+          pr_sum += graph->deg(nodes[rn])/k_sum;
           ++rn;
         }
 

--- a/plugins/import/SocialNetwork/LiuEtAl.cpp
+++ b/plugins/import/SocialNetwork/LiuEtAl.cpp
@@ -89,7 +89,7 @@ struct LiuEtAl:public ImportModule {
       double k_sum = 0;
 
       for(j=0; j<i ; ++j) {
-        k_sum += (double)graph->deg(nodes[j]);
+        k_sum += graph->deg(nodes[j]);
       }
 
       /*
@@ -101,7 +101,7 @@ struct LiuEtAl:public ImportModule {
         unsigned int rn = 0;
 
         while (pr_sum<pr && rn<(i-1)) {
-          pr_sum += (double)graph->deg(nodes[rn])/(k_sum+j);
+          pr_sum += graph->deg(nodes[rn])/(k_sum+j);
           ++rn;
         }
 
@@ -114,7 +114,7 @@ struct LiuEtAl:public ImportModule {
         double k2_sum = 0;
         node n;
         forEach(n, graph->getInOutNodes(nodes[rn])) {
-          k2_sum += (double)graph->deg(n);
+          k2_sum += graph->deg(n);
         }
         pr = tlp::randomDouble();
         pr_sum = 0;
@@ -123,7 +123,7 @@ struct LiuEtAl:public ImportModule {
 
         while(it->hasNext() && pr_sum<pr) {
           v = it->next();
-          pr_sum += (double)graph->deg(v)/(k2_sum);
+          pr_sum += graph->deg(v)/k2_sum;
         }
 
         delete it;

--- a/plugins/import/SocialNetwork/WangRong.cpp
+++ b/plugins/import/SocialNetwork/WangRong.cpp
@@ -126,7 +126,7 @@ struct WangRong:public ImportModule {
         unsigned int rn = 0;
 
         while (pr_sum<pr && rn<(nbNodes-1)) {
-          pr_sum += (double)graph->deg(nodes[rn])/k_sum;
+          pr_sum += graph->deg(nodes[rn])/k_sum;
           ++rn;
         }
 

--- a/plugins/import/dotImport.cpp
+++ b/plugins/import/dotImport.cpp
@@ -30,10 +30,17 @@ using namespace tlp;
 #include <utf8.h>
 #endif
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 namespace {
 #include "dotImportParser.h"
 #include "dotImportLexer.h"
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 static const char *paramHelp[] = {
   // filename

--- a/plugins/import/dotImportCLUT.h
+++ b/plugins/import/dotImportCLUT.h
@@ -754,7 +754,8 @@ bool DecodeColor  ( tlp::Color        & outColor,
     int n = sscanf( inValue.c_str(), "%f,%f,%f", &r, &g, &b );
 
     if( n == 3 ) {
-      outColor = tlp::Color((unsigned int)(r*255.0f),(unsigned int)(g*255.0f),(unsigned int)(b*255.0f));
+      outColor = tlp::Color(uchar(r*255.0f),uchar(g*255.0f),
+                            uchar(b*255.0f));
       return true;
     }
   }
@@ -765,7 +766,8 @@ bool DecodeColor  ( tlp::Color        & outColor,
     int n = sscanf( inValue.c_str(), "%f %f %f", &r, &g, &b );
 
     if( n == 3 ) {
-      outColor = tlp::Color((unsigned int)(r*255.0f),(unsigned int)(g*255.0f),(unsigned int)(b*255.0f));
+      outColor = tlp::Color(uchar(r*255.0f), uchar(g*255.0f),
+                            uchar(b*255.0f));
       return true;
     }
   }
@@ -781,7 +783,8 @@ bool DecodeColor  ( tlp::Color        & outColor,
                   float(X11Clut[i].s)/255.0f,
                   float(X11Clut[i].b)/255.0f,
                   r, g ,b );
-        outColor = tlp::Color((unsigned int)(r),(unsigned int)(g),(unsigned int)(b));
+        outColor = tlp::Color(uchar(r), uchar(g),
+                              uchar(b));
         return true;
       }
     }

--- a/plugins/interactor/FishEye/FishEyeConfigWidget.cpp
+++ b/plugins/interactor/FishEye/FishEyeConfigWidget.cpp
@@ -44,7 +44,7 @@ int FishEyeConfigWidget::getFishEyeType() const {
 }
 
 float FishEyeConfigWidget::getFishEyeRadius() const {
-  return (float) _ui->radiusValSP->value();
+  return float(_ui->radiusValSP->value());
 }
 
 void FishEyeConfigWidget::setFishEyeRadius(const float radius) {
@@ -52,7 +52,7 @@ void FishEyeConfigWidget::setFishEyeRadius(const float radius) {
 }
 
 float FishEyeConfigWidget::getFishEyeHeight() const {
-  return (float) _ui->heightValSP->value();
+  return float(_ui->heightValSP->value());
 }
 
 void FishEyeConfigWidget::setFishEyeHeight(const float height) {
@@ -60,9 +60,9 @@ void FishEyeConfigWidget::setFishEyeHeight(const float height) {
 }
 
 float FishEyeConfigWidget::getFishEyeRadiusIncrementStep() const {
-  return (float) _ui->radiusIncrementStepSP->value();
+  return float(_ui->radiusIncrementStepSP->value());
 }
 
 float FishEyeConfigWidget::getFishEyeHeightIncrementStep() const {
-  return (float) _ui->heightIncrementStepSP->value();
+  return float(_ui->heightIncrementStepSP->value());
 }

--- a/plugins/interactor/FishEye/FishEyeInteractor.cpp
+++ b/plugins/interactor/FishEye/FishEyeInteractor.cpp
@@ -119,7 +119,7 @@ void FishEyeInteractorComponent::viewChanged(View *view) {
     return;
   }
 
-  GlMainView *glView = (GlMainView *) view;
+  GlMainView *glView = static_cast<GlMainView *>(view);
   GlMainWidget *glWidget = glView->getGlMainWidget();
 
   if (!glWidget->hasMouseTracking()) {
@@ -134,7 +134,7 @@ void FishEyeInteractorComponent::viewChanged(View *view) {
 
 bool FishEyeInteractorComponent::eventFilter(QObject *obj, QEvent *e) {
 
-  GlMainWidget *glWidget = (GlMainWidget*)obj;
+  GlMainWidget *glWidget = static_cast<GlMainWidget*>(obj);
   Camera *camera=&glWidget->getScene()->getGraphCamera();
 
   activateFishEye = false;
@@ -143,7 +143,7 @@ bool FishEyeInteractorComponent::eventFilter(QObject *obj, QEvent *e) {
       e->type() == QEvent::MouseButtonPress ||
       e->type() == QEvent::MouseButtonRelease) {
     activateFishEye = true;
-    QMouseEvent *me = (QMouseEvent *) e;
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
     float x = glWidget->width() - me->x();
     float y = me->y();
     Coord screenCoords(x, y, 0);
@@ -153,7 +153,7 @@ bool FishEyeInteractorComponent::eventFilter(QObject *obj, QEvent *e) {
   }
   else if (e->type() == QEvent::Wheel) {
     activateFishEye = true;
-    QWheelEvent *wheelEvent = (QWheelEvent *) e;
+    QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(e);
     int numSteps = wheelEvent->delta() / 120;
 
     if (wheelEvent->orientation() == Qt::Vertical && (wheelEvent->modifiers() == Qt::ControlModifier)) {

--- a/plugins/interactor/MouseLassoNodesSelector/MouseLassoNodesSelector.cpp
+++ b/plugins/interactor/MouseLassoNodesSelector/MouseLassoNodesSelector.cpp
@@ -99,10 +99,10 @@ void MouseLassoNodesSelectorInteractorComponent::selectGraphElementsUnderPolygon
 
   polygonVprt.push_back(polygon[0]);
 
-  int xStart = (int) polygonVprtBB[0][0];
-  int yStart = (int) polygonVprtBB[0][1];
-  int xEnd = (int) polygonVprtBB[1][0];
-  int yEnd = (int) polygonVprtBB[1][1];
+  int xStart = int(polygonVprtBB[0][0]);
+  int yStart = int(polygonVprtBB[0][1]);
+  int xEnd = int(polygonVprtBB[1][0]);
+  int yEnd = int(polygonVprtBB[1][1]);
 
   vector<SelectedEntity> tmpNodes;
   vector<SelectedEntity> tmpEdges;

--- a/plugins/interactor/MouseMagnifyingGlass/MouseMagnifyingGlass.cpp
+++ b/plugins/interactor/MouseMagnifyingGlass/MouseMagnifyingGlass.cpp
@@ -90,7 +90,7 @@ bool MouseMagnifyingGlassInteractorComponent::eventFilter(QObject *, QEvent *e) 
     updateMagnifyingGlass = true;
   }
   else if (e->type() == QEvent::Wheel) {
-    QWheelEvent *wheelEvent = (QWheelEvent *) e;
+    QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(e);
     float x = glWidget->width() - wheelEvent->x();
     float y = wheelEvent->y();
     screenCoords = Coord(x, y, 0);
@@ -139,7 +139,7 @@ void MouseMagnifyingGlassInteractorComponent::generateMagnifyingGlassTexture(con
     antialiased = true;
   }
 
-  int fboSize = static_cast<int>(radius * 2);
+  int fboSize = int(radius * 2);
 
   // instantiate fbo if needed
   if (fbo == NULL) {

--- a/plugins/interactor/NeighborhoodHighlighter/NeighborhoodHighlighterInteractor.cpp
+++ b/plugins/interactor/NeighborhoodHighlighter/NeighborhoodHighlighterInteractor.cpp
@@ -63,7 +63,7 @@ public :
     forEach(n, graph->getNodes()) {
       const Coord &startPos = srcLayout->getNodeValue(n);
       const Coord &endPos = destLayout->getNodeValue(n);
-      viewLayout->setNodeValue(n, startPos + (animationStep / static_cast<float>(nbAnimationSteps) * (endPos - startPos)));
+      viewLayout->setNodeValue(n, startPos + (animationStep / float(nbAnimationSteps) * (endPos - startPos)));
     }
 
     edge e;
@@ -73,7 +73,7 @@ public :
       vector<Coord> newBends;
 
       for (size_t i = 0 ; i < destBends.size() ; ++i) {
-        newBends.push_back(srcBends[i] + (animationStep / static_cast<float>(nbAnimationSteps) * (destBends[i] - srcBends[i])));
+        newBends.push_back(srcBends[i] + (animationStep / float(nbAnimationSteps) * (destBends[i] - srcBends[i])));
       }
 
       viewLayout->setEdgeValue(e, newBends);
@@ -595,7 +595,7 @@ void NeighborhoodHighlighter::morphCircleAlpha(unsigned char startA, unsigned en
 }
 
 void NeighborhoodHighlighter::morphCircleAlphaAnimStep(int animStep) {
-  circleAlphaValue = static_cast<unsigned char>(startAlpha + animStep/static_cast<float>(nbAnimSteps) * (endAlpha - startAlpha));
+  circleAlphaValue = uchar(startAlpha + animStep/float(nbAnimSteps) * (endAlpha - startAlpha));
   glWidget->redraw();
 }
 

--- a/plugins/interactor/PathFinder/PathFinder.cpp
+++ b/plugins/interactor/PathFinder/PathFinder.cpp
@@ -199,10 +199,7 @@ void PathFinder::configureHighlighterButtonPressed() {
    * Each highlighter has it's own configuration widget.
    * We build a QDialog and integrate this widget into it to display highlighter-specific configuration to the user.
    */
-  QListWidget *listWidget = dynamic_cast<QListWidget *> (highlightersListWidget->findChild<QListWidget *> ("listWidget"));
-
-  if (!listWidget)
-    return;
+  QListWidget *listWidget = static_cast<QListWidget *> (highlightersListWidget->findChild<QListWidget *> ("listWidget"));
 
   QList<QListWidgetItem *> lst = listWidget->selectedItems();
   string text("");

--- a/plugins/interactor/PathFinder/PathFinderComponent.cpp
+++ b/plugins/interactor/PathFinder/PathFinderComponent.cpp
@@ -216,6 +216,6 @@ QSet<PathHighlighter *> PathFinderComponent::getHighlighters() {
 }
 
 void PathFinderComponent::clear() {
-  GlMainView *glMainView=dynamic_cast<GlMainView*>(view());
+  GlMainView *glMainView=static_cast<GlMainView*>(view());
   glMainView->getGlMainWidget()->setCursor(QCursor());
 }

--- a/plugins/layout/BubblePack.cpp
+++ b/plugins/layout/BubblePack.cpp
@@ -188,7 +188,7 @@ double BubblePack::computeRelativePosition(tlp::node n, NodeStaticProperty<Vec4f
 
             for (unsigned int k=0; k<placed.size(); ++k) {
               if(placed[k].dist(tmp) < placed[k].radius + tmp.radius) {
-                spiralRadius = std::max(spiralRadius, (double) placed[k].norm() + placed[k].radius + radius + 1E-3 );
+                spiralRadius = std::max(spiralRadius, double(placed[k].norm()) + placed[k].radius + radius + 1E-3 );
                 //spiralRadius += 0.01;
                 tmp = Circled(spiralRadius * cos(_angle), spiralRadius * sin(_angle), radius );
                 //restart = true;

--- a/plugins/layout/BubbleTree.cpp
+++ b/plugins/layout/BubbleTree.cpp
@@ -236,8 +236,8 @@ void BubbleTree::calcLayout2(tlp::node n, tlp::Vector<double, 5 >&nrPos,
   rot2[2]=0.;
   zeta = rot1*zeta[0] + rot2*zeta[1];
 
-  result->setNodeValue(n, Coord(static_cast<float>(enclosingCircleCenter[0]+zeta[0]),
-                                static_cast<float>(enclosingCircleCenter[1]+zeta[1]),
+  result->setNodeValue(n, Coord(float(enclosingCircleCenter[0]+zeta[0]),
+                                float(enclosingCircleCenter[1]+zeta[1]),
                                 0.) );
 
   /*
@@ -257,7 +257,7 @@ void BubbleTree::calcLayout2(tlp::node n, tlp::Vector<double, 5 >&nrPos,
       edge ite=itE->next();
       delete itE;
       vector<Coord>tmp(1);
-      tmp[0] = Coord(static_cast<float>(bend[0]), static_cast<float>(bend[1]), 0.);
+      tmp[0] = Coord(float(bend[0]), float(bend[1]), 0.);
       result->setEdgeValue(ite,tmp);
     }
   }

--- a/plugins/layout/ConeTreeExtended.cpp
+++ b/plugins/layout/ConeTreeExtended.cpp
@@ -110,19 +110,19 @@ double ConeTreeExtended::treePlace3D(tlp::node n,
 
   for (unsigned int i=0; i<subCircleRadius.size()-1; ++i) {
     for (unsigned int j=i+1; j<subCircleRadius.size(); ++j) {
-      newRadius = std::max(newRadius , minRadius(static_cast<float>(subCircleRadius[i]),static_cast<float>(vangles[i]),static_cast<float>(subCircleRadius[j]),static_cast<float>(vangles[j])));
+      newRadius = std::max(newRadius , minRadius(float(subCircleRadius[i]),float(vangles[i]),float(subCircleRadius[j]),float(vangles[j])));
     }
   }
 
-  if (newRadius==0) newRadius=static_cast<float>(radius);
+  if (newRadius==0) newRadius=float(radius);
 
   //compute Circle Hull
   vector<Circlef > circles(subCircleRadius.size());
 
   for (unsigned int i=0; i<subCircleRadius.size(); ++i) {
-    circles[i][0]=newRadius*static_cast<float>(cos(vangles[i]));
-    circles[i][1]=newRadius*static_cast<float>(sin(vangles[i]));
-    circles[i].radius=static_cast<float>(subCircleRadius[i]);
+    circles[i][0]=newRadius*float(cos(vangles[i]));
+    circles[i][1]=newRadius*float(sin(vangles[i]));
+    circles[i].radius=float(subCircleRadius[i]);
   }
 
   tlp::Circlef circleH=tlp::enclosingCircle(circles);
@@ -143,7 +143,7 @@ double ConeTreeExtended::treePlace3D(tlp::node n,
 void ConeTreeExtended::calcLayout(tlp::node n, TLP_HASH_MAP<tlp::node,double> *px,
                                   TLP_HASH_MAP<tlp::node,double> *py,
                                   double x, double y, int level) {
-  result->setNodeValue(n,Coord(static_cast<float>(x+(*px)[n]), - static_cast<float>(yCoordinates[level]),static_cast<float>(y+(*py)[n])));
+  result->setNodeValue(n,Coord(float(x+(*px)[n]), - float(yCoordinates[level]),float(y+(*py)[n])));
   node itn;
   forEach(itn, tree->getOutNodes(n)) {
     calcLayout(itn, px, py, x+(*px)[n], y+(*py)[n], level + 1);

--- a/plugins/layout/FastOverlapRemoval/FastOverlapRemoval.cpp
+++ b/plugins/layout/FastOverlapRemoval/FastOverlapRemoval.cpp
@@ -126,7 +126,7 @@ bool FastOverlapRemoval::run () {
     // size initialization
     forEach(n, graph->getNodes())
     size.setNodeValue(n, viewSize->getNodeValue(n) *
-                      passIndex/(float)nbPasses);
+                      passIndex/float(nbPasses));
 
     //actually apply fast overlap removal
     vector<vpsc::Rectangle *>nodeRectangles (graph->numberOfNodes());

--- a/plugins/layout/FastOverlapRemoval/PairingHeap.cpp
+++ b/plugins/layout/FastOverlapRemoval/PairingHeap.cpp
@@ -251,7 +251,7 @@ PairingHeap<T>::combineSiblings( PairNode<T> *firstSibling ) const {
   int numSiblings = 0;
 
   for( ; firstSibling != NULL; numSiblings++ ) {
-    if( numSiblings == (int)treeArray.size( ) )
+    if( numSiblings == int(treeArray.size( )) )
       treeArray.resize( numSiblings * 2 );
 
     treeArray[ numSiblings ] = firstSibling;
@@ -259,7 +259,7 @@ PairingHeap<T>::combineSiblings( PairNode<T> *firstSibling ) const {
     firstSibling = firstSibling->nextSibling;
   }
 
-  if( numSiblings == (int)treeArray.size( ) )
+  if( numSiblings == int(treeArray.size( ) ))
     treeArray.resize( numSiblings + 1 );
 
   treeArray[ numSiblings ] = NULL;

--- a/plugins/layout/FastOverlapRemoval/generate-constraints.cpp
+++ b/plugins/layout/FastOverlapRemoval/generate-constraints.cpp
@@ -158,8 +158,8 @@ NodeSet* getRightNeighbours(NodeSet &scanline,Node *v) {
 }
 
 int compare_events(const void *a, const void *b) {
-  Event *ea=*(Event**)a;
-  Event *eb=*(Event**)b;
+  const Event *ea=*(static_cast<const Event * const *>(a));
+  const Event *eb=*(static_cast<const Event * const *>(b));
 
   if(ea->v->r==eb->v->r) {
     // when comparing opening and closing from the same rect
@@ -199,7 +199,7 @@ int ConstraintsGenerator::generateXConstraints(Rectangle** rs, Variable** vars, 
     events[ctr++]=new Event(Close,v,rs[i]->getMaxY());
   }
 
-  qsort((Event*)events, (size_t)2*n, sizeof(Event*), compare_events );
+  qsort(reinterpret_cast<Event*>(events), static_cast<size_t>(2*n), sizeof(Event*), compare_events );
 
   NodeSet scanline;
   vector<Constraint*> constraints;
@@ -299,7 +299,7 @@ int ConstraintsGenerator::generateYConstraints(Rectangle** rs, Variable** vars, 
     events[ctr++] = new Event(Close,v,rs[i]->getMaxX());
   }
 
-  qsort((Event*)events, (size_t)2*n, sizeof(Event*), compare_events );
+  qsort(reinterpret_cast<Event*>(events), static_cast<size_t>(2*n), sizeof(Event*), compare_events );
   NodeSet scanline;
   vector<Constraint*> constraints;
 

--- a/plugins/layout/FastOverlapRemoval/variable.h
+++ b/plugins/layout/FastOverlapRemoval/variable.h
@@ -46,7 +46,7 @@ public:
   }
 
   size_t id() const {
-    return (size_t) this;
+    return reinterpret_cast<size_t>(this);
   }
 };
 }

--- a/plugins/layout/GEMLayout.cpp
+++ b/plugins/layout/GEMLayout.cpp
@@ -133,7 +133,7 @@ Coord GEMLayout::computeForces(unsigned int v,
 
   //Init force in a random position
   for (unsigned int cnt = 0; cnt<_dim; ++cnt) {
-    force[cnt] =  shake  - static_cast<float>(randomDouble(2. * shake));
+    force[cnt] =  shake  - float(randomDouble(2. * shake));
   }
 
   //Add central force
@@ -142,7 +142,7 @@ Coord GEMLayout::computeForces(unsigned int v,
   double  maxEdgeLength;
 
   if (_useLength)
-    maxEdgeLength = std::max(2.0f, (float)metric->getEdgeDoubleMin());
+    maxEdgeLength = std::max(2.0, metric->getEdgeDoubleMin());
   else
     maxEdgeLength = EDGELENGTH;
 
@@ -155,7 +155,7 @@ Coord GEMLayout::computeForces(unsigned int v,
       float n = d[0]*d[0] + d[1]*d[1] + d[2]*d[2]; //d.norm() * d.norm();
 
       if (n > 0.)
-        force += d * (float)maxEdgeLength / n;
+        force += d * float(maxEdgeLength) / n;
     }
   }
 
@@ -174,14 +174,14 @@ Coord GEMLayout::computeForces(unsigned int v,
       float edgeLength;
 
       if (_useLength)
-        edgeLength = static_cast<float>(metric->getEdgeDoubleValue(e));
+        edgeLength = float(metric->getEdgeDoubleValue(e));
       else
         edgeLength = EDGELENGTH;
 
       Coord d(vPos - gemQ->pos);
       float n = d.norm() / vMass;
       n = std::min(n, MAXATTRACT);  //   1048576L
-      force -= (d * n) / (float)(edgeLength * edgeLength + 1.);
+      force -= (d * n) / (edgeLength * edgeLength + 1.f);
     }
   }
   return force;
@@ -260,7 +260,7 @@ void GEMLayout::insert() {
       }
 
       if (d > 1) {
-        gemP->pos /= static_cast<float>(d);
+        gemP->pos /= float(d);
       }
 
       d = 0;
@@ -323,7 +323,7 @@ void GEMLayout::arrange() {
   double  maxEdgeLength;
 
   if (_useLength)
-    maxEdgeLength = std::max(2.0f, (float)metric->getEdgeDoubleMin());
+    maxEdgeLength = std::max(2.0, metric->getEdgeDoubleMin());
   else
     maxEdgeLength = EDGELENGTH;
 
@@ -334,7 +334,7 @@ void GEMLayout::arrange() {
   _oscillation      = a_oscillation;
   _rotation         = a_rotation;
   _maxtemp          = a_maxtemp;
-  stop_temperature  = static_cast<float>(a_finaltemp * a_finaltemp * maxEdgeLength * _nbNodes);
+  stop_temperature  = float(a_finaltemp * a_finaltemp * maxEdgeLength * _nbNodes);
   Iteration         = 0;
 
   while (_temperature > stop_temperature && Iteration < max_iter) {
@@ -411,7 +411,7 @@ bool GEMLayout::run() {
   node n;
   unsigned int i = 0;
   forEach(n, graph->getNodes()) {
-    _particules[i] = GEMparticule(static_cast<float>(graph->deg(n)));
+    _particules[i] = GEMparticule(float(graph->deg(n)));
     _particules[i].n = n;
     _particules[i].id = i;
 

--- a/plugins/layout/Grip/Grip.cpp
+++ b/plugins/layout/Grip/Grip.cpp
@@ -168,9 +168,9 @@ void Grip::firstNodesPlacement() {
   node n2 = misf->ordering[1];
   node n3 = misf->ordering[2];
 
-  float d12 = (float) getDist(currentGraph,n1,n2);
-  float d13 = (float) getDist(currentGraph,n1,n3);
-  float d23 = (float) getDist(currentGraph,n2,n3);
+  float d12 = getDist(currentGraph,n1,n2);
+  float d13 = getDist(currentGraph,n1,n3);
+  float d23 = getDist(currentGraph,n2,n3);
 
   result->setNodeValue(n1,Coord(0,0,0));
   result->setNodeValue(n2,Coord(d12,0,0));
@@ -189,7 +189,7 @@ void Grip::firstNodesPlacement() {
     g->addNode(n1);
     g->addNode(n2);
     g->addNode(n3);
-    result->rotateX(3.14159/2. - (3.14159 * (double)(randomInteger(1))), g->getNodes(), g->getEdges());
+    result->rotateX(3.14159/2. - (3.14159 * randomInteger(1)), g->getNodes(), g->getEdges());
     currentGraph->delSubGraph(g);
 
     const Coord& c1 = result->getNodeValue(n1);
@@ -202,16 +202,16 @@ void Grip::firstNodesPlacement() {
 
   neighbors[n1].push_back(n2);
   neighbors[n1].push_back(n3);
-  neighbors_dist[n1].push_back((unsigned int)d12);
-  neighbors_dist[n1].push_back((unsigned int)d13);
+  neighbors_dist[n1].push_back(uint(d12));
+  neighbors_dist[n1].push_back(uint(d13));
   neighbors[n2].push_back(n1);
   neighbors[n2].push_back(n3);
-  neighbors_dist[n2].push_back((unsigned int)d12);
-  neighbors_dist[n2].push_back((unsigned int)d23);
+  neighbors_dist[n2].push_back(uint(d12));
+  neighbors_dist[n2].push_back(uint(d23));
   neighbors[n3].push_back(n1);
   neighbors[n3].push_back(n2);
-  neighbors_dist[n3].push_back((unsigned int)d13);
-  neighbors_dist[n3].push_back((unsigned int)d23);
+  neighbors_dist[n3].push_back(uint(d13));
+  neighbors_dist[n3].push_back(uint(d23));
 
 }
 //======================================================
@@ -269,7 +269,7 @@ void Grip::initialPlacement(unsigned int start, unsigned int end) {
     }
 
     double alpha = edgeLength / 6.0 * randomDouble();
-    Coord  alea  = Coord(alpha - (2. * alpha* (double)(randomInteger(1))), alpha - (2. * alpha * double(randomInteger(1))), (alpha - (2. * alpha* (double)(randomInteger(1)))));
+    Coord  alea  = Coord(alpha - (2. * alpha * randomInteger(1)), alpha - (2. * alpha * randomInteger(1)), (alpha - (2. * alpha* randomInteger(1))));
 
     if(_dim == 2) alea[2] = 0.;
 
@@ -300,7 +300,7 @@ void Grip::kk_local_reffinement(node currNode) {
 
       if(_dim == 3) euclidian_dist_sqr += c_tmp[2] * c_tmp[2];
 
-      float th_dist = (float)neighbors_dist[currNode][j];
+      float th_dist = neighbors_dist[currNode][j];
       c_tmp *=  (euclidian_dist_sqr / (th_dist * th_dist * edgeLength * edgeLength))-1.;
       disp[currNode] += c_tmp;
     }
@@ -317,7 +317,7 @@ void Grip::displace(node n) {
   if(disp_norm > 1E-4) {
     disp[n]    /= disp_norm;
     oldDisp[n] = disp[n];
-    disp[n]    *= (float) heat[n];
+    disp[n]    *= float(heat[n]);
     result->setNodeValue(n, result->getNodeValue(n) + disp[n]);
   }
 }
@@ -340,7 +340,7 @@ void Grip::kk_reffinement(unsigned int start, unsigned int end) {
 
         if(_dim == 3) euclidian_dist_sqr += c_tmp[2] * c_tmp[2];
 
-        float th_dist = (float)neighbors_dist[currNode][j];
+        float th_dist = neighbors_dist[currNode][j];
         c_tmp *= (euclidian_dist_sqr / (th_dist * th_dist * edgeLength * edgeLength))-1.;
         disp[currNode] +=  c_tmp;
       }
@@ -375,7 +375,7 @@ void Grip::fr_reffinement(unsigned int start, unsigned int end) {
 
         if(_dim == 3) euclidian_dist_sqr += c_tmp[2] * c_tmp[2];
 
-        c_tmp *= euclidian_dist_sqr/((float) edgeLength * (float) edgeLength);
+        c_tmp *= euclidian_dist_sqr/(edgeLength * edgeLength);
         disp[currNode] += c_tmp;
       }
 
@@ -384,20 +384,21 @@ void Grip::fr_reffinement(unsigned int start, unsigned int end) {
         node  n     = neighbors[currNode][j];
         const Coord& c_n   = result->getNodeValue(n);
         Coord c_tmp = curCoord - c_n;
-        double euclidian_dist_sqr = (double)c_tmp[0] * (double)c_tmp[0] + (double)c_tmp[1] * (double)c_tmp[1];
+        double euclidian_dist_sqr = double(c_tmp[0]) * double(c_tmp[0]) +
+                                    double(c_tmp[1]) * double(c_tmp[1]);
 
         if(_dim == 3) euclidian_dist_sqr += c_tmp[2] * c_tmp[2];
 
         if(!(euclidian_dist_sqr > 1E-4)) {
           double alpha = randomDouble(2.0);
-          c_tmp = Coord (alpha - (2. * alpha* (double)(randomInteger(1))),alpha -(2. * alpha * double(randomInteger(1))),alpha - (2. * alpha* (double)(randomInteger(1))));
+          c_tmp = Coord (alpha - (2. * alpha * randomInteger(1)),alpha -(2. * alpha * randomInteger(1)),alpha - (2. * alpha * randomInteger(1)));
 
           if(_dim == 2) c_tmp[2] = 0.;
 
           euclidian_dist_sqr = 0.01;
         }
 
-        c_tmp *= (0.05 * edgeLength * edgeLength) /(float)euclidian_dist_sqr;
+        c_tmp *= (0.05f * edgeLength * edgeLength) / float(euclidian_dist_sqr);
         disp[currNode] +=  c_tmp;
       }
     }
@@ -419,8 +420,8 @@ void Grip::updateLocalTemp(node v) {
 
   if(curDisp_norm * oldDisp_norm > 1E-4) {
 
-    double scalar = (double) disp[v].dotProduct(oldDisp[v]);
-    double cos = (double) scalar /(curDisp_norm * oldDisp_norm);
+    double scalar = disp[v].dotProduct(oldDisp[v]);
+    double cos = scalar /(curDisp_norm * oldDisp_norm);
 
     Coord tmp1 = oldDisp[v] / oldDisp_norm;
     Coord tmp2 = disp[v] / curDisp_norm;
@@ -447,8 +448,8 @@ unsigned int Grip::rounds(unsigned int x, unsigned int max, unsigned int maxVal,
   if( x <= max )
     return maxVal;
   else if( max <= x && x <= min ) {
-    double k = -log((double)minVal/maxVal)/min;
-    return (unsigned int )(ceil(maxVal * exp( -k * x )));
+    double k = -log(minVal/double(maxVal))/min;
+    return uint(ceil(maxVal * exp( -k * x )));
   }
   else
     return minVal;
@@ -463,7 +464,7 @@ void Grip::init() {
   double diam = sqrt(currentGraph->numberOfNodes());
   node n;
   forEach(n,currentGraph->getNodes()) {
-    Coord  alea  = Coord(diam - (2. * diam * (double)(randomInteger(1))), diam - (2. * diam * double(randomInteger(1))), diam - (2. * diam * double(randomInteger(1))));
+    Coord  alea  = Coord(diam - (2. * diam * randomInteger(1)), diam - (2. * diam * randomInteger(1)), diam - (2. * diam * randomInteger(1)));
 
     if(_dim == 2) alea[2] = 0.;
 
@@ -490,44 +491,44 @@ void Grip::set_nbr_size() {
   forEach(n,currentGraph->getNodes())
   maxCxty += currentGraph->deg(n);
 
-  if(maxCxty < (unsigned int)initCxty)
+  if(maxCxty < uint(initCxty))
     maxCxty = initCxty;
 
   for(unsigned int i = 1; i < misf->index.size() ; ++i) {
-    if((int)(misf->index[i] * misf->index[i]) - initCxty >= 0) {
+    if(int(misf->index[i] * misf->index[i]) - initCxty >= 0) {
       maxLevel = i;
       break;
     }
   }
 
-  if(maxLevel == 0 &&  (int)(currentGraph->numberOfNodes() * currentGraph->numberOfNodes()) - initCxty >= 0)
+  if(maxLevel == 0 &&  int(currentGraph->numberOfNodes() * currentGraph->numberOfNodes()) - initCxty >= 0)
     maxLevel = misf->index.size();
 
 
   for(unsigned int i = 1; i < misf->index.size() ; ++i) {
     if( i >= maxLevel)
-      levelToNbNeighbors[i] =  min((unsigned int)(sched(misf->index.size()-i,0,2,10000,1) * maxCxty/(misf->index[i])),  (unsigned int)(misf->index[i]-1));
+      levelToNbNeighbors[i] =  min(uint(sched(misf->index.size()-i,0,2,10000,1) * maxCxty/(misf->index[i])),  uint(misf->index[i]-1));
     else
-      levelToNbNeighbors[i] = max(misf->index[i]-1, (unsigned int) 3);
+      levelToNbNeighbors[i] = max(misf->index[i]-1, 3u);
   }
 
 
   if( misf->index.size() >= maxLevel)
-    levelToNbNeighbors[misf->index.size()] =  min((unsigned int)(sched(currentGraph->numberOfNodes(),0,2,10000,1) * (float)maxCxty/((float)currentGraph->numberOfNodes())), (unsigned int)(currentGraph->numberOfNodes()-1));
+    levelToNbNeighbors[misf->index.size()] =  min(uint(sched(currentGraph->numberOfNodes(),0,2,10000,1) * maxCxty/(float(currentGraph->numberOfNodes()))), uint(currentGraph->numberOfNodes()-1));
   else
-    levelToNbNeighbors[misf->index.size()] = max(currentGraph->numberOfNodes()-1, (unsigned int) 3);
+    levelToNbNeighbors[misf->index.size()] = max(currentGraph->numberOfNodes()-1, 3u);
 
   levelToNbNeighbors[misf->index.size()] = min(2*levelToNbNeighbors[misf->index.size()], currentGraph->numberOfNodes()-1);
 }
 //======================================================
 float Grip::sched(int x, int max, int maxVal, int min, int minVal) {
   if( x <= max )
-    return (float)maxVal;
+    return maxVal;
   else if( max <= x && x <= min ) {
-    return ((minVal - maxVal)/(float)(min-max))*(x - max) + maxVal;
+    return ((minVal - maxVal)/float(min-max))*(x - max) + maxVal;
   }
   else
-    return (float)minVal;
+    return minVal;
 }
 //======================================================
 PLUGIN(Grip)

--- a/plugins/layout/Grip/MISFiltering.cpp
+++ b/plugins/layout/Grip/MISFiltering.cpp
@@ -60,7 +60,7 @@ void MISFiltering::computeFiltering() {
     inCurVi.setAll(false);
     inCurVi.set(firstNode.id,true);
 
-    unsigned int depth = (unsigned int) 2 << (level - 1);
+    unsigned int depth = 2u << (level - 1u);
 
     for(unsigned int i = 0; i < toVisit.size() ; ++i) {
       node current = toVisit[i];

--- a/plugins/layout/LinLog/LinLogLayout.cpp
+++ b/plugins/layout/LinLog/LinLogLayout.cpp
@@ -556,9 +556,9 @@ bool LinLogLayout::minimizeEnergyNoTree (int nrIterations) {
       else if (step <= 0.9*nrIterations) {
         // gradually move to final energy model
         attrExponent += 1.1 * (1.0 - finalRepuExponent)
-                        * (0.9 - ((double)step)/nrIterations) / 0.3;
+                        * (0.9 - (step/double(nrIterations))) / 0.3;
         repuExponent += 0.9 * (1.0 - finalRepuExponent)
-                        * (0.9 - ((double)step)/nrIterations) / 0.3;
+                        * (0.9 - (step/double(nrIterations))) / 0.3;
       }
     }
 
@@ -678,9 +678,9 @@ bool LinLogLayout::minimizeEnergy (int nrIterations) {
       else if (step <= 0.9*nrIterations) {
         // gradually move to final energy model
         attrExponent += 1.1 * (1.0 - finalRepuExponent)
-                        * (0.9 - ((double)step)/nrIterations) / 0.3;
+                        * (0.9 - (step/double(nrIterations))) / 0.3;
         repuExponent += 0.9 * (1.0 - finalRepuExponent)
-                        * (0.9 - ((double)step)/nrIterations) / 0.3;
+                        * (0.9 - (step/double(nrIterations))) / 0.3;
       }
     }
 

--- a/plugins/layout/MixedModel.cpp
+++ b/plugins/layout/MixedModel.cpp
@@ -154,16 +154,16 @@ bool MixedModel::run() {
         if(e.isValid()) {
           vector<Coord> bends(2);
           bends.clear();
-          unsigned int max = (unsigned int) (c[1]>c2[1]? c[1]/2 : c2[1]/2);
-          max += (unsigned int) edgeNodeSpacing;
+          unsigned int max = uint(c[1]>c2[1]? c[1]/2 : c2[1]/2);
+          max += uint(edgeNodeSpacing);
 
           if(currentGraph->source(e) == n) {
-            bends.push_back(Coord(0,static_cast<float>(max),0));
-            bends.push_back(Coord(2.f * spacing + c.getX()/2.f + c2.getX()+c3.getX()/2.f,static_cast<float>(max),0));
+            bends.push_back(Coord(0,float(max),0));
+            bends.push_back(Coord(2.f * spacing + c.getX()/2.f + c2.getX()+c3.getX()/2.f,float(max),0));
           }
           else {
-            bends.push_back(Coord(2.f * spacing + c.getX()/2.f + c2.getX()+c3.getX()/2.f,static_cast<float>(max),0));
-            bends.push_back(Coord(0,static_cast<float>(max),0));
+            bends.push_back(Coord(2.f * spacing + c.getX()/2.f + c2.getX()+c3.getX()/2.f,float(max),0));
+            bends.push_back(Coord(0,float(max),0));
           }
 
           result->setEdgeValue(e, bends);
@@ -174,7 +174,7 @@ bool MixedModel::run() {
       delete itn;
       edge e;
       forEach(e,currentGraph->getEdges())
-      edge_planar.push_back(e);
+        edge_planar.push_back(e);
       continue;
     }
 
@@ -800,15 +800,15 @@ void MixedModel::assignInOutPoints() { // on considère qu'il n'y a pas d'arc do
         Coord c;
 
         for(int x = -out_l, y = dl; x<=-1 ; ++x,++y) {
-          c.set(static_cast<float>(x), static_cast<float>(y));
+          c.set(float(x), float(y));
           out_points[v].push_back(c);
         }
 
-        c.set(0,(out_l+dl-1 > out_r+dr-1) ? static_cast<float>(out_l+dl-1) : static_cast<float>(out_r+dr-1));
+        c.set(0,(out_l+dl-1 > out_r+dr-1) ? float(out_l+dl-1) : float(out_r+dr-1));
         out_points[v].push_back(c);
 
         for(int x = 1, y = out_r+dr-1; y>=dr ; ++x,--y) {
-          c.set(static_cast<float>(x),static_cast<float>(y));
+          c.set(float(x),float(y));
           out_points[v].push_back(c);
         }
       }
@@ -857,27 +857,27 @@ void MixedModel::assignInOutPoints() { // on considère qu'il n'y a pas d'arc do
 
       if(nbIn > 3) {
         unsigned int j = 0;
-        Coord c(-static_cast<float>(in_l),0);
+        Coord c(-float(in_l),0);
         InPoints[listOfEdgesIN[j]].push_back(c);
         ++j;
 
         for(int x = -in_l, y = -1; x<=-1 ; ++x,--y) {
-          c.set(static_cast<float>(x), static_cast<float>(y));
+          c.set(float(x), float(y));
           InPoints[listOfEdgesIN[j]].push_back(c);
           ++j;
         }
 
-        c.set(0, -static_cast<float>(in_r));
+        c.set(0, -float(in_r));
         InPoints[listOfEdgesIN[j]].push_back(c);
         ++j;
 
         for(int x = 1, y = -in_r; x<=in_r ; ++x,++y) {
-          c.set(static_cast<float>(x), static_cast<float>(y));
+          c.set(float(x), float(y));
           InPoints[listOfEdgesIN[j]].push_back(c);
           ++j;
         }
 
-        c.set(static_cast<float>(in_r), 0);
+        c.set(float(in_r), 0);
         InPoints[listOfEdgesIN[j]].push_back(c);
         ++j;
 
@@ -938,8 +938,8 @@ void MixedModel::computeCoords() {
     Coord c = nodeSize.get((V[0][i]).id);
     float x;
 
-    if(i == 0) x = (out_l < static_cast<double>(c.getX()/2.f)) ? (c.getX()/2.f) : static_cast<float>(out_l) ;
-    else  x = static_cast<float>(out_r_moins1) + ((out_l < static_cast<double>(c.getX()/2.f)) ? (c.getX()/2.f) : static_cast<float>(out_l))  + spacing;
+    if(i == 0) x = (out_l < double(c.getX()/2.f)) ? (c.getX()/2.f) : float(out_l) ;
+    else  x = float(out_r_moins1) + ((out_l < double(c.getX()/2.f)) ? (c.getX()/2.f) : float(out_l))  + spacing;
 
     NodeCoords[v] = Coord(x, 0, 0);  // y(vi) = 0
     out_r_moins1 = (out_r < (c.getX()/2.) ? (c.getX()/2.) : out_r);
@@ -975,11 +975,11 @@ void MixedModel::computeCoords() {
 
     node Z0 = V[k][0];
     co = nodeSize.get(Z0.id);
-    int max_y_taille = (int) ((inr[Z0]<co.getY()/2.) ? co.getY()/2. : inr[Z0]);
+    int max_y_taille = int((inr[Z0]<co.getY()/2.) ? co.getY()/2. : inr[Z0]);
 
     for(unsigned int i = 0; i<p; ++i) {
       co = nodeSize.get((V[k][i]).id);
-      int taille_tmp = (int) ((inr[V[k][i]]<co.getY()/2.) ? co.getY()/2. : inr[V[k][i]]);
+      int taille_tmp = int((inr[V[k][i]]<co.getY()/2.) ? co.getY()/2. : inr[V[k][i]]);
 
       if(taille_tmp > max_y_taille)
         max_y_taille = taille_tmp;
@@ -992,8 +992,8 @@ void MixedModel::computeCoords() {
 
     // assign x-coords :
     unsigned int n = EdgesIN[V[k][p-1]].size();
-    int dxl = (int)(OutPoints[EdgesIN[V[k][0]][0]].getX()),
-        dxr = (int)(OutPoints[EdgesIN[V[k][p-1]][n-1]].getX());
+    int dxl = int(OutPoints[EdgesIN[V[k][0]][0]].getX()),
+        dxr = int(OutPoints[EdgesIN[V[k][p-1]][n-1]].getX());
 
     if(EdgesIN[Z0].size() >= 3) {
       assert(p==1);
@@ -1055,10 +1055,10 @@ void MixedModel::computeCoords() {
         if(i == 0) x = ((out_l<co2.getX()/2.) ? co2.getX()/2. : out_l) + dxl;
         else x = out_r_moins1 + ((out_l<co2.getX()/2.) ? co2.getX()/2. : out_l)+1;
 
-        NodeCoords[V[k][i]].setX(static_cast<float>(x));
-        somme += static_cast<float>(x);
+        NodeCoords[V[k][i]].setX(float(x));
+        somme += float(x);
 
-        out_r_moins1 = (int) ((out_r<co2.getX()/2.) ? co2.getX()/2. : out_r);
+        out_r_moins1 = int((out_r<co2.getX()/2.) ? co2.getX()/2. : out_r);
       }
 
       //assign x(cr)
@@ -1071,7 +1071,7 @@ void MixedModel::computeCoords() {
       if(tmp > xtmp - somme) x = tmp;
       else x = xtmp - somme;
 
-      NodeCoords[cr].setX(static_cast<float>(x));
+      NodeCoords[cr].setX(float(x));
 
       float xZ0 = NodeCoords[Z0].getX();
 

--- a/plugins/layout/OGDF/OGDFBalloon.cpp
+++ b/plugins/layout/OGDF/OGDFBalloon.cpp
@@ -82,7 +82,7 @@ public:
                     "Computes a radial (balloon) layout based on a spanning tree.<br/>The algorithm is partially based on the paper <b>On Balloon Drawings of Rooted Trees</b> by Lin and Yen and on <b>Interacting with Huge Hierarchies: Beyond Cone Trees</b> by Carriere and Kazman. ","1.4","Hierarchical")
   OGDFBalloon(const tlp::PluginContext* context) :OGDFLayoutPluginBase(context, new ogdf::ComponentSplitterLayout()), balloon(new ogdf::BalloonLayout()) {
     addInParameter<bool> ("Even angles", paramHelp[0], "false", false);
-    ogdf::ComponentSplitterLayout *csl = reinterpret_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
+    ogdf::ComponentSplitterLayout *csl = static_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
     // ComponentSplitterLayout takes ownership of the BalloonLayout instance
     csl->setLayoutModule(balloon);
   }

--- a/plugins/layout/OGDF/OGDFFastMultipoleEmbedder.cpp
+++ b/plugins/layout/OGDF/OGDFFastMultipoleEmbedder.cpp
@@ -98,7 +98,7 @@ public:
     addInParameter<double>("default node size", paramHelp[3], "20.0");
     addInParameter<double>("default edge length", paramHelp[4], "1.0");
     addInParameter<int>("number of threads", paramHelp[5], "3");
-    ogdf::ComponentSplitterLayout *csl = reinterpret_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
+    ogdf::ComponentSplitterLayout *csl = static_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
     // ComponentSplitterLayout takes ownership of the FastMultipoleEmbedder instance
     csl->setLayoutModule(fme);
   }

--- a/plugins/layout/OGDF/OGDFFastMultipoleMultilevelEmbedder.cpp
+++ b/plugins/layout/OGDF/OGDFFastMultipoleMultilevelEmbedder.cpp
@@ -85,7 +85,7 @@ public:
     addInParameter<int>("number of threads", paramHelp[0], "2");
     addInParameter<int>("multilevel nodes bound", paramHelp[1], "10");
 
-    ogdf::ComponentSplitterLayout *csl = reinterpret_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
+    ogdf::ComponentSplitterLayout *csl = static_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
     // ComponentSplitterLayout takes ownership of the FastMultipoleMultilevelEmbedder instance
     csl->setLayoutModule(fmme);
 

--- a/plugins/layout/OGDF/OGDFTileToRowsPacking.cpp
+++ b/plugins/layout/OGDF/OGDFTileToRowsPacking.cpp
@@ -69,7 +69,7 @@ public:
   PLUGININFORMATION("Tile To Rows Packing (OGDF)","Carsten Gutwenger","12/11/2007","The tile-to-rows algorithm for packing drawings of connected components.","1.0","Misc")
   OGDFTileToRowsPacking(const tlp::PluginContext* context) :
     OGDFLayoutPluginBase(context, new ogdf::ComponentSplitterLayout()) {
-    ogdf::ComponentSplitterLayout *csl = reinterpret_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
+    ogdf::ComponentSplitterLayout *csl = static_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
     // ComponentSplitterLayout takes ownership of the SameLayout instance
     csl->setLayoutModule(new SameLayout());
   }

--- a/plugins/layout/OGDF/OGDFVisibility.cpp
+++ b/plugins/layout/OGDF/OGDFVisibility.cpp
@@ -83,7 +83,7 @@ public:
   OGDFVisibility(const tlp::PluginContext* context) :OGDFLayoutPluginBase(context, new ogdf::ComponentSplitterLayout()), visibility(new ogdf::VisibilityLayout()) {
     addInParameter<int>("minimum grid distance", paramHelp[0], "1");
     addInParameter<bool>("transpose", paramHelp[1], "false");
-    ogdf::ComponentSplitterLayout *csl = reinterpret_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
+    ogdf::ComponentSplitterLayout *csl = static_cast<ogdf::ComponentSplitterLayout*>(ogdfLayoutAlgo);
     // ComponentSplitterLayout takes ownership of the VisibilityLayout instance
     csl->setLayoutModule(visibility);
   }

--- a/plugins/layout/PolyominoPacking.cpp
+++ b/plugins/layout/PolyominoPacking.cpp
@@ -272,7 +272,7 @@ int PolyominoPacking::computeGridStep() {
 
   double r = sqrt(d);
   double l1 = (-b + r) / (2 * a);
-  int root = static_cast<int>(l1);
+  int root = int(l1);
 
   if (root == 0) root = 1;
 
@@ -280,7 +280,7 @@ int PolyominoPacking::computeGridStep() {
 }
 
 static int grid(float x, int s) {
-  return static_cast<int>(ceil(x/s));
+  return int(ceil(x/s));
 }
 
 template <typename T>
@@ -302,7 +302,7 @@ static T cell(const T &p, int gridStep) {
 }
 
 static Vec2i vec3fToVec2i(const Vec3f &c) {
-  return Vec2i((int)rint(c[0]), (int)rint(c[1]));
+  return Vec2i(int(rint(c[0])), int(rint(c[1])));
 }
 
 void PolyominoPacking::genPolyomino(Polyomino &poly, LayoutProperty* layout,

--- a/plugins/layout/RectanglePacking.cpp
+++ b/plugins/layout/RectanglePacking.cpp
@@ -271,32 +271,34 @@ void RectanglePacking::dimensionsBoundingBoxOfAllOptimalPositionnedRectangles(li
 
 int RectanglePacking::calculOfNumberOptimalRepositionnedRectangles(const char * quality) {
 
+  double numberOfRectanglesDouble = numberOfRectangles;
+
   if(!strcmp(quality,"n5"))
     return numberOfRectangles;
 
   else if(!strcmp(quality,"n4logn"))
-    return (int)floor(pow((double)pow((float)numberOfRectangles,4)*log((float)numberOfRectangles),0.2));
+    return int(floor(pow(pow(numberOfRectanglesDouble, 4.0)*log(numberOfRectanglesDouble),0.2)));
 
   else if(!strcmp(quality,"n4"))
-    return (int)floor(pow((double)numberOfRectangles,0.8));
+    return int(floor(pow(numberOfRectanglesDouble,0.8)));
 
   else if(!strcmp(quality,"n3logn"))
-    return (int)floor(pow((double)pow((float)numberOfRectangles,3)*log((float)numberOfRectangles),0.2));
+    return int(floor(pow(pow(numberOfRectanglesDouble,3.0)*log(numberOfRectanglesDouble),0.2)));
 
   else if(!strcmp(quality,"n3"))
-    return (int)floor(pow((double)numberOfRectangles,0.6));
+    return int(floor(pow(numberOfRectanglesDouble,0.6)));
 
   else if(!strcmp(quality,"n2logn"))
-    return (int)floor(pow((double)pow((float)numberOfRectangles,2)*log((float)numberOfRectangles),0.2));
+    return int(floor(pow(pow(numberOfRectanglesDouble,2.0)*log(numberOfRectanglesDouble),0.2)));
 
   else if(!strcmp(quality,"n2"))
-    return (int)floor(pow((double)numberOfRectangles,0.4));
+    return int(floor(pow(numberOfRectanglesDouble,0.4)));
 
   else if(!strcmp(quality,"nlogn"))
-    return (int)floor(pow((double)numberOfRectangles*log((float)numberOfRectangles),0.2));
+    return int(floor(pow(numberOfRectanglesDouble*log(numberOfRectanglesDouble),0.2)));
 
   else if(!strcmp(quality,"n"))
-    return (int)floor(pow((double)numberOfRectangles,0.2));
+    return int(floor(pow(numberOfRectanglesDouble,0.2)));
 
   return 0;
 }
@@ -569,23 +571,25 @@ void RectanglePacking::optimalPositionOfNewRectangleLimPos(vector<Rectangle<floa
 
 int RectanglePacking::calculNumberOfTestedPositions(const char * quality) {
 
+  double numberOfRectanglesDouble = numberOfRectangles;
+
   if(!strcmp(quality,"n5"))
     return numberOfRectangles;
 
   else if(!strcmp(quality,"n4logn"))
-    return (int)floor(pow((double)pow((float)numberOfRectangles,3)*log((float)numberOfRectangles),0.25));
+    return int(floor(pow(pow(numberOfRectanglesDouble,3.0)*log(numberOfRectanglesDouble),0.25)));
 
   else if(!strcmp(quality,"n4"))
-    return (int)floor(pow((double)numberOfRectangles,0.75));
+    return int(floor(pow(numberOfRectanglesDouble,0.75)));
 
   else if(!strcmp(quality,"n3logn"))
-    return (int)floor(pow((double)pow((float)numberOfRectangles,2)*log((float)numberOfRectangles),0.25));
+    return int(floor(pow(pow(numberOfRectanglesDouble,2.0)*log(numberOfRectanglesDouble),0.25)));
 
   else if(!strcmp(quality,"n3"))
-    return (int)floor(sqrt((double)numberOfRectangles));
+    return int(floor(sqrt(numberOfRectanglesDouble)));
 
   else if(!strcmp(quality,"n2logn"))
-    return (int)floor(sqrt((double)log((float)numberOfRectangles)));
+    return int(floor(sqrt(log(numberOfRectanglesDouble))));
 
   return 0;
 }

--- a/plugins/layout/SquarifiedTreeMap.cpp
+++ b/plugins/layout/SquarifiedTreeMap.cpp
@@ -129,8 +129,8 @@ bool SquarifiedTreeMap::run() {
   computeNodesSize(root);
 
   Vec2d center = initialSpace.center();
-  result->setNodeValue(root, Coord(static_cast<float>(center[0]), static_cast<float>(center[1]), 0));
-  Size initialSpaceSize(static_cast<float>(initialSpace.width()), static_cast<float>(initialSpace.height()), 0);
+  result->setNodeValue(root, Coord(float(center[0]), float(center[1]), 0));
+  Size initialSpaceSize(float(initialSpace.width()), float(initialSpace.height()), 0);
   sizeResult->setNodeValue(root, initialSpaceSize);
   vector<node> toTreat(orderedChildren(root));
 
@@ -185,8 +185,8 @@ void SquarifiedTreeMap::layoutRow(const std::vector<tlp::node> &row, const int d
     assert(layoutRec.isValid());
     sum += nodesSize.get(it->id);
     Vec2d center = layoutRec.center();
-    result->setNodeValue(*it, Coord(static_cast<float>(center[0]), static_cast<float>(center[1]), static_cast<float>(depth * SEPARATION_Z)));
-    sizeResult->setNodeValue(*it, Size(static_cast<float>(layoutRec.width()), static_cast<float>(layoutRec.height()), 0));
+    result->setNodeValue(*it, Coord(float(center[0]), float(center[1]), float(depth * SEPARATION_Z)));
+    sizeResult->setNodeValue(*it, Size(float(layoutRec.width()), float(layoutRec.height()), 0));
 
     if (graph->outdeg(*it) > 0) {
       vector<node> toTreat(orderedChildren(*it));

--- a/plugins/layout/TreeRadial.cpp
+++ b/plugins/layout/TreeRadial.cpp
@@ -129,7 +129,7 @@ public:
       float lRadiusPrev = lRadius;
       lRadius += nRadii[i] + nRadii[i + 1] + lSpacing;
       // check if there is enough space for nodes of layer i + 1
-      float mRadius = (bfs[i + 1].size() * (nRadii[i + 1] + nSpacing))/static_cast<float>(2 * M_PI);
+      float mRadius = (bfs[i + 1].size() * (nRadii[i + 1] + nSpacing))/float(2 * M_PI);
 
       if (mRadius > lRadius)
         lRadius = mRadius;
@@ -309,8 +309,8 @@ public:
         if (depth > 0) {
           // layout the node in the middle of the sector
           double nAngle = (startAngle + endAngle)/2.0;
-          result->setNodeValue(n, Coord(lRadii[depth] * static_cast<float>(cos(nAngle)),
-                                        lRadii[depth] * static_cast<float>(sin(nAngle)),
+          result->setNodeValue(n, Coord(lRadii[depth] * float(cos(nAngle)),
+                                        lRadii[depth] * float(sin(nAngle)),
                                         0));
         }
         else
@@ -385,7 +385,7 @@ public:
       const Size& boundingBox = sizes->getNodeValue (n);
       double diam = 2.*sqrt (boundingBox.getW() * boundingBox.getW()/4.0 +
                              boundingBox.getH() * boundingBox.getH()/4.0);
-      circleSizes->setNodeValue (n, Size (static_cast<float>(diam), static_cast<float>(diam), 1.0f));
+      circleSizes->setNodeValue (n, Size (float(diam), float(diam), 1.0f));
     }
     sizes = circleSizes;
 

--- a/plugins/layout/TreeReingoldAndTilfordExtended.cpp
+++ b/plugins/layout/TreeReingoldAndTilfordExtended.cpp
@@ -316,8 +316,8 @@ void TreeReingoldAndTilfordExtended::calcLayout(tlp::node n, TLP_HASH_MAP<tlp::n
   Coord tmpCoord;
 
   if(!compactLayout)
-    tmpCoord.set(static_cast<float>(x+(*p)[n]), -static_cast<float>(y), 0);
-  else tmpCoord.set(static_cast<float>(x+(*p)[n]), - static_cast<float>(y+maxLevelSize[level]/2.f), 0);
+    tmpCoord.set(float(x+(*p)[n]), -float(y), 0);
+  else tmpCoord.set(float(x+(*p)[n]), - float(y+maxLevelSize[level]/2.f), 0);
 
   result->setNodeValue(n,tmpCoord);
 
@@ -404,7 +404,7 @@ bool TreeReingoldAndTilfordExtended::run() {
       const Size& boundCircle = sizes->getNodeValue (n);
       double diam = 2*sqrt (boundCircle.getW()*boundCircle.getW()/4.0 +
                             boundCircle.getH()*boundCircle.getH()/4.0);
-      circleSizes->setNodeValue (n, Size (static_cast<float>(diam), static_cast<float>(diam), 1.0f));
+      circleSizes->setNodeValue (n, Size (float(diam), float(diam), 1.0f));
     }//end forEach
     sizes = circleSizes;
   }//end if
@@ -447,7 +447,7 @@ bool TreeReingoldAndTilfordExtended::run() {
   // than the max of the minimum layer spacing of the tree
   if(!compactLayout) {
     for (unsigned int i = 0; i < maxSizeLevel.size() - 1;  ++i) {
-      float minLayerSpacing = static_cast<float>((maxSizeLevel[i] + maxSizeLevel[i + 1]) / 2);
+      float minLayerSpacing = float((maxSizeLevel[i] + maxSizeLevel[i + 1]) / 2);
 
       if (minLayerSpacing + nodeSpacing > spacing)
         spacing = minLayerSpacing + spacing;

--- a/plugins/metric/BetweennessCentrality.cpp
+++ b/plugins/metric/BetweennessCentrality.cpp
@@ -174,7 +174,7 @@ public:
     //Normalization
     if(norm || !directed) {
       double n = graph->numberOfNodes();
-      const double nNormFactor = 1./(double)((n - 1) * (n - 2));
+      const double nNormFactor = 1.0/((n - 1) * (n - 2));
       it = graph->getNodes();
 
       while(it->hasNext()) {
@@ -191,7 +191,7 @@ public:
       delete it;
 
       Iterator<edge> *itE = graph->getEdges();
-      const double eNormFactor = 4./(double)(n * n);
+      const double eNormFactor = 4.0/(n * n);
 
       while(itE->hasNext()) {
         edge e = itE->next();

--- a/plugins/metric/DegreeMetric.cpp
+++ b/plugins/metric/DegreeMetric.cpp
@@ -65,7 +65,7 @@ bool DegreeMetric::run() {
   }
 
   NodeStaticProperty<double> deg(graph);
-  degree(graph, deg, (EDGE_TYPE) degreeTypes.getCurrent(), weights, norm);
+  degree(graph, deg, static_cast<EDGE_TYPE>(degreeTypes.getCurrent()), weights, norm);
   deg.copyToProperty(result);
 
   return true;

--- a/plugins/metric/KCores.cpp
+++ b/plugins/metric/KCores.cpp
@@ -106,7 +106,7 @@ bool KCores::run() {
     dataSet->get("metric", metric);
   }
 
-  EDGE_TYPE degree_type = (EDGE_TYPE) degreeTypes.getCurrent();
+  EDGE_TYPE degree_type = static_cast<EDGE_TYPE>(degreeTypes.getCurrent());
 
   // the famous k
   double k = DBL_MAX;

--- a/plugins/metric/LinkCommunities.cpp
+++ b/plugins/metric/LinkCommunities.cpp
@@ -252,7 +252,7 @@ double LinkCommunities::getSimilarity(edge ee, const std::vector<edge>& edges) {
     wuv+=2;
 
   if(m>0)
-    return (double)wuv / (double)m;
+    return wuv / double(m);
   else
     return 0.0;
 }

--- a/plugins/metric/PageRank.cpp
+++ b/plugins/metric/PageRank.cpp
@@ -95,7 +95,7 @@ struct PageRank : public DoubleAlgorithm {
       pr[i] = oon;
 
     const double one_minus_d = (1-d)/nbNodes;
-    const unsigned int kMax = (unsigned int) (15*log(nbNodes));
+    const unsigned int kMax = uint(15*log(nbNodes));
 
     for(unsigned int k=0; k < kMax + 1; ++k) {
       if (directed) {

--- a/plugins/metric/StrahlerMetric.cpp
+++ b/plugins/metric/StrahlerMetric.cpp
@@ -241,16 +241,16 @@ bool StrahlerMetric::run() {
 
       switch(computationTypes.getCurrent()) {
       case ALL:
-        result->setNodeValue(itn,sqrt((double)cachedValues[itn].strahler*(double)cachedValues[itn].strahler
-                                      +(double)cachedValues[itn].stacks*(double)cachedValues[itn].stacks));
+        result->setNodeValue(itn, sqrt(double(cachedValues[itn].strahler) * double(cachedValues[itn].strahler) +
+                                       double(cachedValues[itn].stacks) * double(cachedValues[itn].stacks)));
         break;
 
       case REGISTERS:
-        result->setNodeValue(itn, (double)cachedValues[itn].strahler);
+        result->setNodeValue(itn, cachedValues[itn].strahler);
         break;
 
       case STACKS:
-        result->setNodeValue(itn, (double)cachedValues[itn].stacks);
+        result->setNodeValue(itn, cachedValues[itn].stacks);
       }
 
       visited.clear();
@@ -272,16 +272,16 @@ bool StrahlerMetric::run() {
 
       switch(computationTypes.getCurrent()) {
       case ALL:
-        result->setNodeValue(itn,sqrt((double)cachedValues[itn].strahler*(double)cachedValues[itn].strahler
-                                      +(double)cachedValues[itn].stacks*(double)cachedValues[itn].stacks));
+        result->setNodeValue(itn,sqrt(double(cachedValues[itn].strahler) * double(cachedValues[itn].strahler) +
+                                      double(cachedValues[itn].stacks) * double(cachedValues[itn].stacks)));
         break;
 
       case REGISTERS:
-        result->setNodeValue(itn, (double)cachedValues[itn].strahler);
+        result->setNodeValue(itn, cachedValues[itn].strahler);
         break;
 
       case STACKS:
-        result->setNodeValue(itn, (double)cachedValues[itn].stacks);
+        result->setNodeValue(itn, cachedValues[itn].stacks);
       }
     }
 

--- a/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp
+++ b/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp
@@ -113,7 +113,7 @@ GraphPerspective::GraphPerspective(const tlp::PluginContext* c):
   _recentDocumentsSettingsKey("perspective/recent_files"), _logger(NULL) {
   Q_INIT_RESOURCE(GraphPerspective);
 
-  if (c && ((PerspectiveContext *) c)->parameters.contains("gui_testing")) {
+  if (c && static_cast<const PerspectiveContext *>(c)->parameters.contains("gui_testing")) {
     tlp::setGuiTestingMode(true);
     // we must ensure that choosing a file is relative to
     // the current directory to allow to run the gui tests
@@ -341,7 +341,7 @@ void GraphPerspective::findPlugins() {
 
 bool GraphPerspective::eventFilter(QObject* obj, QEvent* ev) {
   if(ev->type() == QEvent::DragEnter) {
-    QDragEnterEvent* dragEvent = dynamic_cast<QDragEnterEvent*>(ev);
+    QDragEnterEvent* dragEvent = static_cast<QDragEnterEvent*>(ev);
 
     if(dragEvent->mimeData()->hasUrls()) {
       dragEvent->accept();
@@ -349,7 +349,7 @@ bool GraphPerspective::eventFilter(QObject* obj, QEvent* ev) {
   }
 
   if(ev->type() == QEvent::Drop) {
-    QDropEvent* dropEvent = dynamic_cast<QDropEvent*>(ev);
+    QDropEvent* dropEvent = static_cast<QDropEvent*>(ev);
 
     foreach(const QUrl& url, dropEvent->mimeData()->urls()) {
       open(url.toLocalFile());

--- a/plugins/perspective/GraphPerspective/src/PreferencesDialog.cpp
+++ b/plugins/perspective/GraphPerspective/src/PreferencesDialog.cpp
@@ -189,8 +189,8 @@ void PreferencesDialog::writeSettings() {
       setDefaultNodeValueInProperty<IntegerProperty>("viewShape", TulipSettings::instance().defaultShape(tlp::NODE), graphPush);
   }
 
-  if (TulipSettings::instance().defaultShape(tlp::EDGE) != (int)(model->data(model->index(2,2)).value<EdgeShape::EdgeShapes>())) {
-    TulipSettings::instance().setDefaultShape(tlp::EDGE,(int)(model->data(model->index(2,2)).value<EdgeShape::EdgeShapes>()));
+  if (TulipSettings::instance().defaultShape(tlp::EDGE) != int(model->data(model->index(2,2)).value<EdgeShape::EdgeShapes>())) {
+    TulipSettings::instance().setDefaultShape(tlp::EDGE, int(model->data(model->index(2,2)).value<EdgeShape::EdgeShapes>()));
     setDefaultEdgeValueInProperty<IntegerProperty>("viewShape", TulipSettings::instance().defaultShape(tlp::EDGE), graphPush);
   }
 
@@ -407,17 +407,17 @@ void PreferencesDialog::showGraphDefaultsContextMenu(const QPoint& p) {
       subMenu->setToolTip(QString("Choose the type of elements for which the default value will be reset"));
       action = subMenu->addAction(QString("Node default value"));
       action->setToolTip(QString("Reset the node ") + defaultProp + " to the Tulip predefined value");
-      action->setData(QVariant((int) RESET_NODE));
+      action->setData(QVariant(int(RESET_NODE)));
       action = subMenu->addAction(QString("Edge default value"));
       action->setToolTip(QString("Reset the edge ") + defaultProp + " to the Tulip predefined value");
-      action->setData(QVariant((int) RESET_EDGE));
+      action->setData(QVariant(int(RESET_EDGE)));
       action = subMenu->addAction(QString("Node/Edge default values"));
       action->setToolTip(QString("Reset the node/edge ") + defaultProp + " to the Tulip predefined value");
-      action->setData(QVariant((int) RESET_BOTH));
+      action->setData(QVariant(int(RESET_BOTH)));
     }
     else {
       action = contextMenu.addAction(QString("Reset to Tulip predefined value"));
-      action->setData(QVariant((int) RESET_BOTH));
+      action->setData(QVariant(int(RESET_BOTH)));
       action->setToolTip(QString("Reset ") + defaultProp + " to the Tulip predefined value");
     }
 

--- a/plugins/selection/SpanningDagSelection.cpp
+++ b/plugins/selection/SpanningDagSelection.cpp
@@ -50,7 +50,7 @@ bool SpanningDagSelection::run() {
 
   //output some useful information
   if (dataSet!=NULL) {
-    dataSet->set("#Edges selected", static_cast<unsigned int>(graph->numberOfEdges()-obstructions.size()));
+    dataSet->set("#Edges selected", uint(graph->numberOfEdges()-obstructions.size()));
   }
 
   return true;

--- a/plugins/sizes/MetricMapping.cpp
+++ b/plugins/sizes/MetricMapping.cpp
@@ -181,11 +181,11 @@ public:
 
         Size size=entrySize->getNodeValue(itn);
 
-        if (xaxis) size[0]=static_cast<float>(sizos);
+        if (xaxis) size[0]=float(sizos);
 
-        if (yaxis) size[1]=static_cast<float>(sizos);
+        if (yaxis) size[1]=float(sizos);
 
-        if (zaxis) size[2]=static_cast<float>(sizos);
+        if (zaxis) size[2]=float(sizos);
 
         result->setNodeValue(itn, size);
 
@@ -211,8 +211,8 @@ public:
         double sizos =
           min+(entryMetric->getEdgeDoubleValue(ite)-shift)*(max-min)/range;
         Size size = entrySize->getEdgeValue(ite);
-        size[0] = static_cast<float>(sizos);
-        size[1] = static_cast<float>(sizos);
+        size[0] = float(sizos);
+        size[1] = float(sizos);
         result->setEdgeValue(ite, size);
 
         if ((++iter % 500 == 0) &&

--- a/plugins/view/GeographicView/GeographicView.cpp
+++ b/plugins/view/GeographicView/GeographicView.cpp
@@ -224,7 +224,7 @@ DataSet GeographicView::state() const {
   DataSet dataSet;
   DataSet configurationWidget = geoViewConfigWidget->state();
   dataSet.set("configurationWidget", configurationWidget);
-  dataSet.set("viewType", static_cast<int>(_viewType));
+  dataSet.set("viewType", int(_viewType));
   pair<double, double> mapCenter = geoViewGraphicsView->getGoogleMapsPage()->getCurrentMapCenter();
   dataSet.set("mapCenterLatitude", mapCenter.first);
   dataSet.set("mapCenterLongitude", mapCenter.second);
@@ -384,9 +384,9 @@ void GeographicView::loadStoredPolyInformation(const DataSet &dataset) {
         polyConf.get((*it).first,entityData);
         Color color;
         entityData.get("color",color);
-        ((GlComplexPolygon*)(*it).second)->setFillColor(color);
+        static_cast<GlComplexPolygon*>((*it).second)->setFillColor(color);
         entityData.get("outlineColor",color);
-        ((GlComplexPolygon*)(*it).second)->setOutlineColor(color);
+        static_cast<GlComplexPolygon*>((*it).second)->setOutlineColor(color);
       }
     }
   }
@@ -399,8 +399,8 @@ void GeographicView::saveStoredPolyInformation(DataSet &dataset) const {
 
   for(map<string,GlSimpleEntity*>::const_iterator it=entities.begin(); it!=entities.end(); ++it) {
     DataSet entityData;
-    entityData.set("color",((GlComplexPolygon*)(*it).second)->getFillColor());
-    entityData.set("outlineColor",((GlComplexPolygon*)(*it).second)->getOutlineColor());
+    entityData.set("color", static_cast<GlComplexPolygon*>((*it).second)->getFillColor());
+    entityData.set("outlineColor", static_cast<GlComplexPolygon*>((*it).second)->getOutlineColor());
     polyConf.set((*it).first,entityData);
   }
 

--- a/plugins/view/GeographicView/GeographicViewConfigWidget.cpp
+++ b/plugins/view/GeographicView/GeographicViewConfigWidget.cpp
@@ -200,11 +200,11 @@ void GeographicViewConfigWidget::setState(const DataSet &dataSet) {
 
 DataSet GeographicViewConfigWidget::state() const {
   DataSet data;
-  data.set("polyFileType",(int)polyFileType());
-  data.set("csvFileName",QStringToTlpString(_ui->csvFile->text()));
-  data.set("polyFileName",QStringToTlpString(_ui->polyFile->text()));
-  data.set("useSharedLayout",useSharedLayoutProperty());
-  data.set("useSharedSize",useSharedSizeProperty());
-  data.set("useSharedShape",useSharedShapeProperty());
+  data.set("polyFileType", int(polyFileType()));
+  data.set("csvFileName", QStringToTlpString(_ui->csvFile->text()));
+  data.set("polyFileName", QStringToTlpString(_ui->polyFile->text()));
+  data.set("useSharedLayout", useSharedLayoutProperty());
+  data.set("useSharedSize", useSharedSizeProperty());
+  data.set("useSharedShape", useSharedShapeProperty());
   return data;
 }

--- a/plugins/view/GeographicView/GeographicViewGraphicsView.cpp
+++ b/plugins/view/GeographicView/GeographicViewGraphicsView.cpp
@@ -650,7 +650,7 @@ void GeographicViewGraphicsView::loadPolyFile(QString fileName) {
 }
 
 void GeographicViewGraphicsView::mapToPolygon() {
-  GlComposite *composite=dynamic_cast<GlComposite*>(polygonEntity);
+  GlComposite *composite=polygonEntity;
 
   if(!composite)
     return;
@@ -667,7 +667,7 @@ void GeographicViewGraphicsView::mapToPolygon() {
 
     for(map<string,GlSimpleEntity*>::const_iterator it=entities.begin(); it!=entities.end(); ++it) {
       if((*it).second->getBoundingBox().contains(nodePos)) {
-        GlComplexPolygon *polygon=dynamic_cast<GlComplexPolygon*>((*it).second);
+        GlComplexPolygon *polygon=static_cast<GlComplexPolygon*>((*it).second);
 
         const vector<vector<Coord> > polygonSides=polygon->getPolygonSides();
 
@@ -1047,18 +1047,18 @@ void GeographicViewGraphicsView::setGeoShape(IntegerProperty *property) {
 
 void GeographicViewGraphicsView::afterSetNodeValue(PropertyInterface *prop, const node n) {
   if (geoViewSize != NULL) {
-    SizeProperty *viewSize = (SizeProperty *) prop;
+    SizeProperty *viewSize = static_cast<SizeProperty *>(prop);
     const Size &nodeSize = viewSize->getNodeValue(n);
-    float sizeFactor = pow((float) 1.3, (int) currentMapZoom);
+    float sizeFactor = pow(1.3f, float(currentMapZoom));
     geoViewSize->setNodeValue(n, Size(sizeFactor * nodeSize.getW(), sizeFactor * nodeSize.getH(), sizeFactor * nodeSize.getD()));
   }
 }
 
 void GeographicViewGraphicsView::afterSetAllNodeValue(PropertyInterface *prop) {
   if (geoViewSize != NULL) {
-    SizeProperty *viewSize = (SizeProperty *) prop;
+    SizeProperty *viewSize = static_cast<SizeProperty *>(prop);
     const Size &nodeSize = viewSize->getNodeValue(graph->getOneNode());
-    float sizeFactor = pow((float) 1.3, (int) currentMapZoom);
+    float sizeFactor = pow(1.3f, float(currentMapZoom));
     geoViewSize->setAllNodeValue(Size(sizeFactor * nodeSize.getW(), sizeFactor * nodeSize.getH(), sizeFactor * nodeSize.getD()));
   }
 }
@@ -1291,7 +1291,7 @@ void GeographicViewGraphicsView::switchViewType() {
         vector<Coord> bends;
 
         for(unsigned int i=0; i<bendsNumber; ++i) {
-          Coord tmp=srcC+((tgtC-srcC)/(bendsNumber+1.f))*((float)i+1);
+          Coord tmp=srcC+((tgtC-srcC)/(bendsNumber+1.f))*(i+1.f);
           float lambda = tmp[1];
           float theta;
 

--- a/plugins/view/GeographicView/GeographicViewShowElementInfo.cpp
+++ b/plugins/view/GeographicView/GeographicViewShowElementInfo.cpp
@@ -53,14 +53,15 @@ public:
   }
 
   QVariantList propertiesQVariant() const  {
-    return QVariantList() << QVariant::fromValue<Color>(((GlComplexPolygon *) entity)->getFillColor()) << QVariant::fromValue<Color>(((GlComplexPolygon *) entity)->getOutlineColor());
+    return QVariantList() << QVariant::fromValue<Color>(static_cast<GlComplexPolygon *>(entity)->getFillColor())
+                          << QVariant::fromValue<Color>(static_cast<GlComplexPolygon *>(entity)->getOutlineColor());
   }
 
   void setProperty(const QString &name, const QVariant &value) {
     if(name=="fillColor")
-      ((GlComplexPolygon *) entity)->setFillColor(value.value<Color>());
+      static_cast<GlComplexPolygon *>(entity)->setFillColor(value.value<Color>());
     else if(name=="outlineColor")
-      ((GlComplexPolygon *) entity)->setOutlineColor(value.value<Color>());
+      static_cast<GlComplexPolygon *>(entity)->setOutlineColor(value.value<Color>());
   }
 };
 
@@ -109,7 +110,7 @@ GeographicViewShowElementInfo::~GeographicViewShowElementInfo() {
 }
 
 void GeographicViewShowElementInfo::clear() {
-  dynamic_cast<GeographicView*>(view())->getGeographicViewGraphicsView()->getGlMainWidget()->setCursor(QCursor());
+  static_cast<GeographicView*>(view())->getGeographicViewGraphicsView()->getGlMainWidget()->setCursor(QCursor());
   _informationWidgetItem->setVisible(false);
 }
 
@@ -129,7 +130,7 @@ bool GeographicViewShowElementInfo::eventFilter(QObject *widget, QEvent* e) {
   QMouseEvent * qMouseEv = dynamic_cast<QMouseEvent *>(e);
 
   if(qMouseEv != NULL) {
-    GeographicView *geoView=dynamic_cast<GeographicView*>(view());
+    GeographicView *geoView=static_cast<GeographicView*>(view());
     SelectedEntity selectedEntity;
 
     if(e->type() == QEvent::MouseMove) {
@@ -233,7 +234,7 @@ bool GeographicViewShowElementInfo::eventFilter(QObject *widget, QEvent* e) {
 }
 
 bool GeographicViewShowElementInfo::pick(int x, int y, SelectedEntity &selectedEntity) {
-  GeographicView *geoView=dynamic_cast<GeographicView*>(view());
+  GeographicView *geoView=static_cast<GeographicView*>(view());
 
   if(geoView->getGeographicViewGraphicsView()->getGlMainWidget()->pickNodesEdges(x,y,selectedEntity))
     return true;
@@ -254,7 +255,7 @@ void GeographicViewShowElementInfo::viewChanged(View * view) {
     return;
   }
 
-  GeographicView *geoView=dynamic_cast<GeographicView*>(view);
+  GeographicView *geoView=static_cast<GeographicView*>(view);
   _view=geoView;
   connect(_view,SIGNAL(graphSet(tlp::Graph*)),_informationWidgetItem,SLOT(close()));
   _view->getGeographicViewGraphicsView()->scene()->addItem(_informationWidgetItem);

--- a/plugins/view/GeographicView/GoogleMaps.cpp
+++ b/plugins/view/GeographicView/GoogleMaps.cpp
@@ -287,7 +287,7 @@ int GoogleMaps::getWorldWidth() {
   QVariant ret = executeJavascript(code);
 
   QString retStr = ret.toString();
-  return (int) (retStr.toDouble() + 1);
+  return int(retStr.toDouble() + 1);
 }
 
 string GoogleMaps::getLatLngForAddress(const QString &address, pair<double, double> &latLng, bool skipMultipleResults) {

--- a/plugins/view/HistogramView/GlyphScaleConfigDialog.cpp
+++ b/plugins/view/HistogramView/GlyphScaleConfigDialog.cpp
@@ -58,7 +58,7 @@ vector<int> GlyphScaleConfigDialog::getSelectedGlyphsId() const {
   vector<int> ret;
 
   for (int i = 0 ; i < _ui->tableWidget->rowCount() ; ++i) {
-    string glyphName = QStringToTlpString(((QComboBox *)_ui->tableWidget->cellWidget(i, 0))->currentText());
+    string glyphName = QStringToTlpString(static_cast<QComboBox *>(_ui->tableWidget->cellWidget(i, 0))->currentText());
     ret.push_back(PluginLister::pluginInformation(glyphName).id());
   }
 

--- a/plugins/view/HistogramView/Histogram.cpp
+++ b/plugins/view/HistogramView/Histogram.cpp
@@ -149,12 +149,12 @@ void Histogram::computeHistogram() {
   }
   else {
     if (dataLocation == NODE) {
-      min = (double) graph->getProperty<IntegerProperty>(propertyName)->getNodeMin(graph);
-      max = (double) graph->getProperty<IntegerProperty>(propertyName)->getNodeMax(graph);
+      min = graph->getProperty<IntegerProperty>(propertyName)->getNodeMin(graph);
+      max = graph->getProperty<IntegerProperty>(propertyName)->getNodeMax(graph);
     }
     else {
-      min = (double) graph->getProperty<IntegerProperty>(propertyName)->getEdgeMin(graph);
-      max = (double) graph->getProperty<IntegerProperty>(propertyName)->getEdgeMax(graph);
+      min = graph->getProperty<IntegerProperty>(propertyName)->getEdgeMin(graph);
+      max = graph->getProperty<IntegerProperty>(propertyName)->getEdgeMax(graph);
     }
   }
 
@@ -221,7 +221,7 @@ void Histogram::computeHistogram() {
 
       while (nodesIt->hasNext()) {
         node n = nodesIt->next();
-        unsigned int binId = (unsigned int) propertyCopy->getNodeValue(n);
+        unsigned int binId = uint(propertyCopy->getNodeValue(n));
         histogramBins[binId].push_back(n.id);
 
         if (histogramBins[binId].size() > maxBinSize) {
@@ -254,7 +254,7 @@ void Histogram::computeHistogram() {
 
       while (edgesIt->hasNext()) {
         edge e = edgesIt->next();
-        unsigned int binId = (unsigned int) propertyCopy->getEdgeValue(e);
+        unsigned int binId = uint(propertyCopy->getEdgeValue(e));
         histogramBins[binId].push_back(e.id);
 
         if (histogramBins[binId].size() > maxBinSize) {
@@ -317,11 +317,11 @@ void Histogram::computeHistogram() {
           integerScale = integerScale && (fracpart == 0);
         }
         else {
-          value = (double) graph->getProperty<IntegerProperty>(propertyName)->getNodeValue(n);
+          value = graph->getProperty<IntegerProperty>(propertyName)->getNodeValue(n);
         }
 
         if (value != max) {
-          unsigned int nodeHistoBin = clamp(static_cast<unsigned int>(floor((value - min) / binWidth)), 0, nbHistogramBins - 1);
+          unsigned int nodeHistoBin = clamp(uint(floor((value - min) / binWidth)), 0, nbHistogramBins - 1);
           histogramBins[nodeHistoBin].push_back(n.id);
 
           if (histogramBins[nodeHistoBin].size() > maxBinSize) {
@@ -354,11 +354,11 @@ void Histogram::computeHistogram() {
           integerScale = integerScale && (fracpart == 0);
         }
         else {
-          value = (double) graph->getProperty<IntegerProperty>(propertyName)->getEdgeValue(e);
+          value = graph->getProperty<IntegerProperty>(propertyName)->getEdgeValue(e);
         }
 
         if (value != max) {
-          unsigned int nodeHistoBin = (unsigned int) floor((value - min) / binWidth);
+          unsigned int nodeHistoBin = uint(floor((value - min) / binWidth));
           histogramBins[nodeHistoBin].push_back(e.id);
 
           if (histogramBins[nodeHistoBin].size() > maxBinSize) {
@@ -409,15 +409,15 @@ void Histogram::createAxis() {
   initYAxisScale = make_pair(minAxisValue, maxAxisValue);
 
   if (yAxisScaleDefined) {
-    if (yAxisScale.first < (double)minAxisValue)
-      minAxisValue = (unsigned int)yAxisScale.first;
+    if (yAxisScale.first < double(minAxisValue))
+      minAxisValue = uint(yAxisScale.first);
 
-    if (yAxisScale.second > (double)maxAxisValue)
-      maxAxisValue = (unsigned int)yAxisScale.second;
+    if (yAxisScale.second > double(maxAxisValue))
+      maxAxisValue = uint(yAxisScale.second);
   }
 
-  yAxisScale.first = (double)minAxisValue;
-  yAxisScale.second = (double)maxAxisValue;
+  yAxisScale.first = minAxisValue;
+  yAxisScale.second = maxAxisValue;
 
   yAxisIncrementStep = maxAxisValue / 10;
 
@@ -444,7 +444,7 @@ void Histogram::createAxis() {
   }
 
   yAxis = new GlQuantitativeAxis((dataLocation == NODE ? "number of nodes" : "number of edges"), Coord(0,0,0), axisLength, GlAxis::VERTICAL_AXIS, textColor);
-  yAxis->setAxisParameters((int) minAxisValue ,(int) maxAxisValue, yAxisIncrementStep, GlAxis::LEFT_OR_BELOW, true);
+  yAxis->setAxisParameters(int(minAxisValue) , int(maxAxisValue), yAxisIncrementStep, GlAxis::LEFT_OR_BELOW, true);
   yAxis->setLogScale(yAxisLogScale);
   float yAxisGradsWidth = axisLength / 20;
   yAxis->setAxisGradsWidth(yAxisGradsWidth);
@@ -466,13 +466,13 @@ void Histogram::createAxis() {
   }
   else {
     if (integerScale) {
-      long long axisMin = (long long) min;
-      long long axisMax = (long long) max;
+      long long axisMin = static_cast<long long>(min);
+      long long axisMax = static_cast<long long>(max);
 
       // check the [min, max] double values range
       // fit in a long long range
       if (axisMax != LLONG_MIN) {
-        long long incrementStep = (long long) ((max - min) / nbXGraduations);
+        long long incrementStep = static_cast<long long>((max - min) / nbXGraduations);
 
         if (incrementStep <1) incrementStep = 1;
 
@@ -659,7 +659,7 @@ void Histogram::update() {
     for (unsigned int j = 0 ; j < binSize ; ++j) {
       if (dataLocation == NODE) {
         for (unsigned int k = 0 ; k < 4 ; ++k ) {
-          quadColorCumul[k] += (unsigned int) viewColor->getNodeValue(node(histogramBins[i][j]))[k];
+          quadColorCumul[k] += uint(viewColor->getNodeValue(node(histogramBins[i][j]))[k]);
         }
       }
     }

--- a/plugins/view/HistogramView/HistogramInteractors.cpp
+++ b/plugins/view/HistogramView/HistogramInteractors.cpp
@@ -152,7 +152,7 @@ public:
 
 
   void viewChanged(View *v) {
-    hView = (HistogramView *) v;
+    hView = static_cast<HistogramView *>(v);
     MouseShowElementInfo::viewChanged(v);
   }
 

--- a/plugins/view/HistogramView/HistogramMetricMapping.cpp
+++ b/plugins/view/HistogramView/HistogramMetricMapping.cpp
@@ -767,12 +767,14 @@ void HistogramMetricMapping::initInteractor() {
 
 bool HistogramMetricMapping::eventFilter(QObject *widget, QEvent *e) {
 
-  if(!dynamic_cast<QMouseEvent *>(e))
+  QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+
+  if(!me)
     return false;
 
   bool ret  = false;
 
-  GlMainWidget *glWidget = (GlMainWidget *) widget;
+  GlMainWidget *glWidget = static_cast<GlMainWidget *>(widget);
 
   if (!glWidget->hasMouseTracking()) {
     glWidget->setMouseTracking(true);
@@ -783,10 +785,9 @@ bool HistogramMetricMapping::eventFilter(QObject *widget, QEvent *e) {
   initInteractor();
 
   if (e->type() == QEvent::MouseMove) {
-    QMouseEvent *me = (QMouseEvent *) e;
     int x = glWidget->width() - me->x();
     int y = me->y();
-    Coord screenCoords((double) x, (double) y, 0);
+    Coord screenCoords(x, y, 0);
     Coord sceneCoords(glWidget->getScene()->getGraphCamera().viewportTo3DWorld(glWidget->screenToViewport(screenCoords)));
 
     if (!curveDragStarted) {
@@ -828,10 +829,9 @@ bool HistogramMetricMapping::eventFilter(QObject *widget, QEvent *e) {
       selectedAnchor = NULL;
     }
     else {
-      QMouseEvent *me = (QMouseEvent *) e;
       int x = glWidget->width() - me->x();
       int y = me->y();
-      Coord screenCoords((double) x, (double) y, 0);
+      Coord screenCoords(x, y, 0);
       Coord sceneCoords(glWidget->getScene()->getGraphCamera().viewportTo3DWorld(glWidget->screenToViewport(screenCoords)));
 
       if (curve->pointBelong(sceneCoords)) {
@@ -865,7 +865,6 @@ bool HistogramMetricMapping::eventFilter(QObject *widget, QEvent *e) {
     ret =  true;
   }
   else if (e->type() == QEvent::MouseButtonPress) {
-    QMouseEvent *me = (QMouseEvent *) e;
 
     if (me->buttons() == Qt::LeftButton && selectedAnchor != NULL) {
       curveDragStarted = true;
@@ -874,7 +873,7 @@ bool HistogramMetricMapping::eventFilter(QObject *widget, QEvent *e) {
     else if (me->buttons() == Qt::RightButton) {
       int x = glWidget->width() - me->x();
       int y = me->y();
-      Coord screenCoords((double) x, (double) y, 0);
+      Coord screenCoords(x, y, 0);
       Coord sceneCoords(glWidget->getScene()->getGraphCamera().viewportTo3DWorld(glWidget->screenToViewport(screenCoords)));
 
       if (pointerUnderScale(sceneCoords)) {

--- a/plugins/view/HistogramView/HistogramStatistics.cpp
+++ b/plugins/view/HistogramView/HistogramStatistics.cpp
@@ -358,12 +358,12 @@ void HistogramStatistics::computeInteractor() {
   }
   else {
     if (histoView->getDataLocation() == NODE) {
-      min = (double) graph->getProperty<IntegerProperty>(selectedProperty)->getNodeMin();
-      max = (double) graph->getProperty<IntegerProperty>(selectedProperty)->getNodeMax();
+      min = graph->getProperty<IntegerProperty>(selectedProperty)->getNodeMin();
+      max = graph->getProperty<IntegerProperty>(selectedProperty)->getNodeMax();
     }
     else {
-      min = (double) graph->getProperty<IntegerProperty>(selectedProperty)->getEdgeMin();
-      max = (double) graph->getProperty<IntegerProperty>(selectedProperty)->getEdgeMax();
+      min = graph->getProperty<IntegerProperty>(selectedProperty)->getEdgeMin();
+      max = graph->getProperty<IntegerProperty>(selectedProperty)->getEdgeMax();
     }
   }
 
@@ -379,7 +379,7 @@ void HistogramStatistics::computeInteractor() {
         nodeVal = graph->getProperty<DoubleProperty>(selectedProperty)->getNodeValue(n);
       }
       else {
-        nodeVal = (double) graph->getProperty<IntegerProperty>(selectedProperty)->getNodeValue(n);
+        nodeVal = graph->getProperty<IntegerProperty>(selectedProperty)->getNodeValue(n);
       }
 
       graphPropertyValueSet[n.id] = nodeVal;
@@ -398,7 +398,7 @@ void HistogramStatistics::computeInteractor() {
         edgeVal = graph->getProperty<DoubleProperty>(selectedProperty)->getEdgeValue(e);
       }
       else {
-        edgeVal = (double) graph->getProperty<IntegerProperty>(selectedProperty)->getEdgeValue(e);
+        edgeVal = graph->getProperty<IntegerProperty>(selectedProperty)->getEdgeValue(e);
       }
 
       graphPropertyValueSet[e.id] = edgeVal;
@@ -430,10 +430,10 @@ void HistogramStatistics::computeInteractor() {
       float fx = 0;
 
       for (map<unsigned, double>::iterator it = graphPropertyValueSet.begin() ; it != graphPropertyValueSet.end() ; ++it) {
-        fx +=  (*kf)((val - (it->second)) / (bandwidth / 2.));
+        fx +=  float((*kf)((val - (it->second)) / (bandwidth / 2.)));
       }
 
-      fx *= (1. / (float) (graphPropertyValueSet.size() * (bandwidth / 2.)));
+      fx *= (1.f / float(graphPropertyValueSet.size() * (bandwidth / 2.)));
       estimatedDensity.push_back(fx);
 
       if (fx > maxDensityValue) {
@@ -452,7 +452,7 @@ void HistogramStatistics::computeInteractor() {
 
     densityAxis = new GlQuantitativeAxis("density", Coord(histoXAxis->getAxisBaseCoord().getX() + histoXAxis->getAxisLength(), 0, 0),
                                          histoYAxis->getAxisLength(), GlAxis::VERTICAL_AXIS, Color(255,0,0), true);
-    densityAxis->setAxisParameters((double) 0 ,(double) maxDensityValue, 15, GlAxis::RIGHT_OR_ABOVE, true);
+    densityAxis->setAxisParameters(0.0, double(maxDensityValue), 15, GlAxis::RIGHT_OR_ABOVE, true);
     densityAxis->updateAxis();
     densityAxis->addCaption(GlAxis::LEFT, densityAxis->getSpaceBetweenAxisGrads(), false);
   }

--- a/plugins/view/HistogramView/HistogramView.cpp
+++ b/plugins/view/HistogramView/HistogramView.cpp
@@ -430,7 +430,7 @@ bool HistogramView::eventFilter(QObject *object, QEvent *event) {
     QHelpEvent *he = static_cast<QHelpEvent *>(event);
     int x = glw->width() - he->x();
     int y = he->y();
-    Coord screenCoords((double) x, (double) y, 0);
+    Coord screenCoords(x, y, 0);
     Coord sceneCoords(glw->getScene()->getLayer("Main")->getCamera().viewportTo3DWorld(glw->screenToViewport(screenCoords)));
     BoundingBox xAxisBB = xAxisDetail->getBoundingBox();
 
@@ -621,8 +621,8 @@ void HistogramView::buildHistograms() {
   float spaceBetweenOverviews = OVERVIEW_SIZE / 10.f;
   float labelHeight = OVERVIEW_SIZE / 6.0f;
 
-  float squareRoot = sqrt(double(selectedProperties.size()));
-  const unsigned int N =  (unsigned int) squareRoot + (fmod((float) selectedProperties.size(), squareRoot) == 0. ? 0 : 1);
+  float squareRoot = sqrt(float(selectedProperties.size()));
+  const unsigned int N =  uint(squareRoot) + (fmod(float(selectedProperties.size()), squareRoot) == 0.f ? 0u : 1u);
 
   Color backgroundColor(histoOptionsWidget->getBackgroundColor());
   getGlMainWidget()->getScene()->setBackgroundColor(backgroundColor);

--- a/plugins/view/HistogramView/SizeScaleConfigDialog.cpp
+++ b/plugins/view/HistogramView/SizeScaleConfigDialog.cpp
@@ -34,11 +34,11 @@ SizeScaleConfigDialog::~SizeScaleConfigDialog() {
 }
 
 float SizeScaleConfigDialog::getMinSize() const {
-  return (float) _ui->minSizeSpinBox->value();
+  return float(_ui->minSizeSpinBox->value());
 }
 
 float SizeScaleConfigDialog::getMaxSize() const {
-  return (float) _ui->maxSizeSpinBox->value();
+  return float(_ui->maxSizeSpinBox->value());
 }
 
 bool SizeScaleConfigDialog::applySizeMappingOnX() const {

--- a/plugins/view/MatrixView/MatrixViewConfigurationWidget.cpp
+++ b/plugins/view/MatrixView/MatrixViewConfigurationWidget.cpp
@@ -132,7 +132,7 @@ void MatrixViewConfigurationWidget::orderingDirectionChanged() {
 }
 
 GridDisplayMode MatrixViewConfigurationWidget::gridDisplayMode() const {
-  return (GridDisplayMode)_ui->gridDisplayCombo->currentIndex();
+  return static_cast<GridDisplayMode>(_ui->gridDisplayCombo->currentIndex());
 }
 
 int MatrixViewConfigurationWidget::orderingProperty() const {

--- a/plugins/view/ParallelCoordinatesView/AxisConfigDialogs.cpp
+++ b/plugins/view/ParallelCoordinatesView/AxisConfigDialogs.cpp
@@ -65,9 +65,9 @@ QuantitativeAxisConfigDialog::QuantitativeAxisConfigDialog(QuantitativeParallelA
 
   if (axis->getAxisDataTypeName() == "int") {
     intAxisMinValue = new QSpinBox();
-    intAxisMinValue->setMaximum((int)axis->getAssociatedPropertyMinValue());
+    intAxisMinValue->setMaximum(int(axis->getAssociatedPropertyMinValue()));
     intAxisMinValue->setMinimum(INT_MIN);
-    intAxisMinValue->setValue((int)axis->getAxisMinValue());
+    intAxisMinValue->setValue(int(axis->getAxisMinValue()));
     axisMinLayout->addWidget(intAxisMinValue);
   }
   else {
@@ -82,9 +82,9 @@ QuantitativeAxisConfigDialog::QuantitativeAxisConfigDialog(QuantitativeParallelA
 
   if (axis->getAxisDataTypeName() == "int") {
     intAxisMaxValue = new QSpinBox();
-    intAxisMaxValue->setMinimum((int)axis->getAssociatedPropertyMaxValue());
+    intAxisMaxValue->setMinimum(int(axis->getAssociatedPropertyMaxValue()));
     intAxisMaxValue->setMaximum(INT_MAX);
-    intAxisMaxValue->setValue((int)axis->getAxisMaxValue());
+    intAxisMaxValue->setValue(int(axis->getAxisMaxValue()));
     axisMaxLayout->addWidget(intAxisMaxValue);
   }
   else {

--- a/plugins/view/ParallelCoordinatesView/NominalParallelAxis.cpp
+++ b/plugins/view/ParallelCoordinatesView/NominalParallelAxis.cpp
@@ -32,7 +32,7 @@ namespace tlp {
 
 NominalParallelAxis::NominalParallelAxis(const Coord &base_coord, const float height, const float axisAreaWidth, ParallelCoordinatesGraphProxy *graph, const std::string &propertyName, const Color &axisColor, const float rotationAngle, const GlAxis::CaptionLabelPosition captionPosition) :
   ParallelAxis(new GlNominativeAxis(propertyName, base_coord, height, GlAxis::VERTICAL_AXIS, axisColor), axisAreaWidth, rotationAngle, captionPosition), graphProxy(graph) {
-  glNominativeAxis = dynamic_cast<GlNominativeAxis *>(glAxis);
+  glNominativeAxis = static_cast<GlNominativeAxis *>(glAxis);
   setLabels();
   ParallelAxis::redraw();
 }

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordinatesDrawing.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordinatesDrawing.cpp
@@ -94,7 +94,7 @@ void ParallelCoordinatesDrawing::createAxis(GlMainWidget *glWidget,
     progressBar->setComment("Creating parallel axes ...");
     progressBar->progress(0, selectedProperties.size());
     glWidget->getScene()->centerScene();
-    float glWidth = (float) glWidget->getScene()->getBoundingBox().width();
+    float glWidth = glWidget->getScene()->getBoundingBox().width();
     glWidget->getScene()->zoomFactor((glWidth - 50)/ glWidth);
     glWidget->draw();
     // needed to display progressBar

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordinatesGraphProxy.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordinatesGraphProxy.cpp
@@ -149,7 +149,7 @@ Iterator<unsigned int> *ParallelCoordinatesGraphProxy::getDataIterator() {
 }
 
 Iterator<unsigned int> *ParallelCoordinatesGraphProxy::getSelectedDataIterator() {
-  BooleanProperty *viewSelection = (BooleanProperty *) getProperty("viewSelection");
+  BooleanProperty *viewSelection = static_cast<BooleanProperty *>(getProperty("viewSelection"));
 
   if (getDataLocation() == NODE) {
     return new ParallelCoordinatesDataIterator<node>(viewSelection->getNodesEqualTo(true, graph_component));
@@ -160,7 +160,7 @@ Iterator<unsigned int> *ParallelCoordinatesGraphProxy::getSelectedDataIterator()
 }
 
 Iterator<unsigned int> *ParallelCoordinatesGraphProxy::getUnselectedDataIterator() {
-  BooleanProperty *viewSelection = (BooleanProperty *) getProperty("viewSelection");
+  BooleanProperty *viewSelection = static_cast<BooleanProperty *>(getProperty("viewSelection"));
 
   if (getDataLocation() == NODE) {
     return new ParallelCoordinatesDataIterator<node>(viewSelection->getNodesEqualTo(false));

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordinatesView.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordinatesView.cpp
@@ -232,7 +232,7 @@ void ParallelCoordinatesView::setState(const DataSet &dataSet) {
     if (dataSet.exist("dataLocation")) {
       int dataLocation = 0;
       dataSet.get("dataLocation", dataLocation);
-      dataConfigWidget->setDataLocation((ElementType) dataLocation);
+      dataConfigWidget->setDataLocation(static_cast<ElementType>(dataLocation));
     }
 
     if (dataSet.exist("backgroundColor")) {
@@ -364,19 +364,19 @@ DataSet ParallelCoordinatesView::state() const {
   }
 
   dataSet.set("selectedProperties", selectedPropertiesData);
-  dataSet.set("dataLocation", (int) graphProxy->getDataLocation());
+  dataSet.set("dataLocation", int(graphProxy->getDataLocation()));
   dataSet.set("backgroundColor", drawConfigWidget->getBackgroundColor());
   dataSet.set("axisHeight", drawConfigWidget->getAxisHeight());
-  unsigned int axisPointMinSize = (unsigned int) drawConfigWidget->getAxisPointMinSize().getW();
-  unsigned int axisPointMaxSize = (unsigned int) drawConfigWidget->getAxisPointMaxSize().getW();
+  unsigned int axisPointMinSize = uint(drawConfigWidget->getAxisPointMinSize().getW());
+  unsigned int axisPointMaxSize = uint(drawConfigWidget->getAxisPointMaxSize().getW());
   dataSet.set("axisPointMinSize", axisPointMinSize);
   dataSet.set("axisPointMaxSize", axisPointMaxSize);
   dataSet.set("drawPointsOnAxis", drawConfigWidget->drawPointOnAxis());
   dataSet.set("linesTextureFileName", drawConfigWidget->getLinesTextureFilename());
   dataSet.set("linesColorAlphaValue", drawConfigWidget->getLinesColorAlphaValue());
   dataSet.set("non highlighted alpha value", drawConfigWidget->getUnhighlightedEltsColorsAlphaValue());
-  dataSet.set("layoutType", (int) getLayoutType());
-  dataSet.set("linesType", (int) getLinesType());
+  dataSet.set("layoutType", int(getLayoutType()));
+  dataSet.set("linesType", int(getLinesType()));
   dataSet.set("lastViewWindowWidth",  getGlMainWidget()->width());
   dataSet.set("lastViewWindowHeight",  getGlMainWidget()->height());
 

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisBoxPlot.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisBoxPlot.cpp
@@ -291,7 +291,7 @@ void ParallelCoordsAxisBoxPlot::viewChanged(View *view) {
     return;
   }
 
-  parallelView = dynamic_cast<ParallelCoordinatesView *>(view);
+  parallelView = static_cast<ParallelCoordinatesView *>(view);
   initOrUpdateBoxPlots();
 }
 
@@ -344,7 +344,7 @@ void ParallelCoordsAxisBoxPlot::deleteGlAxisPlot() {
 
 bool ParallelCoordsAxisBoxPlot::eventFilter(QObject *widget, QEvent *e) {
 
-  GlMainWidget *glWidget = dynamic_cast<GlMainWidget *>(widget);
+  GlMainWidget *glWidget = static_cast<GlMainWidget *>(widget);
 
   if(!glWidget)
     return false;
@@ -352,7 +352,7 @@ bool ParallelCoordsAxisBoxPlot::eventFilter(QObject *widget, QEvent *e) {
   initOrUpdateBoxPlots();
 
   if (e->type() == QEvent::MouseMove) {
-    QMouseEvent *me = (QMouseEvent *) e;
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
     int x = glWidget->width() - me->x();
     int y = me->y();
     Coord screenCoords(x, y, 0.0f);

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisSliders.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisSliders.cpp
@@ -185,7 +185,7 @@ void ParallelCoordsAxisSliders::viewChanged(View *view) {
     return;
   }
 
-  parallelView = dynamic_cast<ParallelCoordinatesView *>(view);
+  parallelView = static_cast<ParallelCoordinatesView *>(view);
   initOrUpdateSliders();
 }
 
@@ -237,7 +237,7 @@ void ParallelCoordsAxisSliders::initOrUpdateSliders() {
 
 bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
 
-  GlMainWidget *glWidget = dynamic_cast<GlMainWidget *>(widget);
+  GlMainWidget *glWidget = static_cast<GlMainWidget *>(widget);
 
   if(glWidget==NULL)
     return false;
@@ -251,7 +251,7 @@ bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
   }
 
   if (e->type() == QEvent::MouseMove) {
-    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
     int x = glWidget->width() - me->x();
     int y = me->y();
     Coord screenCoords(x, y, 0.0f);
@@ -350,7 +350,7 @@ bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
     return true;
   }
   else if (e->type() == QEvent::MouseButtonPress) {
-    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
 
     if (me->button() == Qt::LeftButton && selectedSlider != NULL && !axisSliderDragStarted) {
       axisSliderDragStarted = true;
@@ -359,7 +359,7 @@ bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
     }
     else if (selectedAxis != NULL && pointerBetweenSliders &&
              highlightedEltsSetOperation != ParallelCoordinatesDrawing::INTERSECTION && !slidersRangeDragStarted) {
-      QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+      QMouseEvent *me = static_cast<QMouseEvent *>(e);
       slidersRangeDragStarted = true;
       slidersRangeLength = axisSlidersMap[selectedAxis][TOP_SLIDER]->getSliderCoord().getY() -
                            axisSlidersMap[selectedAxis][BOTTOM_SLIDER]->getSliderCoord().getY();
@@ -369,7 +369,7 @@ bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
     }
   }
   else if (e->type() == QEvent::MouseButtonRelease) {
-    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
 
     if (me->button() == Qt::LeftButton && selectedAxis != NULL && (axisSliderDragStarted || slidersRangeDragStarted)) {
       axisSliderDragStarted = false;
@@ -391,7 +391,7 @@ bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
     }
   }
   else if (e->type() == QEvent::KeyPress) {
-    QKeyEvent *ke = dynamic_cast<QKeyEvent *>(e);
+    QKeyEvent *ke = static_cast<QKeyEvent *>(e);
 
     if (ke->key() == Qt::Key_Control) {
       highlightedEltsSetOperation = ParallelCoordinatesDrawing::INTERSECTION;
@@ -405,7 +405,7 @@ bool ParallelCoordsAxisSliders::eventFilter(QObject *widget, QEvent *e) {
     return true;
   }
   else if (e->type() == QEvent::KeyRelease) {
-    QKeyEvent *ke = dynamic_cast<QKeyEvent *>(e);
+    QKeyEvent *ke = static_cast<QKeyEvent *>(e);
 
     if (ke->key() == Qt::Key_Control || ke->key() == Qt::Key_Shift) {
       highlightedEltsSetOperation = ParallelCoordinatesDrawing::NONE;

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisSpacer.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisSpacer.cpp
@@ -37,10 +37,10 @@ ParallelCoordsAxisSpacer::ParallelCoordsAxisSpacer() : parallelView(NULL), selec
 
 bool ParallelCoordsAxisSpacer::eventFilter(QObject *widget, QEvent *e) {
 
-  GlMainWidget *glWidget = qobject_cast<GlMainWidget*>(widget);
+  GlMainWidget *glWidget = static_cast<GlMainWidget*>(widget);
+  QMouseEvent *me = static_cast<QMouseEvent *>(e);
 
   if (e->type() == QEvent::MouseMove) {
-    QMouseEvent *me = (QMouseEvent *) e;
 
     if (!dragStarted) {
       selectedAxis = parallelView->getAxisUnderPointer(me->x(), me->y());
@@ -51,7 +51,7 @@ bool ParallelCoordsAxisSpacer::eventFilter(QObject *widget, QEvent *e) {
           neighborsAxis = make_pair(allAxis[allAxis.size() - 1], allAxis[1]);
         }
         else {
-          neighborsAxis = make_pair((ParallelAxis *) NULL, allAxis[1]);
+          neighborsAxis = make_pair(static_cast<ParallelAxis *>(NULL), allAxis[1]);
         }
       }
       else if (selectedAxis == allAxis[allAxis.size() - 1]) {
@@ -59,7 +59,7 @@ bool ParallelCoordsAxisSpacer::eventFilter(QObject *widget, QEvent *e) {
           neighborsAxis = make_pair(allAxis[allAxis.size() - 2], allAxis[0]);
         }
         else {
-          neighborsAxis = make_pair(allAxis[allAxis.size() - 2], (ParallelAxis *) NULL);
+          neighborsAxis = make_pair(allAxis[allAxis.size() - 2], static_cast<ParallelAxis *>(NULL));
         }
       }
 
@@ -120,7 +120,7 @@ bool ParallelCoordsAxisSpacer::eventFilter(QObject *widget, QEvent *e) {
 
     return true;
   }
-  else if (e->type() == QEvent::MouseButtonPress && ((QMouseEvent *) e)->button() == Qt::LeftButton) {
+  else if (e->type() == QEvent::MouseButtonPress && me->button() == Qt::LeftButton) {
     if (selectedAxis != NULL && !dragStarted) {
       dragStarted = true;
     }
@@ -128,7 +128,7 @@ bool ParallelCoordsAxisSpacer::eventFilter(QObject *widget, QEvent *e) {
     return true;
 
   }
-  else if (e->type() == QEvent::MouseButtonRelease && ((QMouseEvent *) e)->button() == Qt::LeftButton) {
+  else if (e->type() == QEvent::MouseButtonRelease && me->button() == Qt::LeftButton) {
     if (selectedAxis != NULL && dragStarted) {
       dragStarted = false;
       selectedAxis = NULL;
@@ -165,7 +165,7 @@ bool ParallelCoordsAxisSpacer::draw(GlMainWidget *glMainWidget) {
 }
 
 void ParallelCoordsAxisSpacer::viewChanged(View *view) {
-  parallelView = dynamic_cast<ParallelCoordinatesView *>(view);
+  parallelView = static_cast<ParallelCoordinatesView *>(view);
 }
 
 

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisSwapper.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsAxisSwapper.cpp
@@ -45,17 +45,18 @@ ParallelCoordsAxisSwapper::ParallelCoordsAxisSwapper() : parallelView(NULL), sel
 ParallelCoordsAxisSwapper::~ParallelCoordsAxisSwapper() {}
 
 void ParallelCoordsAxisSwapper::viewChanged(View *view) {
-  parallelView = dynamic_cast<ParallelCoordinatesView *>(view);
+  parallelView = static_cast<ParallelCoordinatesView *>(view);
 }
 
 bool ParallelCoordsAxisSwapper::eventFilter(QObject *widget, QEvent *e) {
 
-  GlMainWidget *glWidget = dynamic_cast<GlMainWidget *>(widget);
+  GlMainWidget *glWidget = static_cast<GlMainWidget *>(widget);
+  QMouseEvent *me = static_cast<QMouseEvent *>(e);
 
   mouseMove = false;
 
   if (e->type() == QEvent::MouseMove && !axisSwapStarted) {
-    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+
     mouseMove = true;
 
     if (!dragStarted) {
@@ -90,7 +91,7 @@ bool ParallelCoordsAxisSwapper::eventFilter(QObject *widget, QEvent *e) {
     return true;
 
   }
-  else if (e->type() == QEvent::MouseButtonPress && ((QMouseEvent *) e)->button() == Qt::LeftButton) {
+  else if (e->type() == QEvent::MouseButtonPress && me->button() == Qt::LeftButton) {
     if (selectedAxis != NULL && !dragStarted) {
       dragStarted = true;
       parallelView->removeAxis(selectedAxis);
@@ -103,7 +104,7 @@ bool ParallelCoordsAxisSwapper::eventFilter(QObject *widget, QEvent *e) {
     return true;
 
   }
-  else if (e->type() == QEvent::MouseButtonRelease && ((QMouseEvent *) e)->button() == Qt::LeftButton) {
+  else if (e->type() == QEvent::MouseButtonRelease && me->button() == Qt::LeftButton) {
 
     if (selectedAxis != NULL && dragStarted) {
       selectedAxis->setRotationAngle(0.0f);

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsDrawConfigWidget.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsDrawConfigWidget.cpp
@@ -159,7 +159,7 @@ unsigned int ParallelCoordsDrawConfigWidget::getLinesColorAlphaValue() const {
     return 300;
   }
   else {
-    return (unsigned int) _ui->viewColorAlphaValue->value();
+    return _ui->viewColorAlphaValue->value();
   }
 }
 
@@ -176,7 +176,7 @@ void ParallelCoordsDrawConfigWidget::setDrawPointOnAxis(const bool drawPointOnAx
 }
 
 unsigned int ParallelCoordsDrawConfigWidget::getUnhighlightedEltsColorsAlphaValue() const {
-  return (unsigned int) _ui->nonHighlightedEltsAlphaValue->value();
+  return _ui->nonHighlightedEltsAlphaValue->value();
 }
 
 void ParallelCoordsDrawConfigWidget::setUnhighlightedEltsColorsAlphaValue(const unsigned int alphaValue) {

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsElementDeleter.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsElementDeleter.cpp
@@ -30,10 +30,10 @@ namespace tlp {
 bool ParallelCoordsElementDeleter::eventFilter(QObject *, QEvent *e) {
 
   if (e->type() == QEvent::MouseButtonPress) {
-    QMouseEvent *me = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
 
     if (me->buttons()==Qt::LeftButton) {
-      ParallelCoordinatesView *parallelView = dynamic_cast<ParallelCoordinatesView *>(view());
+      ParallelCoordinatesView *parallelView = static_cast<ParallelCoordinatesView *>(view());
       Observable::holdObservers();
       parallelView->deleteDataUnderPointer(me->x(), me->y());
       Observable::unholdObservers();

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsElementHighlighter.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsElementHighlighter.cpp
@@ -37,7 +37,7 @@ void ParallelCoordsElementHighlighter::selectedEntitiesHandler(ParallelCoordinat
 }
 
 ParallelCoordsElementHighlighter::~ParallelCoordsElementHighlighter() {
-  ParallelCoordinatesView *parallelView = dynamic_cast<ParallelCoordinatesView *>(view());
+  ParallelCoordinatesView *parallelView = static_cast<ParallelCoordinatesView *>(view());
 
   if (parallelView)
     parallelView->resetHighlightedElements();

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsElementShowInfo.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsElementShowInfo.cpp
@@ -25,7 +25,7 @@ using namespace std;
 namespace tlp {
 
 bool ParallelCoordsElementShowInfo::pick(int x, int y, SelectedEntity &selectedEntity) {
-  ParallelCoordinatesView *parallelView = dynamic_cast<ParallelCoordinatesView *>(view());
+  ParallelCoordinatesView *parallelView = static_cast<ParallelCoordinatesView *>(view());
   return parallelView->getDataUnderPointerProperties(x,y,selectedEntity);
 }
 

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordsGlEntitiesSelector.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordsGlEntitiesSelector.cpp
@@ -29,13 +29,13 @@ namespace tlp {
 
 bool ParallelCoordsGlEntitiesSelector::eventFilter(QObject *widget, QEvent *e) {
 
-  ParallelCoordinatesView *parallelView = dynamic_cast<ParallelCoordinatesView *>(view());
-  GlMainWidget *glMainWidget = dynamic_cast<GlMainWidget *>(widget);
+  ParallelCoordinatesView *parallelView = static_cast<ParallelCoordinatesView *>(view());
+  GlMainWidget *glMainWidget = static_cast<GlMainWidget *>(widget);
 
 
   if (e->type() == QEvent::MouseButtonPress) {
 
-    QMouseEvent *qMouseEv = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *qMouseEv = static_cast<QMouseEvent *>(e);
 
     if (qMouseEv->buttons()== Qt::LeftButton) {
 
@@ -55,7 +55,7 @@ bool ParallelCoordsGlEntitiesSelector::eventFilter(QObject *widget, QEvent *e) {
 
   if (e->type() == QEvent::MouseMove) {
 
-    QMouseEvent *qMouseEv = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *qMouseEv = static_cast<QMouseEvent *>(e);
 
     if (qMouseEv->buttons() & Qt::LeftButton && started) {
       if ((qMouseEv->x() > 0) && (qMouseEv->x() < glMainWidget->width()))
@@ -71,7 +71,7 @@ bool ParallelCoordsGlEntitiesSelector::eventFilter(QObject *widget, QEvent *e) {
 
   if (e->type() == QEvent::MouseButtonRelease) {
 
-    QMouseEvent *qMouseEv = dynamic_cast<QMouseEvent *>(e);
+    QMouseEvent *qMouseEv = static_cast<QMouseEvent *>(e);
 
     if (started) {
       Observable::holdObservers();

--- a/plugins/view/ParallelCoordinatesView/QuantitativeParallelAxis.cpp
+++ b/plugins/view/ParallelCoordinatesView/QuantitativeParallelAxis.cpp
@@ -99,7 +99,7 @@ void QuantitativeParallelAxis::computeBoxPlotCoords() {
       value = graphProxy->getPropertyValueForData<DoubleProperty, DoubleType> (getAxisName(), dataId);
     }
     else {
-      value = static_cast<double>(graphProxy->getPropertyValueForData<IntegerProperty, IntegerType> (getAxisName(), dataId));
+      value = double(graphProxy->getPropertyValueForData<IntegerProperty, IntegerType> (getAxisName(), dataId));
     }
 
     propertyValuesSet.insert(value);
@@ -197,7 +197,7 @@ double QuantitativeParallelAxis::getAssociatedPropertyMinValue() {
       return graphProxy->getPropertyMinValue<DoubleProperty, DoubleType>(getAxisName());
     }
     else {
-      return (double) graphProxy->getPropertyMinValue<IntegerProperty, IntegerType>(getAxisName());
+      return graphProxy->getPropertyMinValue<IntegerProperty, IntegerType>(getAxisName());
     }
   }
   else {
@@ -238,7 +238,7 @@ double QuantitativeParallelAxis::getAssociatedPropertyMaxValue() {
     return graphProxy->getPropertyMaxValue<DoubleProperty, DoubleType>(getAxisName());
   }
   else {
-    return (double) graphProxy->getPropertyMaxValue<IntegerProperty, IntegerType>(getAxisName());
+    return graphProxy->getPropertyMaxValue<IntegerProperty, IntegerType>(getAxisName());
   }
 }
 
@@ -259,7 +259,7 @@ Coord QuantitativeParallelAxis::getPointCoordOnAxisForData(const unsigned int da
     value = graphProxy->getPropertyValueForData<DoubleProperty, DoubleType>(getAxisName(), dataIdx);
   }
   else if (getAxisDataTypeName() == "int") {
-    value = static_cast<double>(graphProxy->getPropertyValueForData<IntegerProperty, IntegerType>(getAxisName(), dataIdx));
+    value = double(graphProxy->getPropertyValueForData<IntegerProperty, IntegerType>(getAxisName(), dataIdx));
   }
 
   Coord axisPointCoord(glQuantitativeAxis->getAxisPointCoordForValue(value));
@@ -297,7 +297,7 @@ double QuantitativeParallelAxis::getValueForAxisCoord(const Coord &axisCoord) {
 
 std::string QuantitativeParallelAxis::getTopSliderTextValue() {
   if (getAxisDataTypeName() == "int" || integerScale) {
-    int val = (int) getValueForAxisCoord(topSliderCoord);
+    int val = int(getValueForAxisCoord(topSliderCoord));
 
     if (glQuantitativeAxis->hasAscendingOrder()) {
       return getStringFromNumber(val == glQuantitativeAxis->getAxisMaxValue() ? val : val - 1);
@@ -316,7 +316,7 @@ std::string QuantitativeParallelAxis::getTopSliderTextValue() {
 
 std::string QuantitativeParallelAxis::getBottomSliderTextValue() {
   if (getAxisDataTypeName() == "int" || integerScale) {
-    int val = (int) getValueForAxisCoord(bottomSliderCoord);
+    int val = int(getValueForAxisCoord(bottomSliderCoord));
 
     if (!glQuantitativeAxis->hasAscendingOrder()) {
       return getStringFromNumber(val == glQuantitativeAxis->getAxisMaxValue() ? val : val - 1);

--- a/plugins/view/PixelOrientedView/POLIB/HSIColorSpace.cpp
+++ b/plugins/view/PixelOrientedView/POLIB/HSIColorSpace.cpp
@@ -52,16 +52,16 @@ RGBA HSI::getRGBA() const {
   RGBA ret;
 
   if (saturation == 0.0) {
-    ret[0] = (unsigned char) (intensity * 255);
-    ret[1] = (unsigned char) (intensity * 255);
-    ret[2] = (unsigned char) (intensity * 255);
-    ret[3] = 255;
+    ret[0] = uchar(intensity * 255);
+    ret[1] = uchar(intensity * 255);
+    ret[2] = uchar(intensity * 255);
+    ret[3] = uchar(255);
   }
   else {
-    ret[0] = (unsigned char) (value(hue + 0.0) * 255);                    // 0 Grad = 0 pi
-    ret[1] = (unsigned char) (value(hue + 4.0) * 255);                  // 240 Grad = 4/3 pi
-    ret[2] = (unsigned char) (value(hue + 2.0) * 255);                   // 120 Grad = 2/3 pi
-    ret[3] = 255;
+    ret[0] = uchar(value(hue + 0.0) * 255);                    // 0 Grad = 0 pi
+    ret[1] = uchar(value(hue + 4.0) * 255);                  // 240 Grad = 4/3 pi
+    ret[2] = uchar(value(hue + 2.0) * 255);                   // 120 Grad = 2/3 pi
+    ret[3] = uchar(255);
   }
 
   return ret;

--- a/plugins/view/PixelOrientedView/POLIB/LinearMappingColor.cpp
+++ b/plugins/view/PixelOrientedView/POLIB/LinearMappingColor.cpp
@@ -93,7 +93,7 @@ RGBA LinearMappingColor::getColor(const double &value, unsigned int) const {
   RGBA color;
 
   for (unsigned int i = 0; i<3 ; ++i) {
-    color[i] = (unsigned char)(double(startColor[i]) + (double(endColor[i]) - double(startColor[i])) * ratio);
+    color[i] = uchar(double(startColor[i]) + (double(endColor[i]) - double(startColor[i])) * ratio);
   }
 
   color[3] = 255;

--- a/plugins/view/PixelOrientedView/POLIB/PixelOrientedMediator.cpp
+++ b/plugins/view/PixelOrientedView/POLIB/PixelOrientedMediator.cpp
@@ -24,7 +24,7 @@ namespace pocore {
 PixelOrientedMediator::PixelOrientedMediator(LayoutFunction *layout, ColorFunction *color)
   : layout(layout), color(color), trans1(new FishEyesScreen()), trans2(new UniformDeformationScreen()),
     zoomBak(1), translationXBak(0), translationYBak(0), fishEyeRadiusBak(0),
-    centerItem((unsigned int) (-1)) {
+    centerItem(uint(-1)) {
   zoom = 1.0;
   totalMove[0] = 0;
   totalMove[1] = 0;
@@ -51,8 +51,8 @@ Vec2i PixelOrientedMediator::sceneToScreen(const pocore::Vec2i &p) {
   res1[0] += imageSize[0] / 2.0;
   res1[1] += imageSize[1] / 2.0;
   Vec2i result;
-  result[0] = (int) rint(res1[0]);
-  result[1] = (int) rint(res1[1]);
+  result[0] = int(rint(res1[0]));
+  result[1] = int(rint(res1[1]));
   return result;
 }
 
@@ -103,15 +103,15 @@ void PixelOrientedMediator::updateFishEyePosition(const int x, const int y, Dime
     point[0] = x;
     point[1] = y;
     Vec2f pos = screenToScene(point);
-    point[0] = (int) rint(pos[0]);
-    point[1] = (int) rint(pos[1]);
+    point[0] = int(rint(pos[0]));
+    point[1] = int(rint(pos[1]));
     centerItem = data->getItemIdAtRank(layout->unproject(point));
     fishCenter = trans2->project(pos);
     trans1->setCenter(fishCenter[0], fishCenter[1]);
   }
   else {
-    totalMove[0] += (int) ((lastMousePosition[0] - x) / zoom);
-    totalMove[1] -= (int) ((lastMousePosition[1] - yScreen) / zoom);
+    totalMove[0] += int((lastMousePosition[0] - x) / zoom);
+    totalMove[1] -= int((lastMousePosition[1] - yScreen) / zoom);
     totalFishMove[0] += lastMousePosition[0] - x;
     totalFishMove[1] += lastMousePosition[1] - yScreen;
   }
@@ -129,8 +129,8 @@ void PixelOrientedMediator::translateFishEye(const int x, const int y) {
 unsigned int PixelOrientedMediator::getRankForPixelPos(Vec2i pos) {
   Vec2f fPos = screenToScene(pos);
   Vec2i fPosI;
-  fPosI[0] = (int) rint(fPos[0]);
-  fPosI[1] = (int) rint(fPos[1]);
+  fPosI[0] = int(rint(fPos[0]));
+  fPosI[1] = int(rint(fPos[1]));
   return layout->unproject(fPosI);
 }
 
@@ -140,8 +140,8 @@ RGBA PixelOrientedMediator::getColorForPixelAtPos(Vec2i pos, DimensionBase *data
 
   Vec2f fPos = screenToScene(pos);
   Vec2i fPosI;
-  fPosI[0] = (int) rint(fPos[0]);
-  fPosI[1] = (int) rint(fPos[1]);
+  fPosI[0] = int(rint(fPos[0]));
+  fPosI[1] = int(rint(fPos[1]));
 
   unsigned int rank = layout->unproject(fPosI);
 
@@ -162,7 +162,7 @@ RGBA PixelOrientedMediator::getColorForPixelAtPos(Vec2i pos, DimensionBase *data
         for (unsigned int i = 0; i < 3; ++i) {
           double a = -double(curColor[i]);
           double b = curColor[i];
-          curColor[i] = (unsigned char) (a * dist * dist + b);
+          curColor[i] = uchar(a * dist * dist + b);
         }
       }
     }

--- a/plugins/view/PixelOrientedView/POLIB/SpiralLayout.cpp
+++ b/plugins/view/PixelOrientedView/POLIB/SpiralLayout.cpp
@@ -77,7 +77,7 @@ Vector<int, 2> SpiralLayout::project(const unsigned int _id) const {
       c = 1;
     else {
       //c = (int)ceil(eq2D(4., 4., 1. - float(_id)));
-      c = (int)ceil(eq2D2(1. - double(_id)));
+      c = int(ceil(eq2D2(1. - double(_id))));
     }
 
     unsigned int t1 = (c-1), t2 = t1 << 2;
@@ -107,7 +107,7 @@ Vector<int, 2> SpiralLayout::project(const unsigned int _id) const {
       break;
 
     default:
-      cerr << "[error] : " << (int)k << endl;
+      cerr << "[error] : " << int(k) << endl;
     }
   }
 

--- a/plugins/view/PixelOrientedView/POLIB/SquareLayout.cpp
+++ b/plugins/view/PixelOrientedView/POLIB/SquareLayout.cpp
@@ -33,11 +33,11 @@ unsigned int SquareLayout::unproject(const Vector<int, 2> &point) const {
   int x = point[0] + _width/2;
   int y = point[1] + _width/2;
 
-  if (x>int(_width)) return UINT_MAX;
+  if (x > int(_width)) return UINT_MAX;
 
-  if (y>int(_width)) return UINT_MAX;
+  if (y > int(_width)) return UINT_MAX;
 
-  return (unsigned int)y * _width + (unsigned int)x;
+  return uint(y) * _width + uint(x);
 }
 //==============================================================
 Vector<int, 2> SquareLayout::project(const unsigned int id) const {

--- a/plugins/view/PixelOrientedView/POLIB/ZOrderLayout.cpp
+++ b/plugins/view/PixelOrientedView/POLIB/ZOrderLayout.cpp
@@ -58,7 +58,7 @@ inline unsigned int zorderKey(const Vec2i &p, const unsigned char order) {
 //===============================================================
 namespace pocore {
 ZorderLayout::ZorderLayout(unsigned char order):order(order) {
-  shift = (int)rint(sqrt(pow(4., order))/2.);
+  shift = int(rint(sqrt(pow(4., order))/2.));
 }
 //==============================================================
 unsigned int ZorderLayout::unproject(const Vec2i &point) const {

--- a/plugins/view/PixelOrientedView/PixelOrientedView.cpp
+++ b/plugins/view/PixelOrientedView/PixelOrientedView.cpp
@@ -110,7 +110,7 @@ void PixelOrientedView::initGlWidget() {
   }
 
   if (mainLayer->findGlEntity("graph")) {
-    GlGraphComposite *lastGraphComposite = (GlGraphComposite *)mainLayer->findGlEntity("graph");
+    GlGraphComposite *lastGraphComposite = static_cast<GlGraphComposite *>(mainLayer->findGlEntity("graph"));
     Graph *theGraph = lastGraphComposite->getInputData()->getGraph();
 
     if(theGraph)
@@ -327,9 +327,9 @@ void PixelOrientedView::initLayoutFunctions() {
   delete squareLayout;
   delete zorderLayout;
 
-  hilbertLayout = new HilbertLayout((int) ceil(log(pixelOrientedGraph->numberOfNodes())/ log(4)));
-  squareLayout = new SquareLayout((int) ceil(sqrt(pixelOrientedGraph->numberOfNodes())));
-  zorderLayout = new ZorderLayout((int) ceil(log(pixelOrientedGraph->numberOfNodes())/ log(4)));
+  hilbertLayout = new HilbertLayout(int(ceil(log(pixelOrientedGraph->numberOfNodes())/ log(4))));
+  squareLayout = new SquareLayout(int(ceil(sqrt(pixelOrientedGraph->numberOfNodes()))));
+  zorderLayout = new ZorderLayout(int(ceil(log(pixelOrientedGraph->numberOfNodes())/ log(4))));
   layoutFunctionsMap["Zorder"] = zorderLayout;
   layoutFunctionsMap["Peano"] = hilbertLayout;
   layoutFunctionsMap["Square"] = squareLayout;
@@ -349,7 +349,7 @@ void PixelOrientedView::initPixelView() {
   overviewWidth = MIN_IMAGE_WIDTH;
   overviewHeight = MIN_IMAGE_HEIGHT;
 
-  minWidth = ((unsigned int) floor(sqrt((double)pixelOrientedGraph->numberOfNodes()))) + 1;
+  minWidth = uint(floor(sqrt(double(pixelOrientedGraph->numberOfNodes())))) + 1;
 
   while (minWidth > overviewWidth) {
     overviewWidth *= 2;
@@ -369,8 +369,8 @@ void PixelOrientedView::initPixelView() {
   if (selectedGraphProperties.empty())
     return;
 
-  float squareRoot = sqrt(double(selectedGraphProperties.size()));
-  const unsigned int N =  (unsigned int) squareRoot + (fmod((float) selectedGraphProperties.size(), squareRoot) == 0. ? 0 : 1);
+  float squareRoot = sqrt(float(selectedGraphProperties.size()));
+  const unsigned int N =  uint(squareRoot) + (fmod(float(selectedGraphProperties.size()), squareRoot) == 0.f ? 0u : 1u);
 
   for (size_t i = 0 ; i < selectedGraphProperties.size() ; ++i) {
 
@@ -625,7 +625,7 @@ void PixelOrientedView::centerView(bool) {
 
   // we apply a zoom factor to preserve a 50 px margin height
   // to ensure the scene will not be drawn under the configuration tabs title
-  float glHeight = (float) graphicsView()->height();
+  float glHeight = graphicsView()->height();
   getGlMainWidget()->getScene()->zoomFactor((glHeight - 50)/ glHeight);
   getGlMainWidget()->draw();
 }

--- a/plugins/view/SOMView/EditColorScaleInteractor.cpp
+++ b/plugins/view/SOMView/EditColorScaleInteractor.cpp
@@ -47,17 +47,10 @@ EditColorScaleInteractor::~EditColorScaleInteractor() {
 }
 
 bool EditColorScaleInteractor::eventFilter(QObject *obj, QEvent *event) {
-  tlp::GlMainWidget *glMainWidget = dynamic_cast<tlp::GlMainWidget*> (obj);
-
-  if (glMainWidget == NULL)
-    return false;
+  tlp::GlMainWidget *glMainWidget = static_cast<tlp::GlMainWidget*>(obj);
 
   if (event->type() == QEvent::MouseButtonDblClick) {
-    QMouseEvent *me = (QMouseEvent*) event;
-    GlMainWidget *glMainWidget = dynamic_cast<tlp::GlMainWidget*> (obj);
-
-    if (!glMainWidget)
-      return false;
+    QMouseEvent *me = static_cast<QMouseEvent*>(event);
 
     glMainWidget->getScene()->getGraphCamera().initGl();
     selectionLayer->set2DMode();
@@ -79,7 +72,7 @@ bool EditColorScaleInteractor::eventFilter(QObject *obj, QEvent *event) {
           foundGlColorScale = true;
 
           if (dialog.exec()) {
-            SOMView *somView = dynamic_cast<SOMView*> (view());
+            SOMView *somView = static_cast<SOMView*> (view());
             // update shared color scale
             somView->getColorScale()->setColorMap(dialog.getColorScale().getColorMap());
             somView->updateDefaultColorProperty();
@@ -98,7 +91,7 @@ bool EditColorScaleInteractor::eventFilter(QObject *obj, QEvent *event) {
   return false;
 }
 void EditColorScaleInteractor::viewChanged(View *view) {
-  SOMView *somView = dynamic_cast<SOMView*> (view);
+  SOMView *somView = static_cast<SOMView*> (view);
 
   if (somView != NULL) {
     assert(colorScale == NULL);
@@ -115,7 +108,7 @@ void EditColorScaleInteractor::viewChanged(View *view) {
 }
 
 bool EditColorScaleInteractor::compute(GlMainWidget *) {
-  SOMView *somView = dynamic_cast<SOMView*> (view());
+  SOMView *somView = static_cast<SOMView*> (view());
   assert(somView != NULL);
 
   screenSizeChanged(somView);
@@ -123,7 +116,7 @@ bool EditColorScaleInteractor::compute(GlMainWidget *) {
 }
 
 bool EditColorScaleInteractor::draw(GlMainWidget *glMainWidget) {
-  SOMView *somView = dynamic_cast<SOMView*> (view());
+  SOMView *somView = static_cast<SOMView*> (view());
   assert(somView != NULL);
 
   if (colorScale) {

--- a/plugins/view/SOMView/GradientManager.cpp
+++ b/plugins/view/SOMView/GradientManager.cpp
@@ -47,7 +47,7 @@ void GradientManager::init(const std::vector<std::string>& properties) {
     return;
 
   int shift =
-    (int) floor(double((endColorRange - beginColorRange) / properties.size()));
+    int(floor(double((endColorRange - beginColorRange) / properties.size())));
   pair<Color, Color> newColors;
   newColors.first.setV(255);
   newColors.first.setS(255);

--- a/plugins/view/SOMView/SOMLIB/InputSample.cpp
+++ b/plugins/view/SOMView/SOMLIB/InputSample.cpp
@@ -88,7 +88,7 @@ void InputSample::buildPropertyVector(
 
       if (type.compare("double") == 0 || type.compare("int") == 0) {
         propertiesNameList.push_back(*it);
-        propertiesList.push_back((NumericProperty*) property);
+        propertiesList.push_back(static_cast<NumericProperty*>(property));
       }
       else {
         cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << " "

--- a/plugins/view/SOMView/SOMLIB/SOMMap.cpp
+++ b/plugins/view/SOMView/SOMLIB/SOMMap.cpp
@@ -81,7 +81,7 @@ void SOMMap::initMap() {
     gridDataSet .set("connectivity", connectivityCollection);
     gridDataSet.set("oppositeNodesConnected", oppositeConnected);
     //Suppress spacing
-    gridDataSet.set("spacing", (double) 0.0);
+    gridDataSet.set("spacing", 0.0);
     graph_component = importGraph("Grid", gridDataSet, NULL, graph_component);
   }
 
@@ -158,7 +158,7 @@ void SOMMap::registerModification(const vector<string>&propertiesToListen) {
 
       //If the property is double no need to convert
       if (properties[propertyNumber]->getTypename().compare("double") == 0) {
-        ((DoubleProperty*) properties[propertyNumber])->setNodeValue(n,
+        static_cast<DoubleProperty*>(properties[propertyNumber])->setNodeValue(n,
             nodeToNodeVec[n][propertyNumber]);
       }
       else {
@@ -172,7 +172,7 @@ void SOMMap::registerModification(const vector<string>&propertiesToListen) {
   }
 }
 tlp::node SOMMap::getNodeAt(unsigned int pos) {
-  return getNodeAt(pos % height, (unsigned int) floor(pos / height));
+  return getNodeAt(pos % height, uint(floor(pos / height)));
 
 }
 tlp::node SOMMap::getNodeAt(unsigned int x, unsigned int y) {

--- a/plugins/view/SOMView/SOMMapElement.cpp
+++ b/plugins/view/SOMView/SOMMapElement.cpp
@@ -100,7 +100,7 @@ void SOMMapElement::buildMainComposite(tlp::Coord basePos, tlp::Size gridSize,
         n = map->getNodeAt(j, i);
         Color c = Color(255, 255, 255, 0);
         tlp::GlCircle *hex = new tlp::GlCircle(center, r, c, c, true, false,
-                                               static_cast<float>(M_PI / 2), 6);
+                                               float(M_PI / 2), 6);
         oss.str("");
         oss << j << "," << i;
         addGlEntity(hex, oss.str());
@@ -141,11 +141,11 @@ void SOMMapElement::updateColors(ColorProperty *newColor) {
   SOMMap::SOMMapConnectivity connect = som->getConnectivity();
   forEach(n,som->getNodes()) {
     if (connect == SOMMap::six) {
-      GlCircle *hex = (GlCircle*) nodesMap[n];
+      GlCircle *hex = static_cast<GlCircle*>(nodesMap[n]);
       hex->setFillColor(newColor->getNodeValue(n));
     }
     else {
-      GlRect *rect = (GlRect*) nodesMap[n];
+      GlRect *rect = static_cast<GlRect*>(nodesMap[n]);
       rect->setBottomRightColor(newColor->getNodeValue(n));
       rect->setTopLeftColor(newColor->getNodeValue(n));
     }

--- a/plugins/view/SOMView/SOMPreviewComposite.cpp
+++ b/plugins/view/SOMView/SOMPreviewComposite.cpp
@@ -92,7 +92,7 @@ Size SOMPreviewComposite::computeAspectRatio(unsigned int width, unsigned int he
 
   if (width > height) {
     elementsSize.setW(maxWidth);
-    elementsSize.setH((elementsSize.getW() * height) / (float) width);
+    elementsSize.setH((elementsSize.getW() * height) / width);
   }
   else {
     elementsSize.setH(maxHeight);

--- a/plugins/view/SOMView/SOMPropertiesWidget.cpp
+++ b/plugins/view/SOMView/SOMPropertiesWidget.cpp
@@ -70,7 +70,7 @@ QList<QWidget *> SOMPropertiesWidget::configurationWidgets() const {
 
   QList<QWidget *> widgets;
 
-  widgets << dimensionConfigurationWidget << (QWidget *) this;
+  widgets << dimensionConfigurationWidget << const_cast<QWidget *>(static_cast<const QWidget*>(this));
 
   return widgets;
 }
@@ -215,7 +215,7 @@ DataSet SOMPropertiesWidget::getData() const {
   data.set("linkColors", getLinkColor());
 
   //SizeMapping
-  data.set("useSizeMapping", (bool) (getSizeMapping() == SOMPropertiesWidget::RealNodeSizeMapping));
+  data.set("useSizeMapping", getSizeMapping() == SOMPropertiesWidget::RealNodeSizeMapping);
 
   //Animation
   data.set("withAnimation", useAnimation());

--- a/plugins/view/SOMView/SOMView.cpp
+++ b/plugins/view/SOMView/SOMView.cpp
@@ -345,14 +345,14 @@ void SOMView::drawPreviews() {
   int thumbHeight = 50;
   int spacing = 5;
   int pos = 0;
-  int colNumber = (int) ceil(sqrt(double(propertiesName.size())));
+  int colNumber = int(ceil(sqrt(double(propertiesName.size()))));
 
   for (vector<string>::iterator it = propertiesName.begin(); it != propertiesName.end(); ++it) {
     double minValue;
     double maxValue;
     ColorProperty *colorProperty = computePropertyColor((*it), minValue, maxValue);
 
-    Coord previewCoord((pos % colNumber) * (thumbWidth + spacing), ((colNumber - 1) - ((int) floor(pos / colNumber))) * (thumbHeight + spacing), 0);
+    Coord previewCoord((pos % colNumber) * (thumbWidth + spacing), (colNumber - 1) - int(floor(pos / colNumber)) * (thumbHeight + spacing), 0);
     Size previewSize(thumbWidth, thumbHeight, 0);
 
     //If the input data uses normalized values we had to translate it to get the real value.
@@ -539,7 +539,7 @@ void SOMView::buildSOMMap() {
   //Keep aspect ratio
   if (som->getWidth() > som->getHeight()) {
     somSize.setW(somMawWidth);
-    somSize.setH((somSize.getW() * som->getHeight()) / (float) som->getWidth());
+    somSize.setH((somSize.getW() * som->getHeight()) / som->getWidth());
   }
   else {
     somSize.setH(somMaxHeight);
@@ -668,10 +668,10 @@ void SOMView::computeMapping() {
   Coord marginShift(nodeDisplayAreaSize.getW() * marginCoef, -(nodeDisplayAreaSize.getH() * marginCoef));
   Size realAreaSize = nodeDisplayAreaSize * (1 - marginCoef * 2);
   //Compute elements size
-  int colNumber = (int) ceil(sqrt(maxSize));
+  int colNumber = int(ceil(sqrt(maxSize)));
 
-  float maxElementWidth = realAreaSize.getW() / (float) colNumber;
-  float maxElementHeight = realAreaSize.getH() / (float) colNumber;
+  float maxElementWidth = realAreaSize.getW() / colNumber;
+  float maxElementHeight = realAreaSize.getH() / colNumber;
 
   float minElementWidth = maxElementWidth * minElementSizeCoef;
   float minElementHeight = maxElementHeight * minElementSizeCoef;
@@ -773,7 +773,7 @@ void SOMView::getPreviewsAtViewportCoord(int x, int y, std::vector<SOMPreviewCom
 
   for (vector<SelectedEntity>::iterator itEntities = selectedEntities.begin(); itEntities != selectedEntities.end(); ++itEntities) {
     for (map<string, SOMPreviewComposite*>::iterator itSOM = propertyToPreviews.begin(); itSOM != propertyToPreviews.end(); ++itSOM) {
-      if (itSOM->second->isElement((GlSimpleEntity*) (itEntities->getSimpleEntity()))) {
+      if (itSOM->second->isElement(itEntities->getSimpleEntity())) {
         result.push_back(itSOM->second);
       }
     }
@@ -791,7 +791,7 @@ void SOMView::computeColor(SOMMap* som, tlp::NumericProperty* property, tlp::Col
     float pos = 0;
 
     if (max - min != 0)
-      pos = fabs((float) ((curentValue - min) / (max - min)));
+      pos = fabs(float((curentValue - min) / (max - min)));
 
     result->setNodeValue(n, colorScale.getColorAtPos(pos));
   }
@@ -801,7 +801,7 @@ bool SOMView::eventFilter(QObject *obj, QEvent *event) {
 
   if (obj == previewWidget) {
     if (event->type() == QMouseEvent::MouseButtonDblClick) {
-      QMouseEvent *me = (QMouseEvent*) event;
+      QMouseEvent *me = static_cast<QMouseEvent*>(event);
 
       if (me->button() == Qt::LeftButton) {
         vector<SOMPreviewComposite*> properties;
@@ -819,7 +819,7 @@ bool SOMView::eventFilter(QObject *obj, QEvent *event) {
     }
 
     if (event->type() == QMouseEvent::ToolTip) {
-      QHelpEvent *he = (QHelpEvent*) event;
+      QHelpEvent *he = static_cast<QHelpEvent*>(event);
       vector<SOMPreviewComposite*> properties;
       Coord screenCoords(he->x(), he->y(), 0.0f);
       Coord viewportCoords = getGlMainWidget()->screenToViewport(screenCoords);

--- a/plugins/view/SOMView/ThresholdInteractor.cpp
+++ b/plugins/view/SOMView/ThresholdInteractor.cpp
@@ -333,20 +333,21 @@ bool ThresholdInteractor::draw(GlMainWidget *glMainWidget) {
 }
 bool ThresholdInteractor::eventFilter(QObject * widget, QEvent * event) {
 
-  GlMainWidget *glMainWidget = dynamic_cast<GlMainWidget*>(widget);
-  SOMView *somView = dynamic_cast<SOMView*>(view());
+  GlMainWidget *glMainWidget = static_cast<GlMainWidget*>(widget);
+  SOMView *somView = static_cast<SOMView*>(view());
 
-  if (event->type() == QEvent::MouseButtonPress && ((QMouseEvent*) event)->button()
-      == Qt::LeftButton) {
+  QMouseEvent *me = static_cast<QMouseEvent*>(event);
 
-    QMouseEvent *e = static_cast<QMouseEvent*>(event);
+  if (event->type() == QEvent::MouseButtonPress &&
+      me->button() == Qt::LeftButton) {
+
     vector<SelectedEntity> selectedEntities;
     //set<Slider*> finalSelectedEntities;
 
     //Update Camera for selection
     layer->set2DMode();
     glMainWidget->getScene()->addExistingLayer(layer);
-    glMainWidget->getScene()->selectEntities(RenderingSimpleEntities, e->x(), e->y(), 0, 0, layer,
+    glMainWidget->getScene()->selectEntities(RenderingSimpleEntities, me->x(), me->y(), 0, 0, layer,
         selectedEntities);
     glMainWidget->getScene()->removeLayer(layer,false);
 
@@ -392,7 +393,7 @@ bool ThresholdInteractor::eventFilter(QObject * widget, QEvent * event) {
         //mouvingSlider = *finalSelectedEntities.begin();
         assert(mouvingSlider);
         mouvingSlider->beginShift();
-        XPosCursor = e->x();
+        XPosCursor = me->x();
         glMainWidget->getScene()->getGraphCamera().initGl();
 
         layer->setVisible(false);
@@ -409,9 +410,8 @@ bool ThresholdInteractor::eventFilter(QObject * widget, QEvent * event) {
 
   if (event->type() == QEvent::MouseMove) {
     if (startDrag) {
-      QMouseEvent *e = (QMouseEvent*) event;
-      float xShift = e->x() - XPosCursor;
-      XPosCursor = e->x();
+      float xShift = me->x() - XPosCursor;
+      XPosCursor = me->x();
 
       if (xShift == 0) {
         return true;
@@ -425,7 +425,6 @@ bool ThresholdInteractor::eventFilter(QObject * widget, QEvent * event) {
   }
 
   if (event->type() == QEvent::MouseButtonRelease && startDrag) {
-    QMouseEvent *me = (QMouseEvent*) event;
     SOMMap *som = somView->getSOM();
     assert(mouvingSlider != NULL);
     glMainWidget->setMouseTracking(false);

--- a/plugins/view/SOMView/ZoomUtils.cpp
+++ b/plugins/view/SOMView/ZoomUtils.cpp
@@ -59,7 +59,7 @@ void zoomOnScreenRegionWithoutAnimation(GlMainWidget *glWidget, const BoundingBo
   double zoomEnd = zoomStart * zoomFactor;
   bool withZoom = zoomFactor < 0.99 || zoomFactor > 1.01;
 
-  Coord newCamCenter = (Coord(boundingBox[0]) + Coord(boundingBox[1])) / ((float)2.0);
+  Coord newCamCenter = Coord(boundingBox[0]) + Coord(boundingBox[1]) / 2.0f;
   newCamCenter.setZ(boundingBox[0][2]);
 
   camera.setCenter(newCamCenter);

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2D.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2D.cpp
@@ -155,7 +155,7 @@ void ScatterPlot2D::generateOverview(GlMainWidget *glWidget, LayoutProperty *rev
     }
 
     for (unsigned int i = 0; i < 4; ++i) {
-      backgroundColor[i] = static_cast<unsigned char>((double(startColor[i]) + (double(endColor[i])- double(startColor[i])) * abs(correlationCoeff)));
+      backgroundColor[i] = uchar((double(startColor[i]) + (double(endColor[i])- double(startColor[i])) * abs(correlationCoeff)));
     }
 
     int bgV = backgroundColor.getV();
@@ -213,8 +213,8 @@ void ScatterPlot2D::clean() {
 void ScatterPlot2D::createAxis() {
   assert(dynamic_cast<NumericProperty *>(graph->getProperty(xDim)));
   assert(dynamic_cast<NumericProperty *>(graph->getProperty(yDim)));
-  NumericProperty* xProp = (NumericProperty *) graph->getProperty(xDim);
-  NumericProperty* yProp = (NumericProperty *) graph->getProperty(yDim);
+  NumericProperty* xProp = static_cast<NumericProperty *>( graph->getProperty(xDim));
+  NumericProperty* yProp = static_cast<NumericProperty *>( graph->getProperty(yDim));
   xType = graph->getProperty(xDim)->getTypename();
   yType = graph->getProperty(yDim)->getTypename();
 
@@ -270,8 +270,8 @@ void ScatterPlot2D::createAxis() {
     xAxis->setAxisParameters(xMin ,xMax, DEFAULT_NB_GRADS, GlAxis::LEFT_OR_BELOW, true);
   }
   else {
-    unsigned int step = static_cast<unsigned int>((xMax - xMin) / 20);
-    xAxis->setAxisParameters(static_cast<int>(xMin), static_cast<int>(xMax),
+    unsigned int step = uint((xMax - xMin) / 20);
+    xAxis->setAxisParameters(int(xMin), int(xMax),
                              step ? step : 1, GlAxis::LEFT_OR_BELOW, true);
   }
 
@@ -285,8 +285,8 @@ void ScatterPlot2D::createAxis() {
     yAxis->setAxisParameters(yMin ,yMax, DEFAULT_NB_GRADS, GlAxis::LEFT_OR_BELOW, true);
   }
   else {
-    unsigned int step = static_cast<unsigned int>((yMax - yMin) / 20);
-    yAxis->setAxisParameters(static_cast<int>(yMin) ,static_cast<int>(yMax),
+    unsigned int step = uint((yMax - yMin) / 20);
+    yAxis->setAxisParameters(int(yMin) ,int(yMax),
                              step ? step : 1, GlAxis::LEFT_OR_BELOW, true);
   }
 
@@ -315,8 +315,8 @@ void ScatterPlot2D::computeScatterPlotLayout(GlMainWidget *glWidget, LayoutPrope
 
   assert(dynamic_cast<NumericProperty *>(graph->getProperty(xDim)));
   assert(dynamic_cast<NumericProperty *>(graph->getProperty(yDim)));
-  NumericProperty* xProp = (NumericProperty *) graph->getProperty(xDim);
-  NumericProperty* yProp = (NumericProperty *) graph->getProperty(yDim);
+  NumericProperty* xProp = static_cast<NumericProperty *>(graph->getProperty(xDim));
+  NumericProperty* yProp = static_cast<NumericProperty *>(graph->getProperty(yDim));
 
   forEach(n, _graph->getNodes()) {
     Coord nodeCoord;

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2D.h
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2D.h
@@ -68,7 +68,7 @@ public :
   }
   Coord getOverviewCenter() const;
   float getOverviewSize() const {
-    return static_cast<float>(size);
+    return float(size);
   }
   LayoutProperty *getScatterPlotLayout() const {
     return scatterLayout;

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2DInteractors.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2DInteractors.cpp
@@ -114,7 +114,7 @@ public:
 
 
   void viewChanged(View *v) {
-    scp2DView = (ScatterPlot2DView *) v;
+    scp2DView = static_cast<ScatterPlot2DView *>(v);
     MouseShowElementInfo::viewChanged(v);
   }
 

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2DOptionsWidget.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2DOptionsWidget.cpp
@@ -96,11 +96,11 @@ Size ScatterPlot2DOptionsWidget::getMaxSizeMapping() const {
 }
 
 void ScatterPlot2DOptionsWidget::setMinSizeMapping(const float minSize) {
-  _ui-> minSizeSpinBox->setValue((int)minSize);
+  _ui-> minSizeSpinBox->setValue(int(minSize));
 }
 
 void ScatterPlot2DOptionsWidget::setMaxSizeMapping(const float maxSize) {
-  _ui->maxSizeSpinBox->setValue((int)maxSize);
+  _ui->maxSizeSpinBox->setValue(int(maxSize));
 }
 
 bool ScatterPlot2DOptionsWidget::useCustomXAxisScale() const {

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2DView.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2DView.cpp
@@ -270,12 +270,12 @@ void ScatterPlot2DView::setState(const DataSet &dataSet) {
   int minSizeMap = 0;
 
   if (dataSet.get("min Size Mapping", minSizeMap))
-    optionsWidget->setMinSizeMapping(static_cast<float>(minSizeMap));
+    optionsWidget->setMinSizeMapping(float(minSizeMap));
 
   int maxSizeMap = 0;
 
   if (dataSet.get("max Size Mapping", maxSizeMap))
-    optionsWidget->setMaxSizeMapping(static_cast<float>(maxSizeMap));
+    optionsWidget->setMaxSizeMapping(float(maxSizeMap));
 
   optionsWidget->configurationChanged();
 
@@ -368,8 +368,8 @@ DataSet ScatterPlot2DView::state() const {
   }
 
   dataSet.set("generated scatter plots", generatedScatterPlotDataSet);
-  dataSet.set("min Size Mapping", static_cast<int>(optionsWidget->getMinSizeMapping().getW()));
-  dataSet.set("max Size Mapping", static_cast<int>(optionsWidget->getMaxSizeMapping().getW()));
+  dataSet.set("min Size Mapping", int(optionsWidget->getMinSizeMapping().getW()));
+  dataSet.set("max Size Mapping", int(optionsWidget->getMaxSizeMapping().getW()));
   dataSet.set("background color", optionsWidget->getBackgroundColor());
   dataSet.set("display graph edges", optionsWidget->displayGraphEdges());
   dataSet.set("display node labels", optionsWidget->displayNodeLabels());
@@ -726,7 +726,7 @@ void ScatterPlot2DView::centerView(bool) {
 
   // we apply a zoom factor to preserve a 50 px margin width
   // to ensure the scene will not be drawn under the configuration tabs title
-  float glWidth = (float) graphicsView()->width();
+  float glWidth = graphicsView()->width();
   getGlMainWidget()->getScene()->zoomFactor((glWidth - 50)/ glWidth);
   getGlMainWidget()->draw();
   center = false;

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2DViewNavigator.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2DViewNavigator.cpp
@@ -37,13 +37,13 @@ ScatterPlot2DViewNavigator::ScatterPlot2DViewNavigator() : scatterPlot2dView(NUL
 ScatterPlot2DViewNavigator::~ScatterPlot2DViewNavigator() {}
 
 void ScatterPlot2DViewNavigator::viewChanged(View *view) {
-  scatterPlot2dView = dynamic_cast<ScatterPlot2DView *>(view);
+  scatterPlot2dView = static_cast<ScatterPlot2DView *>(view);
 }
 
 bool ScatterPlot2DViewNavigator::eventFilter(QObject *widget, QEvent *e) {
 
   if (glWidget == NULL) {
-    glWidget = dynamic_cast<GlMainWidget *>(widget);
+    glWidget = static_cast<GlMainWidget *>(widget);
   }
 
   if(glWidget!=NULL) {
@@ -56,7 +56,7 @@ bool ScatterPlot2DViewNavigator::eventFilter(QObject *widget, QEvent *e) {
     }
 
     if (e->type() == QEvent::MouseMove && scatterPlot2dView->matrixViewSet()) {
-      QMouseEvent *me = (QMouseEvent *) e;
+      QMouseEvent *me = static_cast<QMouseEvent *>(e);
       int x = glWidget->width() - me->x();
       int y = me->y();
       Coord screenCoords(x, y, 0.0f);

--- a/plugins/view/ScatterPlot2DView/ScatterPlotCorrelCoeffSelector.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlotCorrelCoeffSelector.cpp
@@ -197,10 +197,7 @@ ScatterPlotCorrelCoeffSelector::ScatterPlotCorrelCoeffSelector(const ScatterPlot
 ScatterPlotCorrelCoeffSelector::~ScatterPlotCorrelCoeffSelector() {}
 
 bool ScatterPlotCorrelCoeffSelector::eventFilter(QObject *obj, QEvent *e) {
-  GlMainWidget *glWidget = dynamic_cast<GlMainWidget *>(obj);
-
-  if(glWidget==NULL)
-    return false;
+  GlMainWidget *glWidget = static_cast<GlMainWidget *>(obj);
 
   Camera &camera = glWidget->getScene()->getLayer("Main")->getCamera();
   Graph *graph = glWidget->getScene()->getGlGraphComposite()->getInputData()->getGraph();
@@ -211,7 +208,7 @@ bool ScatterPlotCorrelCoeffSelector::eventFilter(QObject *obj, QEvent *e) {
   }
 
   if (e->type() == QEvent::MouseMove) {
-    QMouseEvent *me = (QMouseEvent *) e;
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
     x = glWidget->screenToViewport(glWidget->width() - me->x());
     y = glWidget->screenToViewport(me->y());
     Coord newPointerSceneCoords = camera.viewportTo3DWorld(Coord(x, y, 0));
@@ -265,7 +262,7 @@ bool ScatterPlotCorrelCoeffSelector::eventFilter(QObject *obj, QEvent *e) {
     return true;
   }
   else if (e->type() == QEvent::MouseButtonPress) {
-    QMouseEvent *me = (QMouseEvent *) e;
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
     x = glWidget->screenToViewport(glWidget->width() - me->x());
     y = glWidget->screenToViewport(me->y());
     currentPointerSceneCoords = camera.viewportTo3DWorld(Coord(x, y, 0));
@@ -351,7 +348,7 @@ bool ScatterPlotCorrelCoeffSelector::eventFilter(QObject *obj, QEvent *e) {
     return true;
   }
   else if (e->type() == QEvent::MouseButtonDblClick) {
-    QMouseEvent *me = (QMouseEvent *) e;
+    QMouseEvent *me = static_cast<QMouseEvent *>(e);
     x = glWidget->screenToViewport(glWidget->width() - me->x());
     y = glWidget->screenToViewport(me->y());
     currentPointerSceneCoords = camera.viewportTo3DWorld(Coord(x, y, 0.0f));
@@ -502,10 +499,10 @@ void ScatterPlotCorrelCoeffSelector::mapPolygonColorToCorrelCoeffOfData(GlEditab
 
   polygonScr.push_back(camera.worldTo2DViewport(polygonVertices[0]));
 
-  int xStart = static_cast<int>(polygonScrBB[0][0]);
-  int yStart = static_cast<int>(polygonScrBB[0][1]);
-  int xEnd = static_cast<int>(polygonScrBB[1][0]);
-  int yEnd = static_cast<int>(polygonScrBB[1][1]);
+  int xStart = int(polygonScrBB[0][0]);
+  int yStart = int(polygonScrBB[0][1]);
+  int xEnd = int(polygonScrBB[1][0]);
+  int yEnd = int(polygonScrBB[1][1]);
 
   vector<SelectedEntity> tmpNodes;
   vector<SelectedEntity> tmpEdges;
@@ -573,8 +570,8 @@ void ScatterPlotCorrelCoeffSelector::mapPolygonColorToCorrelCoeffOfData(GlEditab
     string yDim(scatterView->getDetailedScatterPlot()->getYDim());
     NumericProperty *xProp = NULL, *yProp = NULL;
 
-    xProp = (NumericProperty *) graph->getProperty(xDim);
-    yProp = (NumericProperty *) graph->getProperty(yDim);
+    xProp = static_cast<NumericProperty *>(graph->getProperty(xDim));
+    yProp = static_cast<NumericProperty *>(graph->getProperty(yDim));
 
     double sumxiyi = 0, sumxi = 0, sumyi = 0, sumxi2 = 0, sumyi2 = 0;
 
@@ -614,7 +611,7 @@ void ScatterPlotCorrelCoeffSelector::mapPolygonColorToCorrelCoeffOfData(GlEditab
     }
 
     for (unsigned int i = 0; i < 4; ++i) {
-      polygonColor[i] = static_cast<unsigned char>((double(startColor[i]) + (double(endColor[i])- double(startColor[i])) * abs(correlationCoeff)));
+      polygonColor[i] = uchar((double(startColor[i]) + (double(endColor[i])- double(startColor[i])) * abs(correlationCoeff)));
     }
 
     polygon->setColor(polygonColor);

--- a/plugins/view/ScatterPlot2DView/ScatterPlotTrendLine.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlotTrendLine.cpp
@@ -142,7 +142,7 @@ bool ScatterPlotTrendLine::compute(GlMainWidget*) {
     xDim = new DoubleProperty(graph);
     node n;
     forEach(n, graph->getNodes()) {
-      xDim->setNodeValue(n, static_cast<double>(xDimInt->getNodeValue(n)));
+      xDim->setNodeValue(n, double(xDimInt->getNodeValue(n)));
     }
   }
 
@@ -154,7 +154,7 @@ bool ScatterPlotTrendLine::compute(GlMainWidget*) {
     yDim = new DoubleProperty(graph);
     node n;
     forEach(n, graph->getNodes()) {
-      yDim->setNodeValue(n, static_cast<double>(yDimInt->getNodeValue(n)));
+      yDim->setNodeValue(n, double(yDimInt->getNodeValue(n)));
     }
   }
 
@@ -178,7 +178,7 @@ void ScatterPlotTrendLine::viewChanged(View *view) {
     return;
   }
 
-  scatterView = dynamic_cast<ScatterPlot2DView *>(view);
+  scatterView = static_cast<ScatterPlot2DView *>(view);
   compute(0);
   scatterView->refresh();
 }

--- a/plugins/view/TableView/TableView.cpp
+++ b/plugins/view/TableView/TableView.cpp
@@ -125,7 +125,7 @@ void TableView::setupWidget() {
 
   setCentralWidget(centralWidget);
 
-  propertiesEditor = new PropertiesEditor((QWidget *) centralItem()->parentWidget());
+  propertiesEditor = new PropertiesEditor(static_cast<QGraphicsProxyWidget *>(centralItem())->widget());
 
   connect(propertiesEditor,SIGNAL(propertyVisibilityChanged(tlp::PropertyInterface*,bool)),this,SLOT(setPropertyVisible(tlp::PropertyInterface*,bool)));
   connect(propertiesEditor,SIGNAL(mapToGraphSelection()),this,SLOT(mapToGraphSelection()));
@@ -345,10 +345,10 @@ void TableView::setMatchProperty() {
   // to popup the menu
   QWidget* pViewport = QApplication::widgetAt(QCursor::pos());
   QWidget* pView = pViewport->parentWidget();
-  QGraphicsView* pGraphicsView = qobject_cast<QGraphicsView*>(pView);
+  QGraphicsView* pGraphicsView = static_cast<QGraphicsView*>(pView);
   QGraphicsItem* pGraphicsItem =
     pGraphicsView->items(pViewport->mapFromGlobal(QCursor::pos())).first();
-  QPoint popupPos = pGraphicsView->mapToGlobal(pGraphicsView->mapFromScene(pGraphicsItem->mapToScene(((QGraphicsProxyWidget *) pGraphicsItem)->subWidgetRect(_ui->matchPropertyButton).bottomLeft())));
+  QPoint popupPos = pGraphicsView->mapToGlobal(pGraphicsView->mapFromScene(pGraphicsItem->mapToScene(static_cast<QGraphicsProxyWidget *>(pGraphicsItem)->subWidgetRect(_ui->matchPropertyButton).bottomLeft())));
 
   action = menu.exec(popupPos);
 

--- a/software/crash_handling/CrashHandling.cpp
+++ b/software/crash_handling/CrashHandling.cpp
@@ -17,6 +17,11 @@
  *
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include <tulip/SystemDefinition.h>
 #include <tulip/TulipRelease.h>
 
@@ -193,4 +198,8 @@ exception_filter(LPEXCEPTION_POINTERS info) {
 void CrashHandling::installCrashHandler() {
   SetUnhandledExceptionFilter(exception_filter);
 }
+#endif
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
 #endif

--- a/software/crash_handling/StackWalker.cpp
+++ b/software/crash_handling/StackWalker.cpp
@@ -19,6 +19,8 @@
 
 #include "StackWalker.h"
 
+#include <tulip/tulipconf.h>
+
 #include <sstream>
 #include <cstring>
 
@@ -215,7 +217,7 @@ void StackWalkerGCC::printCallStack(std::ostream &os, unsigned int maxDepth) {
           *offset_end = 0, *runtime_addr = 0,
            *runtime_addr_end = 0, *dsoName = 0;
 
-    if (static_cast<unsigned int>(i) > maxDepth)
+    if (uint(i) > maxDepth)
       return;
 
     for (char *p = messages[i]; *p; ++p) {

--- a/software/crash_handling/UnixSignalInterposer.cpp
+++ b/software/crash_handling/UnixSignalInterposer.cpp
@@ -26,6 +26,11 @@
 // has to be filled with the path to the resulting shared library before launching the application.
 // For instance : $ LD_PRELOAD=<path to the compiled shared library> <path_to_application_executable> <args>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include <cstdlib>
 #include <cstdio>
 #include <iostream>
@@ -158,3 +163,7 @@ int sigaction(int sig, const struct sigaction *act, struct sigaction *oact) __TH
   }
 
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/software/tulip/src/TulipMainWindow.cpp
+++ b/software/tulip/src/TulipMainWindow.cpp
@@ -268,7 +268,8 @@ void TulipMainWindow::showAboutCenter() {
 }
 
 void TulipMainWindow::showTrayMessage(const QString &message) {
-  showTrayMessage(trUtf8("Perspective"),"\n" + message + "\n\n" + trUtf8("Click to dismiss"),(uint)QSystemTrayIcon::Information,3000);
+  showTrayMessage(trUtf8("Perspective"),"\n" + message + "\n\n" + trUtf8("Click to dismiss"),
+                  uint(QSystemTrayIcon::Information), 3000);
 }
 
 void TulipMainWindow::openProject(const QString &file) {
@@ -312,7 +313,7 @@ void TulipMainWindow::showTrayMessage(const QString &title, const QString &messa
   if (!_systemTrayIcon)
     return;
 
-  _systemTrayIcon->showMessage(title,message,(QSystemTrayIcon::MessageIcon)icon,duration);
+  _systemTrayIcon->showMessage(title,message,static_cast<QSystemTrayIcon::MessageIcon>(icon),duration);
 }
 
 void TulipMainWindow::showErrorMessage(const QString &title, const QString &message) {
@@ -323,5 +324,5 @@ void TulipMainWindow::showErrorMessage(const QString &title, const QString &mess
 
 void TulipMainWindow::pluginErrorMessage(const QString &message) {
   _currentTrayMessage = PluginErrorMessage;
-  showTrayMessage(trUtf8("Error while loading plugins"),message + "\n\n" + trUtf8("Click on this message to see detailed information"),(uint)QSystemTrayIcon::Critical,10000);
+  showTrayMessage(trUtf8("Error while loading plugins"),message + "\n\n" + trUtf8("Click on this message to see detailed information"),uint(QSystemTrayIcon::Critical),10000);
 }

--- a/software/tulip/src/TulipPerspectiveCrashHandler.cpp
+++ b/software/tulip/src/TulipPerspectiveCrashHandler.cpp
@@ -58,7 +58,7 @@ void TulipPerspectiveCrashHandler::setDetailedView(bool f) {
   _isDetailedView = f;
   _ui->detailsLink->setText(f ? "<a href=\"Hide details\">Hide details</a>" :
                             "<a href=\"Show details\">View details</a> <span style=\"font-size:small\"><i>(sent with your comments)</i></span>");
-  _ui->stackedWidget->setCurrentIndex(static_cast<int>(f));
+  _ui->stackedWidget->setCurrentIndex(int(f));
 }
 
 void TulipPerspectiveCrashHandler::toggleDetailedView() {

--- a/software/tulip/src/TulipPerspectiveProcessHandler.cpp
+++ b/software/tulip/src/TulipPerspectiveProcessHandler.cpp
@@ -68,7 +68,7 @@ TulipPerspectiveProcessHandler::TulipPerspectiveProcessHandler() {
 
 QProcess *TulipPerspectiveProcessHandler::fromId(unsigned int id) {
   foreach(QProcess* k, _processInfo.keys()) {
-    if (_processInfo[k]._perspectiveId == (time_t) id)
+    if (_processInfo[k]._perspectiveId == static_cast<time_t>(id))
       return k;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ MACRO(UNIT_TEST)
   ENDFOREACH()
   # this is a cpp[unit] test
   IF(TEST_SRCS)
-    INCLUDE_DIRECTORIES(${TulipCoreBuildInclude} ${TulipCoreInclude} ${CppUnit_INCLUDE_DIRS})
+    INCLUDE_DIRECTORIES(${TulipCoreBuildInclude} ${TulipCoreInclude} ${CppUnit_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/tests/include)
     LINK_DIRECTORIES(${CppUnit_LIBRARY_DIRS})
     ADD_EXECUTABLE(${TEST_NAME} ${TEST_SRCS})
     ADD_DEPENDENCIES(runTests ${TEST_NAME})

--- a/tests/include/CppUnitIncludes.h
+++ b/tests/include/CppUnitIncludes.h
@@ -17,33 +17,19 @@
  *
  */
 
-#ifndef Tulip_FaceIteratorTest_h
-#define Tulip_FaceIteratorTest_h
+#ifndef CPPUNITINCLUDES_H
+#define CPPUNITINCLUDES_H
 
-#include <tulip/FaceIterator.h>
-#include <tulip/PlanarConMap.h>
-#include <tulip/TlpTools.h>
-
-#include "CppUnitIncludes.h"
-
-class FaceIteratorTest : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(FaceIteratorTest);
-  CPPUNIT_TEST(testNodeFaceIterator);
-  CPPUNIT_TEST(testFaceAdjIterator);
-  CPPUNIT_TEST_SUITE_END();
-
-private :
-  tlp::PlanarConMap* map;
-
-  std::vector<tlp::edge> edges;
-  std::vector<tlp::node> nodes;
-
-public :
-  void setUp();
-  void tearDown();
-
-  void testNodeFaceIterator();
-  void testFaceAdjIterator();
-};
-
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
+
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#endif // CPPUNITINCLUDES_H

--- a/tests/library/tulip/BooleanPropertyTest.cpp
+++ b/tests/library/tulip/BooleanPropertyTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/TlpTools.h>
 #include "BooleanPropertyTest.h"
 

--- a/tests/library/tulip/BooleanPropertyTest.h
+++ b/tests/library/tulip/BooleanPropertyTest.h
@@ -22,9 +22,8 @@
 #include <string>
 #include <tulip/Graph.h>
 #include <tulip/BooleanProperty.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class BooleanProperty;

--- a/tests/library/tulip/DataSetTest.cpp
+++ b/tests/library/tulip/DataSetTest.cpp
@@ -18,8 +18,7 @@
  */
 #include <cassert>
 #include <iomanip>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "DataSetTest.h"
 
 #include <string>

--- a/tests/library/tulip/DataSetTest.h
+++ b/tests/library/tulip/DataSetTest.h
@@ -19,9 +19,7 @@
 #ifndef DATASETTEST
 #define DATASETTEST
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 

--- a/tests/library/tulip/DoublePropertyTest.cpp
+++ b/tests/library/tulip/DoublePropertyTest.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <iostream>
 
-#include <cppunit/TestCaller.h>
 #include "DoublePropertyTest.h"
 
 #include <tulip/TlpTools.h>

--- a/tests/library/tulip/DoublePropertyTest.h
+++ b/tests/library/tulip/DoublePropertyTest.h
@@ -22,9 +22,8 @@
 
 #include <tulip/Graph.h>
 #include <tulip/DoubleProperty.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class DoublePropertyTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(DoublePropertyTest);

--- a/tests/library/tulip/ExistEdgeTest.cpp
+++ b/tests/library/tulip/ExistEdgeTest.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <iostream>
 
-#include <cppunit/TestCaller.h>
 #include "ExistEdgeTest.h"
 
 using namespace tlp;

--- a/tests/library/tulip/ExistEdgeTest.h
+++ b/tests/library/tulip/ExistEdgeTest.h
@@ -21,9 +21,8 @@
 #define EXISTEDGETEST_H_
 
 #include <tulip/Graph.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class ExistEdgeTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(ExistEdgeTest);

--- a/tests/library/tulip/ExtendedClusterOperationTest.cpp
+++ b/tests/library/tulip/ExtendedClusterOperationTest.cpp
@@ -18,8 +18,6 @@
  */
 #include <cassert>
 #include <vector>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
 #include <tulip/ForEach.h>
 
 #include "ExtendedClusterOperationTest.h"

--- a/tests/library/tulip/ExtendedClusterOperationTest.h
+++ b/tests/library/tulip/ExtendedClusterOperationTest.h
@@ -21,9 +21,8 @@
 
 #include <string>
 #include <tulip/Graph.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class ExtendedClusterOperationTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(ExtendedClusterOperationTest);

--- a/tests/library/tulip/FaceIteratorTest.cpp
+++ b/tests/library/tulip/FaceIteratorTest.cpp
@@ -17,7 +17,6 @@
  *
  */
 #include "FaceIteratorTest.h"
-#include <cppunit/TestCaller.h>
 
 #include <iostream>
 

--- a/tests/library/tulip/GraphPropertyTest.cpp
+++ b/tests/library/tulip/GraphPropertyTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/TlpTools.h>
 #include "GraphPropertyTest.h"
 

--- a/tests/library/tulip/GraphPropertyTest.h
+++ b/tests/library/tulip/GraphPropertyTest.h
@@ -22,10 +22,9 @@
 #include <string>
 #include <tulip/GraphProperty.h>
 #include <tulip/Graph.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
+
 class GraphPropertyTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(GraphPropertyTest);
   CPPUNIT_TEST(testDestroyGraph);

--- a/tests/library/tulip/IdManagerTest.cpp
+++ b/tests/library/tulip/IdManagerTest.cpp
@@ -17,8 +17,7 @@
  *
  */
 #include <cassert>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "IdManagerTest.h"
 
 using namespace std;
@@ -36,17 +35,17 @@ void IdManagerTest::testFragmentation() {
     idManager->free(i);
   }
 
-  CPPUNIT_ASSERT_EQUAL((size_t)99, idManager->state.freeIds.size());
+  CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(99), idManager->state.freeIds.size());
   idManager->free(0);
-  CPPUNIT_ASSERT_EQUAL((size_t)0, idManager->state.freeIds.size());
+  CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), idManager->state.freeIds.size());
 
   for (unsigned int i = 900; i <999; ++i) {
     idManager->free(i);
   }
 
-  CPPUNIT_ASSERT_EQUAL((size_t)99, idManager->state.freeIds.size());
+  CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(99), idManager->state.freeIds.size());
   idManager->free(999);
-  CPPUNIT_ASSERT_EQUAL((size_t)100, idManager->state.freeIds.size());
+  CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(100), idManager->state.freeIds.size());
 }
 //==========================================================
 void IdManagerTest::testGetFree() {

--- a/tests/library/tulip/IdManagerTest.h
+++ b/tests/library/tulip/IdManagerTest.h
@@ -22,9 +22,8 @@
 #include <string>
 #include <tulip/Graph.h>
 #include <tulip/IdManager.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 

--- a/tests/library/tulip/ImportExportTest.cpp
+++ b/tests/library/tulip/ImportExportTest.cpp
@@ -225,22 +225,22 @@ void ImportExportTest::testSubGraphsImportExport() {
 }
 
 static Color genRandomColor() {
-  return Color(static_cast<unsigned char>(tlp::randomUnsignedInteger(255)),
-               static_cast<unsigned char>(tlp::randomUnsignedInteger(255)),
-               static_cast<unsigned char>(tlp::randomUnsignedInteger(255)),
-               static_cast<unsigned char>(tlp::randomUnsignedInteger(255)));
+  return Color(uchar(tlp::randomUnsignedInteger(255)),
+               uchar(tlp::randomUnsignedInteger(255)),
+               uchar(tlp::randomUnsignedInteger(255)),
+               uchar(tlp::randomUnsignedInteger(255)));
 }
 
 static Coord genRandomCoord() {
-  return tlp::Coord(static_cast<float>(tlp::randomDouble(1000)),
-                    static_cast<float>(tlp::randomDouble(1000)),
-                    static_cast<float>(tlp::randomDouble(1000)));
+  return tlp::Coord(float(tlp::randomDouble(1000)),
+                    float(tlp::randomDouble(1000)),
+                    float(tlp::randomDouble(1000)));
 }
 
 static Size genRandomSize() {
-  return tlp::Size(static_cast<float>(tlp::randomDouble(10)),
-                    static_cast<float>(tlp::randomDouble(10)),
-                    static_cast<float>(tlp::randomDouble(10)));
+  return tlp::Size(float(tlp::randomDouble(10)),
+                    float(tlp::randomDouble(10)),
+                    float(tlp::randomDouble(10)));
 }
 
 Graph* ImportExportTest::createSimpleGraph() const {

--- a/tests/library/tulip/ImportExportTest.h
+++ b/tests/library/tulip/ImportExportTest.h
@@ -19,8 +19,7 @@
 #ifndef IMPORTEXPORTTEST_H
 #define IMPORTEXPORTTEST_H
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class Graph;

--- a/tests/library/tulip/IntegerPropertyMinMaxSubgraphTest.h
+++ b/tests/library/tulip/IntegerPropertyMinMaxSubgraphTest.h
@@ -21,9 +21,8 @@
 
 #include <tulip/Graph.h>
 #include <tulip/IntegerProperty.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class IntegerPropertyMinMaxSubgraphTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(IntegerPropertyMinMaxSubgraphTest);

--- a/tests/library/tulip/IntegerPropertyMinMaxUptodateTest.cpp
+++ b/tests/library/tulip/IntegerPropertyMinMaxUptodateTest.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <iostream>
 
-#include <cppunit/TestCaller.h>
 #include "IntegerPropertyMinMaxUptodateTest.h"
 
 using namespace tlp;

--- a/tests/library/tulip/IntegerPropertyMinMaxUptodateTest.h
+++ b/tests/library/tulip/IntegerPropertyMinMaxUptodateTest.h
@@ -22,9 +22,8 @@
 
 #include <tulip/Graph.h>
 #include <tulip/IntegerProperty.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class IntegerPropertyMinMaxUpdateTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(IntegerPropertyMinMaxUpdateTest);

--- a/tests/library/tulip/IsMetaEdgeTest.cpp
+++ b/tests/library/tulip/IsMetaEdgeTest.cpp
@@ -19,8 +19,6 @@
 #include <tulip/BooleanProperty.h>
 #include <tulip/GraphProperty.h>
 #include <tulip/ForEach.h>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
 
 #include "IsMetaEdgeTest.h"
 
@@ -119,7 +117,7 @@ void IsMetaEdgeTest::testIsMetaEdge() {
   set<edge> underlyingEdgesInMetaEdge = quotientGraph->getProperty<GraphProperty>("viewMetaGraph")->getEdgeValue(quotientGraph->getOneEdge());
 
   // check the number of underlying edges in meta edge
-  CPPUNIT_ASSERT_EQUAL((size_t)nbNodesPerCluster * nbNodesPerCluster, underlyingEdgesInMetaEdge.size());
+  CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(nbNodesPerCluster * nbNodesPerCluster), underlyingEdgesInMetaEdge.size());
 
   // check if the quotient edge is a meta edge
   CPPUNIT_ASSERT_EQUAL(1u, nbMetaEdges);

--- a/tests/library/tulip/IsMetaEdgeTest.h
+++ b/tests/library/tulip/IsMetaEdgeTest.h
@@ -19,9 +19,8 @@
 #include <string>
 #include <tulip/Graph.h>
 #include <tulip/Matrix.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class IsMetaEdgeTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(IsMetaEdgeTest);

--- a/tests/library/tulip/MatrixTest.cpp
+++ b/tests/library/tulip/MatrixTest.cpp
@@ -18,8 +18,7 @@
  */
 #include <cassert>
 #include <iomanip>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "MatrixTest.h"
 
 using namespace std;
@@ -157,7 +156,7 @@ void MatrixTest::testInternalOperation() {
       if (i==j) matid[i][j] = 1.0;
 
       CPPUNIT_ASSERT_EQUAL(0.0, matnull[i][j]);
-      CPPUNIT_ASSERT_EQUAL((double)((i+1)*(j+SIZE)), mat1[i][j]);
+      CPPUNIT_ASSERT_EQUAL(double(((i+1)*(j+SIZE))), mat1[i][j]);
 
       if (i==j) mat1[i][j] = 0.0;
     }

--- a/tests/library/tulip/MatrixTest.h
+++ b/tests/library/tulip/MatrixTest.h
@@ -22,9 +22,8 @@
 #include <string>
 #include <tulip/Graph.h>
 #include <tulip/Matrix.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class MatrixTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(MatrixTest);

--- a/tests/library/tulip/MutableContainerTest.cpp
+++ b/tests/library/tulip/MutableContainerTest.cpp
@@ -17,8 +17,7 @@
  *
  */
 #include <cstdlib>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "MutableContainerTest.h"
 #include <tulip/Iterator.h>
 #include <tulip/TlpTools.h>
@@ -217,7 +216,7 @@ void MutableContainerTest::testSetGet() {
 
   for (unsigned int i=101; i<1000; ++i) {
     mutDouble->set(i,i);
-    CPPUNIT_ASSERT_EQUAL((double)i, mutDouble->get(i));
+    CPPUNIT_ASSERT_EQUAL(double(i), mutDouble->get(i));
   }
 
   for (unsigned int i=101; i<999; ++i) {
@@ -234,7 +233,7 @@ void MutableContainerTest::testSetGet() {
     mutDouble->set(rando, rando);
     mutString->set(rando, string("David"));
     CPPUNIT_ASSERT(mutBool->get(rando));
-    CPPUNIT_ASSERT_EQUAL((double)rando, mutDouble->get(rando));
+    CPPUNIT_ASSERT_EQUAL(double(rando), mutDouble->get(rando));
     CPPUNIT_ASSERT_EQUAL(string("David"), mutString->get(rando));
   }
 

--- a/tests/library/tulip/MutableContainerTest.h
+++ b/tests/library/tulip/MutableContainerTest.h
@@ -23,9 +23,8 @@
 #include <tulip/MutableContainer.h>
 // needed by MutableContainer<std::string>
 #include <tulip/PropertyTypes.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class MutableContainerTest : public CppUnit::TestFixture {

--- a/tests/library/tulip/ObservableGraphTest.cpp
+++ b/tests/library/tulip/ObservableGraphTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/ForEach.h>
 #include "ObservableGraphTest.h"
 #include <tulip/BooleanProperty.h>
@@ -379,10 +378,7 @@ public:
       }
     }
     else {
-      Graph* graph =
-          // From my point of view the use of dynamic_cast should be correct
-          // but it fails, so I use reinterpret_cast (pm)
-          reinterpret_cast<Graph *>(evt.sender());
+      Graph* graph = static_cast<Graph *>(evt.sender());
 
       if (graph && evt.type() == Event::TLP_DELETE) {
         if (deleteBug747) {

--- a/tests/library/tulip/ObservableGraphTest.h
+++ b/tests/library/tulip/ObservableGraphTest.h
@@ -21,9 +21,8 @@
 
 #include <tulip/Graph.h>
 #include <tulip/TlpTools.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class ObservableGraphTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(ObservableGraphTest);

--- a/tests/library/tulip/ObservablePropertyTest.cpp
+++ b/tests/library/tulip/ObservablePropertyTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/ForEach.h>
 #include "ObservablePropertyTest.h"
 #include <tulip/BooleanProperty.h>

--- a/tests/library/tulip/ObservablePropertyTest.h
+++ b/tests/library/tulip/ObservablePropertyTest.h
@@ -22,9 +22,8 @@
 #include <tulip/Graph.h>
 #include <tulip/TlpTools.h>
 #include <tulip/AbstractProperty.h>
-#include <cppunit/TestFixture.h>
-//#include <cppunit/extensions/HelperMacros.h>
-#include <cppunit/TestSuite.h>
+
+#include "CppUnitIncludes.h"
 
 class ObservablePropertyTest : public CppUnit::TestFixture {
 private:

--- a/tests/library/tulip/PlanarConMapTest.cpp
+++ b/tests/library/tulip/PlanarConMapTest.cpp
@@ -18,8 +18,6 @@
  */
 #include "PlanarConMapTest.h"
 #include <tulip/PlanarityTest.h>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
 
 CPPUNIT_TEST_SUITE_REGISTRATION( tlp::PlanarConMapTest );
 

--- a/tests/library/tulip/PlanarConMapTest.h
+++ b/tests/library/tulip/PlanarConMapTest.h
@@ -23,9 +23,7 @@
 #include <tulip/PlanarConMap.h>
 #include <tulip/TlpTools.h>
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 

--- a/tests/library/tulip/PlanarityTestTest.cpp
+++ b/tests/library/tulip/PlanarityTestTest.cpp
@@ -18,8 +18,7 @@
  */
 
 #include <cassert>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/PlanarityTest.h>
 #include <tulip/PlanarConMap.h>
 #include <tulip/ConnectedTest.h>

--- a/tests/library/tulip/PlanarityTestTest.h
+++ b/tests/library/tulip/PlanarityTestTest.h
@@ -22,9 +22,8 @@
 
 #include <string>
 #include <tulip/Graph.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class PlanarityTestTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(PlanarityTestTest);

--- a/tests/library/tulip/PluginsTest.cpp
+++ b/tests/library/tulip/PluginsTest.cpp
@@ -17,8 +17,7 @@
  *
  */
 #include <sstream>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "PluginsTest.h"
 
 #include <tulip/TulipRelease.h>

--- a/tests/library/tulip/PluginsTest.h
+++ b/tests/library/tulip/PluginsTest.h
@@ -21,9 +21,7 @@
 
 #include <string>
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 #include <tulip/Graph.h>
 

--- a/tests/library/tulip/PushPopTest.cpp
+++ b/tests/library/tulip/PushPopTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/ForEach.h>
 #include "PushPopTest.h"
 #include <tulip/BooleanProperty.h>

--- a/tests/library/tulip/PushPopTest.h
+++ b/tests/library/tulip/PushPopTest.h
@@ -21,9 +21,8 @@
 
 #include <tulip/Graph.h>
 #include <tulip/TlpTools.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class PushPopTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(PushPopTest);

--- a/tests/library/tulip/StringPropertyTest.h
+++ b/tests/library/tulip/StringPropertyTest.h
@@ -20,8 +20,7 @@
 #ifndef STRINGPROPERTYTEST_H
 #define STRINGPROPERTYTEST_H
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class Graph;

--- a/tests/library/tulip/SuperGraphTest.cpp
+++ b/tests/library/tulip/SuperGraphTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <tulip/ForEach.h>
 #include "SuperGraphTest.h"
 #include <tulip/BooleanProperty.h>
@@ -809,7 +808,7 @@ void SuperGraphTest::testAttributes() {
   CPPUNIT_ASSERT(dt != NULL);
   delete dt;
   TypedData<string> dtc(new string("test"));
-  graph->setAttribute("name", (const DataType *) &dtc);
+  graph->setAttribute("name", static_cast<const DataType *>(&dtc));
   CPPUNIT_ASSERT(graph->existAttribute("name"));
   dt = graph->getAttribute("name");
   CPPUNIT_ASSERT_EQUAL(0, dt->getTypeName().compare(typeid(string).name()));

--- a/tests/library/tulip/SuperGraphTest.h
+++ b/tests/library/tulip/SuperGraphTest.h
@@ -21,9 +21,8 @@
 
 #include <tulip/Graph.h>
 #include <tulip/TlpTools.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class SuperGraphTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(SuperGraphTest);

--- a/tests/library/tulip/TestAlgorithmTest.cpp
+++ b/tests/library/tulip/TestAlgorithmTest.cpp
@@ -27,8 +27,6 @@
 #include <tulip/BiconnectedTest.h>
 #include <tulip/TriconnectedTest.h>
 
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
 #include "TestAlgorithmTest.h"
 
 using namespace std;

--- a/tests/library/tulip/TestAlgorithmTest.h
+++ b/tests/library/tulip/TestAlgorithmTest.h
@@ -19,9 +19,7 @@
 #ifndef TLPTESTALGORITHMTEST
 #define TLPTESTALGORITHMTEST
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class Graph;

--- a/tests/library/tulip/TestPlugin.cpp
+++ b/tests/library/tulip/TestPlugin.cpp
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string>
 #include <iostream>
-#include <cppunit/TestCase.h>
+
 #include <tulip/TulipPluginHeaders.h>
 
 using namespace std;

--- a/tests/library/tulip/TestPlugin2.cpp
+++ b/tests/library/tulip/TestPlugin2.cpp
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string>
 #include <iostream>
-#include <cppunit/TestCase.h>
+
 #include <tulip/TulipPluginHeaders.h>
 
 using namespace std;

--- a/tests/library/tulip/TestPropertiesMinMaxAfterAddNode.h
+++ b/tests/library/tulip/TestPropertiesMinMaxAfterAddNode.h
@@ -18,9 +18,8 @@
  */
 #include <string>
 #include <tulip/Graph.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class TestPropertiesMinMaxAfterAddNode : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestPropertiesMinMaxAfterAddNode);

--- a/tests/library/tulip/TlpImportExportTest.cpp
+++ b/tests/library/tulip/TlpImportExportTest.cpp
@@ -16,8 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include <vector>
 #include "TlpImportExportTest.h"
 #include <tulip/Graph.h>
@@ -65,7 +64,7 @@ void TlpImportExportTest::testSave() {
   bool ok = saveGraph(graph, "save_test.tlp");
   delete graph;
   CPPUNIT_ASSERT(ok);
-  graph = (Graph *) NULL;
+  graph = NULL;
   graph = loadGraph("save_test.tlp");
   CPPUNIT_ASSERT(graph != NULL);
   node n;
@@ -94,7 +93,7 @@ void TlpImportExportTest::testExport() {
   delete graph;
   delete os;
   CPPUNIT_ASSERT(ok);
-  graph = (Graph *) NULL;
+  graph = NULL;
   graph = tlp_loadGraph("export_test.tlp");
   CPPUNIT_ASSERT(graph != NULL);
   node n;
@@ -123,7 +122,7 @@ void TlpImportExportTest::testExportCluster() {
   delete graph;
   delete os;
   CPPUNIT_ASSERT(ok);
-  graph = (Graph *) NULL;
+  graph = NULL;
   graph = tlp_loadGraph("export_test.tlp");
   CPPUNIT_ASSERT(graph != NULL);
   node n;
@@ -193,7 +192,7 @@ void TlpImportExportTest::testExportAttributes() {
   delete graph;
   delete os;
   CPPUNIT_ASSERT(ok);
-  graph = (Graph *) NULL;
+  graph = NULL;
   graph = tlp_loadGraph("export_attributes.tlp");
   CPPUNIT_ASSERT(graph);
 

--- a/tests/library/tulip/TlpImportExportTest.h
+++ b/tests/library/tulip/TlpImportExportTest.h
@@ -22,9 +22,8 @@
 #include <string>
 #include <tulip/Graph.h>
 #include <tulip/TlpTools.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class TlpImportExportTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TlpImportExportTest);

--- a/tests/library/tulip/VectorGraphTest.cpp
+++ b/tests/library/tulip/VectorGraphTest.cpp
@@ -1,14 +1,11 @@
 #include <cassert>
 #include <iomanip>
 #include <fstream>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include <tulip/vectorgraph.h>
 #include <tulip/ForEach.h>
 #include <tulip/Iterator.h>
+
+#include "CppUnitIncludes.h"
 
 using namespace std;
 

--- a/tests/library/tulip/VectorTest.cpp
+++ b/tests/library/tulip/VectorTest.cpp
@@ -17,8 +17,7 @@
  *
  */
 #include <cassert>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "VectorTest.h"
 
 using namespace std;

--- a/tests/library/tulip/VectorTest.h
+++ b/tests/library/tulip/VectorTest.h
@@ -22,9 +22,8 @@
 #include <string>
 #include <tulip/Graph.h>
 #include <tulip/Vector.h>
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+
+#include "CppUnitIncludes.h"
 
 class VectorTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(VectorTest);

--- a/tests/library/tulip/WithParameterTest.h
+++ b/tests/library/tulip/WithParameterTest.h
@@ -22,8 +22,7 @@
 
 #include <tulip/WithParameter.h>
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 class WithParameterTest : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(WithParameterTest);

--- a/tests/library/tulip/tuliplibtest.cpp
+++ b/tests/library/tulip/tuliplibtest.cpp
@@ -16,7 +16,7 @@
  * See the GNU General Public License for more details.
  *
  */
-//#include <cppunit/ui/qt/TestRunner.h>
+
 #include <cstdlib>
 #include <fstream>
 

--- a/tests/plugins/BasicLayoutTest.h
+++ b/tests/plugins/BasicLayoutTest.h
@@ -19,8 +19,7 @@
 #ifndef BASICLAYOUTTEST_H
 #define BASICLAYOUTTEST_H
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class Graph;

--- a/tests/plugins/BasicMetricTest.h
+++ b/tests/plugins/BasicMetricTest.h
@@ -19,8 +19,7 @@
 #ifndef BASICMETRICTEST_H
 #define BASICMETRICTEST_H
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 namespace tlp {
 class Graph;

--- a/tests/plugins/BasicPluginsTest.cpp
+++ b/tests/plugins/BasicPluginsTest.cpp
@@ -17,8 +17,7 @@
  *
  */
 #include <sstream>
-#include <cppunit/TestCase.h>
-#include <cppunit/TestCaller.h>
+
 #include "BasicPluginsTest.h"
 #include <tulip/TlpTools.h>
 #include <tulip/ForEach.h>
@@ -428,7 +427,7 @@ void BasicPluginsTest::testEqualValueClustering() {
 
   for (unsigned int i=0; i<NB_ADD; ++i) {
     nodes.push_back(graph->addNode());
-    metric->setNodeValue(nodes[i], (double) (randomUnsignedInteger(NB_ADD-1)));
+    metric->setNodeValue(nodes[i], randomUnsignedInteger(NB_ADD-1));
   }
 
   unsigned int NB_EDGES = EDGE_RATIO * NB_ADD;

--- a/tests/plugins/BasicPluginsTest.h
+++ b/tests/plugins/BasicPluginsTest.h
@@ -21,9 +21,7 @@
 
 #include <string>
 
-#include <cppunit/TestFixture.h>
-#include <cppunit/TestSuite.h>
-#include <cppunit/extensions/HelperMacros.h>
+#include "CppUnitIncludes.h"
 
 #include <tulip/Graph.h>
 

--- a/tests/plugins/pluginstest.cpp
+++ b/tests/plugins/pluginstest.cpp
@@ -17,7 +17,6 @@
  *
  */
 
-//#include <cppunit/ui/qt/TestRunner.h>
 #include <iostream>
 #include <cstdlib>
 #include <cppunit/ui/text/TestRunner.h>


### PR DESCRIPTION
That PR brings some code improvements regarding the handling of casts in the whole Tulip codebase (excepted third party codes). The following changes have been made:

1. remove all old style C casts and replace them by the adequate C++ ones (static_cast, const_cast or reinterpret cast), also activates the -Wold-style-cast compiler warnings to avoid their use in the future: the use of C casts is discouraged when writing C++ code as C++ standard defines some safe casting operators (https://stackoverflow.com/questions/332030/when-should-static-cast-dynamic-cast-const-cast-and-reinterpret-cast-be-used) that:

    - tell the compiler to perform some special checks
    - improve code readability and code searching
    - explicitly define the semantic of a cast (notably const ones)

2. replace reinterpret_cast by static_cast whenever it is possible
3. replace dynamic_cast by static_cast whenever it is possible

DO NOT MERGE UNTIL I SQUASHED THE COMMITS !