### PR TITLE
EdgeBundling: Fix segfault with input layout containing nodes with same position

### DIFF
--- a/plugins/general/EdgeBundling/EdgeBundling.cpp
+++ b/plugins/general/EdgeBundling/EdgeBundling.cpp
@@ -394,7 +394,7 @@ bool EdgeBundling::run() {
           continue;
 
         tlp::edge e = gridGraph->addEdge(samePositionNodes[i][j], n);
-        ntype.setEdgeValue(e, 2);
+        ntype.addEdgeValue(e, 2);
       }
     }
   }


### PR DESCRIPTION
While attempting to bundle that graph containing nodes at the same position [air-routes-latest.tlp.gz](https://github.com/Tulip-Dev/tulip/files/2611851/air-routes-latest.tlp.gz), Tulip segfaults.

A regression was introduced in commit 728ac5dd83459eb886b8e97e00e001259d1769ba, due to the switch to static properties for better multi-threading.

The following output from the `AddressSanitizer` tool from `clang` helped me find the cause of this issue (`heap-buffer-overflow` due to a vector not resized after the add of a new edge):

```
antoine@guggenheim:~/dev/tulip_build_clang$ ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-7/bin/llvm-symbolizer ./install/bin/tulip_perspective 
Perspective running in standalone mode
=================================================================
==18119==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7f5f6aef92e4 at pc 0x7f5f8395db42 bp 0x7ffd021db550 sp 0x7ffd021db548
WRITE of size 4 at 0x7f5f6aef92e4 thread T0
    #0 0x7f5f8395db41 in tlp::EdgeStaticProperty<unsigned int>::setEdgeValue(tlp::edge, unsigned int) /home/antoine/dev/tulip/library/tulip-core/include/tulip/StaticProperty.h:211:16
    #1 0x7f5f8395db41 in EdgeBundling::run() /home/antoine/dev/tulip/plugins/general/EdgeBundling/EdgeBundling.cpp:397
    #2 0x7f5fa690fc5b in tlp::Graph::applyAlgorithm(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, tlp::DataSet*, tlp::PluginProgress*) /home/antoine/dev/tulip/library/tulip-core/src/Graph.cpp:689:23
    #3 0x7f5f7d081c76 in AlgorithmRunnerItem::run(tlp::Graph*) /home/antoine/dev/tulip/plugins/perspective/GraphPerspective/src/AlgorithmRunnerItem.cpp:384:20
    #4 0x7f5f7d1d8a20 in AlgorithmRunnerItem::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/antoine/dev/tulip_build_clang/plugins/perspective/GraphPerspective/include/moc_AlgorithmRunnerItem.cxx
    #5 0x7f5fa7b8465f in QMetaObject::activate(QObject*, QMetaObject const*, int, void**) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x19f65f)
    #6 0x7f5fa8a8fc71 in QAbstractButton::clicked(bool) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x863c71)
    #7 0x7f5fa87c65c2  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x59a5c2)
    #8 0x7f5fa87c7943  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x59b943)
    #9 0x7f5fa87c7a53 in QAbstractButton::mouseReleaseEvent(QMouseEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x59ba53)
    #10 0x7f5fa8446e7f in QWidget::event(QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x21ae7f)
    #11 0x7f5fa83f054b in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1c454b)
    #12 0x7f5fa83f8ca6 in QApplication::notify(QObject*, QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1ccca6)
    #13 0x7f5fa7b6ff1c in QCoreApplication::notifyInternal(QObject*, QEvent*) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x18af1c)
    #14 0x7f5fa83f6cca in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1cacca)
    #15 0x7f5fa84721a8  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x2461a8)
    #16 0x7f5fa8470b5b in QApplication::x11ProcessEvent(_XEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x244b5b)
    #17 0x7f5fa849a501  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x26e501)
    #18 0x7f5fa22377f6 in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4a7f6)
    #19 0x7f5fa2237a5f  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4aa5f)
    #20 0x7f5fa2237b0b in g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4ab0b)
    #21 0x7f5fa7ba0853 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x1bb853)
    #22 0x7f5fa849a5d5  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x26e5d5)
    #23 0x7f5fa7b6e7ee in QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x1897ee)
    #24 0x7f5fa7b6eb54 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x189b54)
    #25 0x7f5fa7b74bd8 in QCoreApplication::exec() (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x18fbd8)
    #26 0x555d77 in main /home/antoine/dev/tulip/software/tulip_perspective/src/main.cpp:367:16
    #27 0x7f5fa3b8d2b0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b0)
    #28 0x441ce9 in _start (/home/antoine/dev/tulip_build_clang/install/bin/tulip_perspective+0x441ce9)

0x7f5f6aef92e4 is located 0 bytes to the right of 490212-byte region [0x7f5f6ae81800,0x7f5f6aef92e4)
allocated by thread T0 here:
    #0 0x54d6e0 in operator new(unsigned long) (/home/antoine/dev/tulip_build_clang/install/bin/tulip_perspective+0x54d6e0)
    #1 0x7f5fa720af4b in __gnu_cxx::new_allocator<unsigned int>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/ext/new_allocator.h:111:27
    #2 0x7f5fa720af4b in std::allocator_traits<std::allocator<unsigned int> >::allocate(std::allocator<unsigned int>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/alloc_traits.h:436
    #3 0x7f5fa720af4b in std::_Vector_base<unsigned int, std::allocator<unsigned int> >::_M_allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/stl_vector.h:296
    #4 0x7f5fa720af4b in std::vector<unsigned int, std::allocator<unsigned int> >::_M_default_append(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/vector.tcc:604

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/antoine/dev/tulip/library/tulip-core/include/tulip/StaticProperty.h:211:16 in tlp::EdgeStaticProperty<unsigned int>::setEdgeValue(tlp::edge, unsigned int)
Shadow bytes around the buggy address:
  0x0fec6d5d7200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fec6d5d7210: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fec6d5d7220: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fec6d5d7230: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fec6d5d7240: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0fec6d5d7250: 00 00 00 00 00 00 00 00 00 00 00 00[04]fa fa fa
  0x0fec6d5d7260: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fec6d5d7270: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fec6d5d7280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fec6d5d7290: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fec6d5d72a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==18119==ABORTING
```