### PR TITLE
fix build with Qt 5.11

### DIFF
--- a/library/tulip-gui/src/CSVImportWizard.cpp
+++ b/library/tulip-gui/src/CSVImportWizard.cpp
@@ -20,6 +20,7 @@
 
 #include <QVBoxLayout>
 #include <QLabel>
+#include <QHeaderView>
 
 #include <tulip/CSVGraphImport.h>
 #include <tulip/CSVParserConfigurationWidget.h>

--- a/library/tulip-gui/src/CoordEditor.cpp
+++ b/library/tulip-gui/src/CoordEditor.cpp
@@ -23,6 +23,8 @@
 
 #include <cfloat>
 
+#include <QDoubleValidator>
+
 using namespace tlp;
 
 CoordEditor::CoordEditor(QWidget *parent, bool editSize)

--- a/plugins/view/SOMView/SOMPropertiesWidget.cpp
+++ b/plugins/view/SOMView/SOMPropertiesWidget.cpp
@@ -26,6 +26,7 @@
 #include <QDoubleValidator>
 #include <QRadioButton>
 #include <QPushButton>
+#include <QButtonGroup>
 
 #include <tulip/GraphPropertiesSelectionWidget.h>
 #include <tulip/ColorScalesManager.h>

--- a/software/tulip/src/TulipWelcomePage.cpp
+++ b/software/tulip/src/TulipWelcomePage.cpp
@@ -27,6 +27,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QXmlStreamReader>
+#include <QStyle>
 
 #include <tulip/TulipSettings.h>
 #include <tulip/PluginManager.h>


### PR DESCRIPTION
error: invalid use of incomplete type ‘class QHeaderView’
error: ‘QDoubleValidator’ was not declared in this scope
error: invalid use of incomplete type ‘class QButtonGroup’
