### PR TITLE
Fix Tulip build with GCC 8.2.1 on MSYS2

### DIFF
--- a/appveyor_msys2.bat
+++ b/appveyor_msys2.bat
@@ -14,6 +14,10 @@ bash -lc "pacman --noconfirm --sync --refresh --sysupgrade"
 rem Install required tools
 bash -lc "pacman --noconfirm -S --needed base-devel unzip"
 
+rem Always install latest GCC toolchain in order to detect possible build failures
+rem when its version evolves
+bash -lc "pacman --noconfirm -S --needed mingw-w64-%MSYS2_ARCH%-toolchain"
+
 rem Install the relevant native dependencies
 bash -lc "pacman --noconfirm -S --needed --force mingw-w64-%MSYS2_ARCH%-yajl"
 bash -lc "pacman --noconfirm -S --needed --force mingw-w64-%MSYS2_ARCH%-qhull"

--- a/cmake/TulipUseFile.cmake
+++ b/cmake/TulipUseFile.cmake
@@ -105,7 +105,6 @@ MACRO(TULIP_SET_COMPILER_OPTIONS)
       # Dynamic ling against libstdc++ on win32/MinGW
       # The second test is for the case where ccache is used (CMAKE_CXX_COMPILER_ARG1 contains the path to the g++ compiler)
       IF(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ARG1}" MATCHES ".*[g][+][+].*")
-
         IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.0)
           SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--subsystem,windows")
           #GCC 4.4 use double dashes and gcc 4.6 single dashes for this option
@@ -118,15 +117,6 @@ MACRO(TULIP_SET_COMPILER_OPTIONS)
             SET(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -shared-libgcc  -Wl,--allow-multiple-definition")
             SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -shared-libgcc  -Wl,--allow-multiple-definition")
           ENDIF()
-
-        ENDIF()
-
-        IF(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.4)
-          SET(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lstdc++_s")
-        ELSEIF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.5 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.5)
-          #mingw 4.4.0 cannot link the tulip core library as it does not have exceptions symbols correctly defined (MinGW bug #2836185)
-          SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_DLL")
-          SET(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lstdc++")
         ENDIF()
       ENDIF()
     ENDIF(NOT MSVC)
@@ -175,11 +165,6 @@ MACRO(TULIP_SET_COMPILER_OPTIONS)
     ENDIF("${CMAKE_GENERATOR}" MATCHES ".*MSYS.*")
 	
   ENDIF(WIN32)
-
-  # Use debug mode with GLIBC
-  IF(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ARG1}" MATCHES ".*[g][+][+].*")
-    SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DGLIBCXX")
-  ENDIF()
 
 ENDMACRO(TULIP_SET_COMPILER_OPTIONS)
 


### PR DESCRIPTION
The latest compiler toolchain available for MSYS2 users is GCC 8.2.1 and new compilation errors appear with it, quoting build log:

```
In file included from C:/msys64/mingw64/include/c++/8.2.1/bits/shared_ptr.h:52,
                 from C:/msys64/mingw64/include/c++/8.2.1/memory:81,
                 from C:/msys64/mingw64/include/cppunit/extensions/HelperMacros.h:16,
                 from C:/projects/tulip/tests/include/CppUnitIncludes.h:29,
                 from C:/projects/tulip/tests/library/tulip/ImportExportTest.h:22,
                 from C:/projects/tulip/tests/library/tulip/ImportExportTest.cpp:19:
C:/msys64/mingw64/include/c++/8.2.1/bits/shared_ptr_base.h:510:5: error: function 'static const std::type_info& std::_Sp_make_shared_tag::_S_ti()' definition is marked dllimport
     _S_ti() noexcept _GLIBCXX_VISIBILITY(default)
     ^~~~~
``` 

This was due to some compiler flags needed at the time when Tulip was built with MinGW 4.x (time flies). This compiler is quite dead nowadays and does not support C++11, so we can safely remove 
these flags. I also removed a useless flag (`-DGLIBCXX`) that was set for all compilers.