### PR TITLE
tulipgui-python: Force version of tulip-python dependency

### DIFF
--- a/library/tulip-python/bindings/tulip-gui/packaging/setup.py.in
+++ b/library/tulip-python/bindings/tulip-gui/packaging/setup.py.in
@@ -189,7 +189,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['tulip-python'],
+    install_requires=['tulip-python==@TULIP_PYTHON_WHEEL_VERSION@'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This setup should have been this way from the beginning, my bad.

tulipgui-python X.Y is only compatible with tulip-python X.Y so ensure correct version in install_requires to avoid possible version mismatch the day tulipgui-python will not be distributed on PyPI anymore.