### PR TITLE
Appveyor builds: fix and improvement

### DIFF
--- a/appveyor_msvc.bat
+++ b/appveyor_msvc.bat
@@ -38,10 +38,10 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 rem get, compile and install libpng
 cd C:/tulip_dependencies
-curl -LO https://sourceforge.mirrorservice.org/l/li/libpng/libpng16/1.6.32/libpng-1.6.32.tar.gz
+curl -LO https://sourceforge.mirrorservice.org/l/li/libpng/libpng16/1.6.35/libpng-1.6.35.tar.gz
 if %errorlevel% neq 0 exit /b %errorlevel%
-7z x libpng-1.6.32.tar.gz -so | 7z x -aoa -si -ttar
-cd libpng-1.6.32
+7z x libpng-1.6.35.tar.gz -so | 7z x -aoa -si -ttar
+cd libpng-1.6.35
 md build && cd build
 cmake -G "%CMAKE_VS_GENERATOR%" -DCMAKE_INCLUDE_PATH="C:/tulip_dependencies/include" -DCMAKE_LIBRARY_PATH="C:/tulip_dependencies/lib" -DCMAKE_INSTALL_PREFIX="C:/tulip_dependencies" ..
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/appveyor_msys2.bat
+++ b/appveyor_msys2.bat
@@ -56,18 +56,19 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 bash -lc "cd build && make runTests"
 if %errorlevel% neq 0 exit /b %errorlevel%
 bash -lc "cd build && make bundle"
-if %errorlevel% neq 0 exit /b %errorlevel%
 
-rem Install sphinx for Python 2
-set PATH=%PYTHON2_HOME%;%PYTHON2_HOME%/Scripts;%PATH%
-pip install sphinx
+rem if %errorlevel% neq 0 exit /b %errorlevel%
 
-rem Build Tulip with Python 2, run its unit tests and package it
-bash -lc "mkdir build"
-bash -lc "cd build && cmake -G \"MSYS Makefiles\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_NEED_RESPONSE=ON -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/build/install -DTULIP_BUILD_DOC=OFF -DTULIP_BUILD_TESTS=ON -DTULIP_USE_QT5=ON -DTULIP_USE_CCACHE=ON -DPYTHON_EXECUTABLE=%PYTHON2_HOME%/python.exe .."
-if %errorlevel% neq 0 exit /b %errorlevel%
-bash -lc "cd build && make -j4 install"
-if %errorlevel% neq 0 exit /b %errorlevel%
-bash -lc "cd build && make runTests"
-if %errorlevel% neq 0 exit /b %errorlevel%
-bash -lc "cd build && make bundle"
+rem rem Install sphinx for Python 2
+rem set PATH=%PYTHON2_HOME%;%PYTHON2_HOME%/Scripts;%PATH%
+rem pip install sphinx
+
+rem rem Build Tulip with Python 2, run its unit tests and package it
+rem bash -lc "mkdir build"
+rem bash -lc "cd build && cmake -G \"MSYS Makefiles\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_NEED_RESPONSE=ON -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/build/install -DTULIP_BUILD_DOC=OFF -DTULIP_BUILD_TESTS=ON -DTULIP_USE_QT5=ON -DTULIP_USE_CCACHE=ON -DPYTHON_EXECUTABLE=%PYTHON2_HOME%/python.exe .."
+rem if %errorlevel% neq 0 exit /b %errorlevel%
+rem bash -lc "cd build && make -j4 install"
+rem if %errorlevel% neq 0 exit /b %errorlevel%
+rem bash -lc "cd build && make runTests"
+rem if %errorlevel% neq 0 exit /b %errorlevel%
+rem bash -lc "cd build && make bundle"


### PR DESCRIPTION
This commit fixes the MSVC builds on AppVeyor (libpng url was no more valid) and build Tulip with Python 3 only for MSYS2 in order to avoid build timeouts (limited to 1h, timeouts can still appear but less than before)