### PR TITLE
tulip-python/PythonInterpreter: Remove no more needed function calls

### DIFF
--- a/library/tulip-python/src/PythonInterpreter.cpp
+++ b/library/tulip-python/src/PythonInterpreter.cpp
@@ -343,9 +343,6 @@ PythonInterpreter::PythonInterpreter()
       addModuleSearchPath(tlpStringToQString(tlp::TulipLibDir) + "/tulip/python", true);
 #endif
 
-      initconsoleutils();
-      inittuliputils();
-
       // Try to import site package manually otherwise Py_InitializeEx can crash if Py_NoSiteFlag is
       // not set
       // and if the site module is not present on the host system


### PR DESCRIPTION
Those should have been removed in commit cbb85d6.