### PR TITLE
tulip-gui/TulipProject: Fix not critical stack-use-after-scope issue

### DIFF
--- a/library/tulip-gui/src/TulipProject.cpp
+++ b/library/tulip-gui/src/TulipProject.cpp
@@ -332,10 +332,10 @@ bool TulipProject::readMetaInfo() {
         return false;
       }
 
-      const char *name(QStringToTlpString(doc.name().toString()).c_str());
+      std::string name = QStringToTlpString(doc.name().toString());
 
-      if (property(name).isValid())
-        setProperty(name, doc.readElementText());
+      if (property(name.c_str()).isValid())
+        setProperty(name.c_str(), doc.readElementText());
     }
   }
 


### PR DESCRIPTION
While debugging #56, I also stumbled across that memory issue, not critical but still ugly.
The blame is on me for this one, I introduced it in commit 3548bbb179bef60aa0a7aff9202f21b87ac59f3a. 

```
antoine@guggenheim:~/dev/tulip_build_clang$ ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-7/bin/llvm-symbolizer ./install/bin/tulip_perspective 
Perspective running in standalone mode
=================================================================
==30840==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffcc3a8f0e1 at pc 0x0000004e5102 bp 0x7ffcc3a8ed80 sp 0x7ffcc3a8e530
READ of size 4 at 0x7ffcc3a8f0e1 thread T0
    #0 0x4e5101 in __interceptor_strcmp.part.285 (/home/antoine/dev/tulip_build_clang/install/bin/tulip_perspective+0x4e5101)
    #1 0x7f683b212594 in QMetaObject::indexOfProperty(char const*) const (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x192594)
    #2 0x7f683b21ef98 in QObject::property(char const*) const (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x19ef98)
    #3 0x7f683f1c5448 in tlp::TulipProject::readMetaInfo() /home/antoine/dev/tulip/library/tulip-gui/src/TulipProject.cpp:337:11
    #4 0x7f683f1c484d in tlp::TulipProject::openProjectFile(QString const&, tlp::PluginProgress*) /home/antoine/dev/tulip/library/tulip-gui/src/TulipProject.cpp:102:3
    #5 0x7f6810823cf1 in GraphPerspective::openProjectFile(QString const&) /home/antoine/dev/tulip/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp:1115:15
    #6 0x7f68107faa94 in GraphPerspective::open(QString) /home/antoine/dev/tulip/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp:1098:9
    #7 0x7f6810832301 in GraphPerspective::openRecentFile() /home/antoine/dev/tulip/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp:1697:3
    #8 0x7f68108da717 in GraphPerspective::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/antoine/dev/tulip_build_clang/plugins/perspective/GraphPerspective/include/moc_GraphPerspective.cxx:239:22
    #9 0x7f683b21f65f in QMetaObject::activate(QObject*, QMetaObject const*, int, void**) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x19f65f)
    #10 0x7f683ba85671 in QAction::triggered(bool) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1be671)
    #11 0x7f683ba869d2 in QAction::activate(QAction::ActionEvent) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1bf9d2)
    #12 0x7f683bee33cc  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x61c3cc)
    #13 0x7f683bee7838  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x620838)
    #14 0x7f683bae1e7f in QWidget::event(QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x21ae7f)
    #15 0x7f683beeba8a in QMenu::event(QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x624a8a)
    #16 0x7f683ba8b54b in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1c454b)
    #17 0x7f683ba93ca6 in QApplication::notify(QObject*, QEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1ccca6)
    #18 0x7f683b20af1c in QCoreApplication::notifyInternal(QObject*, QEvent*) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x18af1c)
    #19 0x7f683ba91cca in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x1cacca)
    #20 0x7f683bb0d42c  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x24642c)
    #21 0x7f683bb0bb5b in QApplication::x11ProcessEvent(_XEvent*) (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x244b5b)
    #22 0x7f683bb35501  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x26e501)
    #23 0x7f68358d27f6 in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4a7f6)
    #24 0x7f68358d2a5f  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4aa5f)
    #25 0x7f68358d2b0b in g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4ab0b)
    #26 0x7f683b23b853 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x1bb853)
    #27 0x7f683bb355d5  (/usr/lib/x86_64-linux-gnu/libQtGui.so.4+0x26e5d5)
    #28 0x7f683b2097ee in QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x1897ee)
    #29 0x7f683b209b54 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x189b54)
    #30 0x7f683b20fbd8 in QCoreApplication::exec() (/usr/lib/x86_64-linux-gnu/libQtCore.so.4+0x18fbd8)
    #31 0x555d77 in main /home/antoine/dev/tulip/software/tulip_perspective/src/main.cpp:367:16
    #32 0x7f68372282b0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b0)
    #33 0x441ce9 in _start (/home/antoine/dev/tulip_build_clang/install/bin/tulip_perspective+0x441ce9)

Address 0x7ffcc3a8f0e1 is located in stack of thread T0 at offset 577 in frame
    #0 0x7f683f1c4e5f in tlp::TulipProject::readMetaInfo() /home/antoine/dev/tulip/library/tulip-gui/src/TulipProject.cpp:311

  This frame has 27 object(s):
    [32, 33) 'ret.i.i251'
    [48, 49) 'ret.i.i244'
    [64, 65) 'ret.i.i237'
    [80, 81) 'ret.i.i229'
    [96, 97) 'ret.i.i217'
    [112, 113) 'ret.i.i205'
    [128, 129) 'ret.i.i165'
    [144, 145) 'ret.i.i153'
    [160, 161) 'ret.i.i134'
    [176, 177) 'ret.i.i127'
    [192, 193) 'ret.i.i120'
    [208, 209) 'ret.i.i'
    [224, 240) 'in' (line 312)
    [256, 264) 'ref.tmp' (line 312)
    [288, 296) 'ref.tmp2' (line 312)
    [320, 324) 'agg.tmp'
    [336, 344) 'doc' (line 317)
    [368, 400) 'ref.tmp21' (line 321)
    [432, 440) 'ref.tmp22' (line 321)
    [464, 496) 'ref.tmp50' (line 329)
    [528, 536) 'ref.tmp51' (line 329)
    [560, 592) 'ref.tmp67' (line 335) <== Memory access at offset 577 is inside this variable
    [624, 632) 'ref.tmp68' (line 335)
    [656, 672) 'ref.tmp69' (line 335)
    [688, 704) 'ref.tmp82' (line 337)
    [720, 736) 'ref.tmp91' (line 338)
    [752, 760) 'ref.tmp92' (line 338)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope (/home/antoine/dev/tulip_build_clang/install/bin/tulip_perspective+0x4e5101) in __interceptor_strcmp.part.285
Shadow bytes around the buggy address:
  0x100018749dc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100018749dd0: 00 00 00 00 f1 f1 f1 f1 f8 f2 f8 f2 f8 f2 f8 f2
  0x100018749de0: f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2
  0x100018749df0: 00 00 f2 f2 f8 f2 f2 f2 f8 f2 f2 f2 04 f2 00 f2
  0x100018749e00: f2 f2 f8 f8 f8 f8 f2 f2 f2 f2 f8 f2 f2 f2 f8 f8
=>0x100018749e10: f8 f8 f2 f2 f2 f2 f8 f2 f2 f2 f8 f8[f8]f8 f2 f2
  0x100018749e20: f2 f2 f8 f2 f2 f2 f8 f8 f2 f2 00 00 f2 f2 f8 f8
  0x100018749e30: f2 f2 f8 f3 f3 f3 f3 f3 00 00 00 00 00 00 00 00
  0x100018749e40: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f8 f2 f8 f2
  0x100018749e50: f8 f2 f2 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2
  0x100018749e60: f8 f2 f8 f2 00 f2 f2 f2 f8 f2 f2 f2 f8 f2 f2 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==30840==ABORTING
``` 