### PR TITLE
tulip-python: Fix issue #33

### DIFF
--- a/doc/python/apichanges.rst
+++ b/doc/python/apichanges.rst
@@ -3,6 +3,39 @@
 Release notes and API changes
 =============================
 
+Tulip-Python 5.2
+-----------------
+
+Testing if a node or an edge belongs to a graph using classical Python idioms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is now possible to test if a node or an edge is contained in a graph
+using the classical Python idiom based on the in keyword.
+
+To test if an instance of :class:`tlp.node` belongs to an instance
+of :class:`tlp.Graph`, you can now write::
+
+  if n in graph:
+    # n belongs to the graph
+  else:
+    # n does not belong to the graph
+
+To test if an instance of :class:`tlp.edge` belongs to an instance
+of :class:`tlp.Graph`, you can now write::
+
+  if e in graph:
+    # e belongs to the graph
+  else:
+    # e does not belong to the graph
+
+You can also test if an edge defined by a tuple of two instances of
+:class:`tlp.node` belongs to an instance of :class:`tlp.Graph`::
+
+  if (src, tgt) in graph:
+    # the edge belongs to the graph
+  else:
+    # the edge does not belong to the graph
+
 Tulip-Python 5.1
 -----------------
 

--- a/library/tulip-python/bindings/tulip-core/Graph.sip
+++ b/library/tulip-python/bindings/tulip-core/Graph.sip
@@ -3901,6 +3901,27 @@ meta node and other nodes in the graph.
 
 //===========================================================================================
 
+  int __contains__(const tlp::node &n);
+%MethodCode
+  return sipCpp->isElement(*a0);
+%End
+
+//===========================================================================================
+
+  int __contains__(const tlp::edge &e);
+%MethodCode
+  return sipCpp->isElement(*a0);
+%End
+
+//===========================================================================================
+
+  int __contains__(const std::pair<tlp::node, tlp::node> &e);
+%MethodCode
+  return sipCpp->hasEdge(a0->first, a0->second);
+%End
+
+//===========================================================================================
+
   SIP_PYOBJECT __getitem__(const std::string &attributeName) const;
 %MethodCode
   if (sipCpp->existProperty(*a0)) {

--- a/tests/python/test_graph_structure.py
+++ b/tests/python/test_graph_structure.py
@@ -57,9 +57,11 @@ class TestGraphStructure(unittest.TestCase):
   def test_is_element(self):
     for n in self.nodes:
       self.assertTrue(self.graph.isElement(n))
+      self.assertTrue(n in self.graph)
 
     for e in self.edges:
       self.assertTrue(self.graph.isElement(e))
+      self.assertTrue(e in self.graph)
 
     for n in self.graph.getNodes():
       self.assertIn(n, self.nodes)
@@ -83,11 +85,15 @@ class TestGraphStructure(unittest.TestCase):
     for i in range(NB_NODES - 1):
       self.assertTrue(self.graph.hasEdge(self.nodes[i], self.nodes[i+1]))
       self.assertIn(self.graph.existEdge(self.nodes[i], self.nodes[i+1]), self.edges)
+      self.assertTrue((self.nodes[i], self.nodes[i+1]) in self.graph)
       self.assertTrue(self.graph.hasEdge(self.nodes[i], self.nodes[-1]))
       self.assertIn(self.graph.existEdge(self.nodes[i], self.nodes[-1]), self.edges)
+      self.assertTrue((self.nodes[i], self.nodes[-1]) in self.graph)
 
     self.assertFalse(self.graph.isElement(tlp.node(NB_NODES)))
+    self.assertTrue(tlp.node(NB_NODES) not in self.graph)
     self.assertFalse(self.graph.isElement(tlp.edge(NB_EDGES)))
+    self.assertTrue(tlp.edge(NB_EDGES) not in self.graph)
 
   def test_node_degrees(self):
     for i in range(NB_NODES-1):


### PR DESCRIPTION
This PR adresses issue #33 in order to test if a node or an edge belongs to a graph using classical Python idioms.

You can now write:
```python
# n, src, tgt are instances of tlp.node
# e is an instance of tlp.edge
# graph is an instance of tlp.Graph
if n in graph:
  ...

if e in graph:
  ...

if (src, tgt) in graph:
  ...

```

I have also updated tests and doc.