### PR TITLE
thirdparty: Upgrade ftgl and libtess2

### DIFF
--- a/thirdparty/ftgl/CMakeLists.txt
+++ b/thirdparty/ftgl/CMakeLists.txt
@@ -1,105 +1,120 @@
-SET (FTGL_MAJOR 2)
-SET (FTGL_MINOR 1)
+SET(VERSION_SERIES 2)
+SET(VERSION_MAJOR 3)
+SET(VERSION_MINOR 0)
+SET(FTGL_SOVERSION 1)
 
-IF(MSVC)
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFTGL_LIBRARY")
-ENDIF()
+ADD_DEFINITIONS(-DPACKAGE_VERSION="${VERSION_SERIES}.${VERSION_MAJOR}.${VERSION_MINOR}")
+
+IF(WIN32)
+  ADD_DEFINITIONS(-D_USE_MATH_DEFINES)
+  IF(MSVC)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFTGL_LIBRARY")
+  ENDIF()
+ENDIF(WIN32)
 
 SET(ftgl_SRCS
-    FTBuffer.cpp 
-    FTCharmap.cpp 
-    FTCharmap.h 
-    FTCharToGlyphIndexMap.h 
-    FTContour.cpp 
-    FTContour.h 
-    FTFace.cpp 
-    FTFace.h 
-    FTGlyphContainer.cpp 
-    FTGlyphContainer.h 
-    FTInternals.h 
-    FTLibrary.cpp 
-    FTLibrary.h 
-    FTList.h 
-    FTPoint.cpp 
-    FTSize.cpp 
-    FTSize.h 
-    FTVector.h 
-    FTVectoriser.cpp 
-    FTVectoriser.h 
-    FTUnicode.h 
+    FTBuffer.cpp
+    FTCharmap.cpp
+    FTCharmap.h
+    FTCharToGlyphIndexMap.h
+    FTCleanup.cpp
+    FTCleanup.h
+    FTContour.cpp
+    FTContour.h
+    FTFace.cpp
+    FTFace.h
+    FTGL.cpp
+    FTGlyphContainer.cpp
+    FTGlyphContainer.h
+    FTInternals.h
+    FTLibrary.cpp
+    FTLibrary.h
+    FTList.h
+    FTPoint.cpp
+    FTSize.cpp
+    FTSize.h
+    FTVector.h
+    FTVectoriser.cpp
+    FTVectoriser.h
+    FTUnicode.h
 )
 
-SET(ftgl_headers_SRCS
-    FTGL/ftgl.h 
-    FTGL/FTBBox.h 
-    FTGL/FTBuffer.h 
-    FTGL/FTPoint.h 
-    FTGL/FTGlyph.h 
-    FTGL/FTBitmapGlyph.h 
-    FTGL/FTBufferGlyph.h 
-    FTGL/FTExtrdGlyph.h 
-    FTGL/FTOutlineGlyph.h 
-    FTGL/FTPixmapGlyph.h 
-    FTGL/FTPolyGlyph.h 
-    FTGL/FTTextureGlyph.h 
-    FTGL/FTFont.h 
-    FTGL/FTGLBitmapFont.h 
-    FTGL/FTBufferFont.h 
-    FTGL/FTGLExtrdFont.h 
-    FTGL/FTGLOutlineFont.h 
-    FTGL/FTGLPixmapFont.h 
-    FTGL/FTGLPolygonFont.h 
-    FTGL/FTGLTextureFont.h 
-    FTGL/FTLayout.h 
+SET(ftgl_headers
+    FTGL/ftgl.h
+    FTGL/FTBBox.h
+    FTGL/FTBuffer.h
+    FTGL/FTPoint.h
+    FTGL/FTGlyph.h
+    FTGL/FTBitmapGlyph.h
+    FTGL/FTBufferGlyph.h
+    FTGL/FTExtrdGlyph.h
+    FTGL/FTOutlineGlyph.h
+    FTGL/FTPixmapGlyph.h
+    FTGL/FTPolyGlyph.h
+    FTGL/FTTextureGlyph.h
+    FTGL/FTFont.h
+    FTGL/FTGLBitmapFont.h
+    FTGL/FTBufferFont.h
+    FTGL/FTGLExtrdFont.h
+    FTGL/FTGLOutlineFont.h
+    FTGL/FTGLPixmapFont.h
+    FTGL/FTGLPolygonFont.h
+    FTGL/FTGLTextureFont.h
+    FTGL/FTGLTriangleExtractorFont.h
+    FTGL/FTLayout.h
     FTGL/FTSimpleLayout.h
 )
 
 SET(ftglyph_SRCS
-    FTGlyph/FTGlyph.cpp 
-    FTGlyph/FTGlyphImpl.h 
-    FTGlyph/FTGlyphGlue.cpp 
-    FTGlyph/FTBitmapGlyph.cpp 
-    FTGlyph/FTBitmapGlyphImpl.h 
-    FTGlyph/FTBufferGlyph.cpp 
-    FTGlyph/FTBufferGlyphImpl.h 
-    FTGlyph/FTExtrudeGlyph.cpp 
-    FTGlyph/FTExtrudeGlyphImpl.h 
-    FTGlyph/FTOutlineGlyph.cpp 
-    FTGlyph/FTOutlineGlyphImpl.h 
-    FTGlyph/FTPixmapGlyph.cpp 
-    FTGlyph/FTPixmapGlyphImpl.h 
-    FTGlyph/FTPolygonGlyph.cpp 
-    FTGlyph/FTPolygonGlyphImpl.h 
-    FTGlyph/FTTextureGlyph.cpp 
-    FTGlyph/FTTextureGlyphImpl.h 
+    FTGlyph/FTGlyph.cpp
+    FTGlyph/FTGlyphImpl.h
+    FTGlyph/FTGlyphGlue.cpp
+    FTGlyph/FTBitmapGlyph.cpp
+    FTGlyph/FTBitmapGlyphImpl.h
+    FTGlyph/FTBufferGlyph.cpp
+    FTGlyph/FTBufferGlyphImpl.h
+    FTGlyph/FTExtrudeGlyph.cpp
+    FTGlyph/FTExtrudeGlyphImpl.h
+    FTGlyph/FTOutlineGlyph.cpp
+    FTGlyph/FTOutlineGlyphImpl.h
+    FTGlyph/FTPixmapGlyph.cpp
+    FTGlyph/FTPixmapGlyphImpl.h
+    FTGlyph/FTPolygonGlyph.cpp
+    FTGlyph/FTPolygonGlyphImpl.h
+    FTGlyph/FTTextureGlyph.cpp
+    FTGlyph/FTTextureGlyphImpl.h
+    FTGlyph/FTTriangleExtractorGlyph.cpp
+    FTGlyph/FTTriangleExtractorGlyphImpl.h
 )
 
 SET(ftfont_SRCS
-    FTFont/FTFont.cpp 
-    FTFont/FTFontImpl.h 
-    FTFont/FTFontGlue.cpp 
-    FTFont/FTBitmapFont.cpp 
-    FTFont/FTBitmapFontImpl.h 
-    FTFont/FTBufferFont.cpp 
-    FTFont/FTBufferFontImpl.h 
-    FTFont/FTExtrudeFont.cpp 
-    FTFont/FTExtrudeFontImpl.h 
-    FTFont/FTOutlineFont.cpp 
-    FTFont/FTOutlineFontImpl.h 
-    FTFont/FTPixmapFont.cpp 
-    FTFont/FTPixmapFontImpl.h 
-    FTFont/FTPolygonFont.cpp 
-    FTFont/FTPolygonFontImpl.h 
-    FTFont/FTTextureFont.cpp 
-    FTFont/FTTextureFontImpl.h 
+    FTFont/FTFont.cpp
+    FTFont/FTFontImpl.h
+    FTFont/FTFontGlue.cpp
+    FTFont/FTBitmapFont.cpp
+    FTFont/FTBitmapFontImpl.h
+    FTFont/FTBufferFont.cpp
+    FTFont/FTBufferFontImpl.h
+    FTFont/FTExtrudeFont.cpp
+    FTFont/FTExtrudeFontImpl.h
+    FTFont/FTOutlineFont.cpp
+    FTFont/FTOutlineFontImpl.h
+    FTFont/FTPixmapFont.cpp
+    FTFont/FTPixmapFontImpl.h
+    FTFont/FTPolygonFont.cpp
+    FTFont/FTPolygonFontImpl.h
+    FTFont/FTTextureFont.cpp
+    FTFont/FTTextureFontImpl.h
+    FTFont/FTTriangleExtractorFont.cpp
+    FTFont/FTTriangleExtractorFontImpl.h
 )
 
 SET(ftlayout_SRCS
-    FTLayout/FTLayout.cpp 
-    FTLayout/FTLayoutImpl.h 
-    FTLayout/FTLayoutGlue.cpp 
-    FTLayout/FTSimpleLayout.cpp 
-    FTLayout/FTSimpleLayoutImpl.h 
+    FTLayout/FTLayout.cpp
+    FTLayout/FTLayoutImpl.h
+    FTLayout/FTLayoutGlue.cpp
+    FTLayout/FTSimpleLayout.cpp
+    FTLayout/FTSimpleLayoutImpl.h
 )
 
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${Tess2Include} ${FREETYPE_INCLUDE_DIRS} ${GLEW_INCLUDE_DIR})
@@ -107,8 +122,8 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${Tess2Include} ${FREETYPE_INCLU
 ADD_LIBRARY(${FTGLLibrary} SHARED ${ftgl_SRCS} ${ftgl_headers_SRCS} ${ftglyph_SRCS} ${ftfont_SRCS} ${ftlayout_SRCS})
 TARGET_LINK_LIBRARIES(${FTGLLibrary} ${OPENGL_gl_LIBRARY} ${FREETYPE_LIBRARY} ${Tess2Library} ${GLEW_LIBRARY})
 SET_TARGET_PROPERTIES(${FTGLLibrary} PROPERTIES
-  SOVERSION ${FTGL_MAJOR}
-  VERSION ${FTGL_MAJOR}.${FTGL_MINOR})
+  SOVERSION ${FTGL_SOVERSION}
+  VERSION ${VERSION_SERIES}.${VERSION_MAJOR}.${VERSION_MINOR})
 
 INSTALL(TARGETS ${FTGLLibrary}
        RUNTIME DESTINATION ${TulipBinInstallDir} COMPONENT ftgl

--- a/thirdparty/ftgl/FTBuffer.cpp
+++ b/thirdparty/ftgl/FTBuffer.cpp
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTCharToGlyphIndexMap.h
+++ b/thirdparty/ftgl/FTCharToGlyphIndexMap.h
@@ -52,104 +52,95 @@
 class FTCharToGlyphIndexMap
 {
     public:
-
         typedef unsigned long CharacterCode;
         typedef signed long GlyphIndex;
 
-        enum
-        {
-            NumberOfBuckets = 256,
-            BucketSize = 256,
-            IndexNotFound = -1
-        };
+        // XXX: always ensure that 1 << (3 * BucketIdxBits) >= UnicodeValLimit
+        static const int BucketIdxBits = 7;
+        static const int BucketIdxSize = 1 << BucketIdxBits;
+        static const int BucketIdxMask = BucketIdxSize - 1;
+
+        static const CharacterCode UnicodeValLimit = 0x110000;
+        static const int IndexNotFound = -1;
 
         FTCharToGlyphIndexMap()
         {
-            this->Indices = 0;
+            Indices = 0;
         }
 
         virtual ~FTCharToGlyphIndexMap()
         {
-            if(this->Indices)
-            {
-                // Free all buckets
-                this->clear();
-
-                // Free main structure
-                delete [] this->Indices;
-                this->Indices = 0;
-            }
+            // Free all buckets
+            clear();
         }
 
-        void clear()
+        inline void clear()
         {
-            if(this->Indices)
+            for(int j = 0; Indices && j < BucketIdxSize; j++)
             {
-                for(int i = 0; i < FTCharToGlyphIndexMap::NumberOfBuckets; i++)
+                for(int i = 0; Indices[j] && i < BucketIdxSize; i++)
                 {
-                    if(this->Indices[i])
-                    {
-                        delete [] this->Indices[i];
-                        this->Indices[i] = 0;
-                    }
+                    delete[] Indices[j][i];
+                    Indices[j][i] = 0;
                 }
+                delete[] Indices[j];
+                Indices[j] = 0;
             }
+            delete[] Indices;
+            Indices = 0;
         }
 
-        GlyphIndex find(CharacterCode c)
+        const GlyphIndex find(CharacterCode c)
         {
-            if(!this->Indices)
-            {
+            int OuterIdx = (c >> (BucketIdxBits * 2)) & BucketIdxMask;
+            int InnerIdx = (c >> BucketIdxBits) & BucketIdxMask;
+            int Offset = c & BucketIdxMask;
+
+            if (c >= UnicodeValLimit || !Indices
+                 || !Indices[OuterIdx] || !Indices[OuterIdx][InnerIdx])
                 return 0;
-            }
 
-            // Find position of char code in buckets
-            div_t pos = div(c, FTCharToGlyphIndexMap::BucketSize);
+            GlyphIndex g = Indices[OuterIdx][InnerIdx][Offset];
 
-            if(!this->Indices[pos.quot])
-            {
-                return 0;
-            }
-
-            const FTCharToGlyphIndexMap::GlyphIndex *ptr = &this->Indices[pos.quot][pos.rem];
-            if(*ptr == FTCharToGlyphIndexMap::IndexNotFound)
-            {
-                return 0;
-            }
-
-            return *ptr;
+            return (g != IndexNotFound) ? g : 0;
         }
 
         void insert(CharacterCode c, GlyphIndex g)
         {
-            if(!this->Indices)
+            int OuterIdx = (c >> (BucketIdxBits * 2)) & BucketIdxMask;
+            int InnerIdx = (c >> BucketIdxBits) & BucketIdxMask;
+            int Offset = c & BucketIdxMask;
+
+            if (c >= UnicodeValLimit)
+                return;
+
+            if (!Indices)
             {
-                this->Indices = new GlyphIndex* [FTCharToGlyphIndexMap::NumberOfBuckets];
-                for(int i = 0; i < FTCharToGlyphIndexMap::NumberOfBuckets; i++)
-                {
-                    this->Indices[i] = 0;
-                }
+                Indices = new GlyphIndex** [BucketIdxSize];
+                for(int i = 0; i < BucketIdxSize; i++)
+                    Indices[i] = 0;
             }
 
-            // Find position of char code in buckets
-            div_t pos = div(c, FTCharToGlyphIndexMap::BucketSize);
-
-            // Allocate bucket if does not exist yet
-            if(!this->Indices[pos.quot])
+            if (!Indices[OuterIdx])
             {
-                this->Indices[pos.quot] = new GlyphIndex [FTCharToGlyphIndexMap::BucketSize];
-                for(int i = 0; i < FTCharToGlyphIndexMap::BucketSize; i++)
-                {
-                    this->Indices[pos.quot][i] = FTCharToGlyphIndexMap::IndexNotFound;
-                }
+                Indices[OuterIdx] = new GlyphIndex* [BucketIdxSize];
+                for(int i = 0; i < BucketIdxSize; i++)
+                    Indices[OuterIdx][i] = 0;
             }
 
-            this->Indices[pos.quot][pos.rem] = g;
+            if (!Indices[OuterIdx][InnerIdx])
+            {
+                Indices[OuterIdx][InnerIdx] = new GlyphIndex [BucketIdxSize];
+                for(int i = 0; i < BucketIdxSize; i++)
+                    Indices[OuterIdx][InnerIdx][i] = IndexNotFound;
+            }
+
+            Indices[OuterIdx][InnerIdx][Offset] = g;
         }
 
     private:
-        GlyphIndex** Indices;
+        GlyphIndex*** Indices;
 };
 
-
 #endif  //  __FTCharToGlyphIndexMap__
+

--- a/thirdparty/ftgl/FTCleanup.h
+++ b/thirdparty/ftgl/FTCleanup.h
@@ -1,0 +1,104 @@
+/*
+ * FTGL - OpenGL font library
+ *
+ * Copyright (c) 2009 Sam Hocevar <sam@hocevar.net>
+ *               2009 Mathew Eis (kingrobot)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef     __FTCleanup__
+#define     __FTCleanup__
+
+#include <set>
+
+#include "FTFace.h"
+
+/**
+ * A dummy object type for items to be stored in the cleanup list
+ */
+typedef void* FTCleanupObject;
+
+/**
+ * FTCleanup is used as a "callback" by FTLibrary to
+ * make sure things are cleaned up in the right order
+ */
+class FTCleanup
+{
+    protected:
+
+        /**
+         * singleton instance
+         */
+        static FTCleanup* _instance;
+
+        /**
+         * Constructors
+         */
+         FTCleanup();
+
+        /**
+         * Destructor
+         */
+         ~FTCleanup();
+
+    public:
+
+        /**
+         * Generate the instance if necessary and return it
+         *
+         * @return The FTCleanup instance
+         */
+        static FTCleanup* Instance()
+        {
+            if (FTCleanup::_instance == 0)
+                FTCleanup::_instance = new FTCleanup;
+            return FTCleanup::_instance;
+        }
+
+        /**
+        * Destroy the FTCleanup instance
+        */
+        static void DestroyAll()
+        {
+            delete FTCleanup::_instance;
+        }
+
+        /**
+         * Add an FT_Face to the cleanup list
+         *
+         * @param obj The reference to the FT_Face to be deleted on cleanup
+         */
+        void RegisterObject(FT_Face **obj);
+
+        /**
+         * Remove an FT_Face from the cleanup list
+         *
+         * @param obj The reference to the FT_Face to be removed from the list
+         */
+        void UnregisterObject(FT_Face **obj);
+
+    private:
+
+        std::set<FT_Face **> cleanupFT_FaceItems;
+};
+
+#endif  //  __FTCleanup__
+

--- a/thirdparty/ftgl/FTContour.cpp
+++ b/thirdparty/ftgl/FTContour.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -110,6 +110,13 @@ void FTContour::evaluateCubicCurve(FTPoint A, FTPoint B, FTPoint C, FTPoint D)
 //
 FTPoint FTContour::ComputeOutsetPoint(FTPoint A, FTPoint B, FTPoint C)
 {
+    // If the angle between 'ab' and 'bc' approaches 180 degrees,
+    // the outset point goes to infinity, giving an invalid result.
+    // Even for angles near 180 degrees, the point will be quite
+    // far away from A, B and C. To avoid ugly results, limit
+    // its distance to 64.0 * OutsetMax.
+    static const FTGL_DOUBLE OutsetMax = 5;
+
     /* Build the rotation matrix from 'ba' vector */
     FTPoint ba = (A - B).Normalise();
     FTPoint bc = C - B;
@@ -120,7 +127,11 @@ FTPoint FTContour::ComputeOutsetPoint(FTPoint A, FTPoint B, FTPoint C)
 
     /* Compute the vector bisecting 'abc' */
     FTGL_DOUBLE norm = sqrt(tmp.X() * tmp.X() + tmp.Y() * tmp.Y());
-    FTGL_DOUBLE dist = 64.0 * sqrt((norm - tmp.X()) / (norm + tmp.X()));
+    FTGL_DOUBLE dist;
+    if (norm - tmp.X() > (norm + tmp.X()) * OutsetMax * OutsetMax)
+      dist = 64.0 * OutsetMax;
+    else
+      dist = 64.0 * sqrt((norm - tmp.X()) / (norm + tmp.X()));
     tmp.X(tmp.Y() < 0.0 ? dist : -dist);
     tmp.Y(64.0);
 
@@ -239,7 +250,6 @@ void FTContour::buildFrontOutset(float outset)
 
 void FTContour::buildBackOutset(float outset)
 {
-
     backPointList.clear();
 
     for(size_t i = 0; i < PointCount(); ++i)

--- a/thirdparty/ftgl/FTContour.h
+++ b/thirdparty/ftgl/FTContour.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFace.cpp
+++ b/thirdparty/ftgl/FTFace.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -27,6 +27,7 @@
 #include "config.h"
 
 #include "FTFace.h"
+#include "FTCleanup.h"
 #include "FTLibrary.h"
 
 #include FT_TRUETYPE_TABLES_H
@@ -48,6 +49,8 @@ FTFace::FTFace(const char* fontFilePath, bool precomputeKerning)
         ftFace = 0;
         return;
     }
+
+    FTCleanup::Instance()->RegisterObject(&ftFace);
 
     numGlyphs = (*ftFace)->num_glyphs;
     hasKerningTable = (FT_HAS_KERNING((*ftFace)) != 0);
@@ -79,6 +82,8 @@ FTFace::FTFace(const unsigned char *pBufferBytes, size_t bufferSizeInBytes,
         return;
     }
 
+    FTCleanup::Instance()->RegisterObject(&ftFace);
+
     numGlyphs = (*ftFace)->num_glyphs;
     hasKerningTable = (FT_HAS_KERNING((*ftFace)) != 0);
 
@@ -91,13 +96,12 @@ FTFace::FTFace(const unsigned char *pBufferBytes, size_t bufferSizeInBytes,
 
 FTFace::~FTFace()
 {
-    if(kerningCache)
-    {
-        delete[] kerningCache;
-    }
+    delete[] kerningCache;
 
     if(ftFace)
     {
+        FTCleanup::Instance()->UnregisterObject(&ftFace);
+
         FT_Done_Face(*ftFace);
         delete ftFace;
         ftFace = 0;
@@ -158,11 +162,11 @@ FT_Encoding* FTFace::CharMapList()
 
 FTPoint FTFace::KernAdvance(unsigned int index1, unsigned int index2)
 {
-    float x, y;
+    FTGL_DOUBLE x, y;
 
     if(!hasKerningTable || !index1 || !index2)
     {
-        return FTPoint(0.0f, 0.0f);
+        return FTPoint(0.0, 0.0);
     }
 
     if(kerningCache && index1 < FTFace::MAX_PRECOMPUTED
@@ -207,8 +211,8 @@ void FTFace::BuildKerningCache()
     FT_Vector kernAdvance;
     kernAdvance.x = 0;
     kernAdvance.y = 0;
-    kerningCache = new float[FTFace::MAX_PRECOMPUTED
-                              * FTFace::MAX_PRECOMPUTED * 2];
+    kerningCache = new FTGL_DOUBLE[FTFace::MAX_PRECOMPUTED
+                                    * FTFace::MAX_PRECOMPUTED * 2];
     for(unsigned int j = 0; j < FTFace::MAX_PRECOMPUTED; j++)
     {
         for(unsigned int i = 0; i < FTFace::MAX_PRECOMPUTED; i++)
@@ -223,9 +227,9 @@ void FTFace::BuildKerningCache()
             }
 
             kerningCache[2 * (j * FTFace::MAX_PRECOMPUTED + i)] =
-                                static_cast<float>(kernAdvance.x) / 64.0f;
+                                static_cast<FTGL_DOUBLE>(kernAdvance.x) / 64.0;
             kerningCache[2 * (j * FTFace::MAX_PRECOMPUTED + i) + 1] =
-                                static_cast<float>(kernAdvance.y) / 64.0f;
+                                static_cast<FTGL_DOUBLE>(kernAdvance.y) / 64.0;
         }
     }
 }

--- a/thirdparty/ftgl/FTFace.h
+++ b/thirdparty/ftgl/FTFace.h
@@ -169,7 +169,7 @@ class FTFace
          */
         void BuildKerningCache();
         static const unsigned int MAX_PRECOMPUTED = 128;
-        float *kerningCache;
+        FTGL_DOUBLE* kerningCache;
 
         /**
          * Current error code. Zero means no error.

--- a/thirdparty/ftgl/FTFont/FTBitmapFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTBitmapFont.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -68,22 +68,16 @@ inline FTPoint FTBitmapFontImpl::RenderI(const T* string, const int len,
                                          FTPoint position, FTPoint spacing,
                                          int renderMode)
 {
-    // Protect GL_BLEND
-    glPushAttrib(GL_COLOR_BUFFER_BIT);
-
     // Protect glPixelStorei() calls (also in FTBitmapGlyphImpl::RenderImpl)
     glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
 
     glPixelStorei(GL_UNPACK_LSB_FIRST, GL_FALSE);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-    glDisable(GL_BLEND);
-
     FTPoint tmp = FTFontImpl::Render(string, len,
                                      position, spacing, renderMode);
 
     glPopClientAttrib();
-    glPopAttrib();
 
     return tmp;
 }

--- a/thirdparty/ftgl/FTFont/FTBufferFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTBufferFont.cpp
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -230,15 +230,14 @@ inline FTPoint FTBufferFontImpl::RenderI(const T* string, const int len,
     int cacheIndex = -1;
     bool inCache = false;
 
-    // Protect blending functions, GL_BLEND and GL_TEXTURE_2D
-    glPushAttrib(GL_COLOR_BUFFER_BIT | GL_ENABLE_BIT);
+    // Protect blending functions and GL_TEXTURE_2D
+    glPushAttrib(GL_COLOR_BUFFER_BIT | GL_ENABLE_BIT | GL_TEXTURE_ENV_MODE);
 
     // Protect glPixelStorei() calls
     glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
 
-    glEnable(GL_BLEND);
     glEnable(GL_TEXTURE_2D);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // GL_ONE
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 
     // Search whether the string is already in a texture we uploaded
     for(int n = 0; n < BUFFER_CACHE_SIZE; n++)
@@ -306,23 +305,23 @@ inline FTPoint FTBufferFontImpl::RenderI(const T* string, const int len,
         buffer->Size(0, 0);
     }
 
-    FTPoint low = position + bbox.Lower();
-    FTPoint up = position + bbox.Upper();
+    FTPoint low = position + bbox.Lower() - FTPoint(padding, padding);
+    FTPoint up = position + bbox.Upper() + FTPoint(padding, padding);
 
     glBegin(GL_QUADS);
         glNormal3f(0.0f, 0.0f, 1.0f);
-        glTexCoord2f(padding / texWidth,
-                     (texHeight - height + padding) / texHeight);
-        glVertex2f(low.Xf(), up.Yf());
-        glTexCoord2f(padding / texWidth,
-                     (texHeight - padding) / texHeight);
-        glVertex2f(low.Xf(), low.Yf());
-        glTexCoord2f((width - padding) / texWidth,
-                     (texHeight - padding) / texHeight);
-        glVertex2f(up.Xf(), low.Yf());
-        glTexCoord2f((width - padding) / texWidth,
-                     (texHeight - height + padding) / texHeight);
-        glVertex2f(up.Xf(), up.Yf());
+        glTexCoord2f(0.0f,
+                     1.0f / texHeight * (texHeight - height));
+        glVertex3f(low.Xf(), up.Yf(), position.Zf());
+        glTexCoord2f(0.0f,
+                     1.0f);
+        glVertex3f(low.Xf(), low.Yf(), position.Zf());
+        glTexCoord2f(1.0f / texWidth * width,
+                     1.0f);
+        glVertex3f(up.Xf(), low.Yf(), position.Zf());
+        glTexCoord2f(1.0f / texWidth * width,
+                     1.0f / texHeight * (texHeight - height));
+        glVertex3f(up.Xf(), up.Yf(), position.Zf());
     glEnd();
 
     glPopClientAttrib();

--- a/thirdparty/ftgl/FTFont/FTBufferFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTBufferFontImpl.h
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTExtrudeFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTExtrudeFont.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTExtrudeFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTExtrudeFontImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTFont.cpp
@@ -2,7 +2,8 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
+ * Copyright (c) 2008 Daniel Remenak <dtremenak@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -41,7 +42,6 @@
 #include "FTGlyphContainer.h"
 #include "FTFace.h"
 
-#include <iostream>
 
 //
 //  FTFont
@@ -307,21 +307,21 @@ unsigned int FTFontImpl::FaceSize() const
 }
 
 
-void FTFontImpl::Depth(float)
+void FTFontImpl::Depth(float depth)
 {
-    ;
+    (void)depth;
 }
 
 
-void FTFontImpl::Outset(float)
+void FTFontImpl::Outset(float outset)
 {
-    ;
+    (void)outset;
 }
 
 
-void FTFontImpl::Outset(float, float)
+void FTFontImpl::Outset(float front, float back)
 {
-    ;
+    (void)front; (void)back;
 }
 
 
@@ -466,7 +466,8 @@ inline float FTFontImpl::AdvanceI(const T* string, const int len,
 float FTFontImpl::Advance(const char* string, const int len, FTPoint spacing)
 {
     /* The chars need to be unsigned because they are cast to int later */
-    return AdvanceI((const unsigned char *)string, len, spacing);
+    const unsigned char *ustring = (const unsigned char *)string;
+    return AdvanceI(ustring, len, spacing);
 }
 
 

--- a/thirdparty/ftgl/FTFont/FTFontGlue.cpp
+++ b/thirdparty/ftgl/FTFont/FTFontGlue.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -51,31 +51,45 @@ FTGL_BEGIN_C_DECLS
 
 // FTBitmapFont::FTBitmapFont();
 C_TOR(ftglCreateBitmapFont, (const char *fontname),
-      FTBitmapFont, (fontname), FONT_BITMAP)
+      FTBitmapFont, (fontname), FONT_BITMAP);
+C_TOR(ftglCreateBitmapFontFromMem, (const unsigned char *bytes, size_t len),
+      FTBitmapFont, (bytes, len), FONT_BITMAP);
 
 // FTBufferFont::FTBufferFont();
 C_TOR(ftglCreateBufferFont, (const char *fontname),
-      FTBufferFont, (fontname), FONT_BUFFER)
+      FTBufferFont, (fontname), FONT_BUFFER);
+C_TOR(ftglCreateBufferFontFromMem, (const unsigned char *bytes, size_t len),
+      FTBufferFont, (bytes, len), FONT_BUFFER);
 
 // FTExtrudeFont::FTExtrudeFont();
 C_TOR(ftglCreateExtrudeFont, (const char *fontname),
-      FTExtrudeFont, (fontname), FONT_EXTRUDE)
+      FTExtrudeFont, (fontname), FONT_EXTRUDE);
+C_TOR(ftglCreateExtrudeFontFromMem, (const unsigned char *bytes, size_t len),
+      FTExtrudeFont, (bytes, len), FONT_EXTRUDE);
 
 // FTOutlineFont::FTOutlineFont();
 C_TOR(ftglCreateOutlineFont, (const char *fontname),
-      FTOutlineFont, (fontname), FONT_OUTLINE)
+      FTOutlineFont, (fontname), FONT_OUTLINE);
+C_TOR(ftglCreateOutlineFontFromMem, (const unsigned char *bytes, size_t len),
+      FTOutlineFont, (bytes, len), FONT_OUTLINE);
 
 // FTPixmapFont::FTPixmapFont();
 C_TOR(ftglCreatePixmapFont, (const char *fontname),
-      FTPixmapFont, (fontname), FONT_PIXMAP)
+      FTPixmapFont, (fontname), FONT_PIXMAP);
+C_TOR(ftglCreatePixmapFontFromMem, (const unsigned char *bytes, size_t len),
+      FTPixmapFont, (bytes, len), FONT_PIXMAP);
 
 // FTPolygonFont::FTPolygonFont();
 C_TOR(ftglCreatePolygonFont, (const char *fontname),
-      FTPolygonFont, (fontname), FONT_POLYGON)
+      FTPolygonFont, (fontname), FONT_POLYGON);
+C_TOR(ftglCreatePolygonFontFromMem, (const unsigned char *bytes, size_t len),
+      FTPolygonFont, (bytes, len), FONT_POLYGON);
 
 // FTTextureFont::FTTextureFont();
 C_TOR(ftglCreateTextureFont, (const char *fontname),
-      FTTextureFont, (fontname), FONT_TEXTURE)
+      FTTextureFont, (fontname), FONT_TEXTURE);
+C_TOR(ftglCreateTextureFontFromMem, (const unsigned char *bytes, size_t len),
+      FTTextureFont, (bytes, len), FONT_TEXTURE);
 
 // FTCustomFont::FTCustomFont();
 class FTCustomFont : public FTFont
@@ -84,6 +98,13 @@ public:
     FTCustomFont(char const *fontFilePath, void *p,
                  FTGLglyph * (*makeglyph) (FT_GlyphSlot, void *))
      : FTFont(fontFilePath),
+       data(p),
+       makeglyphCallback(makeglyph)
+    {}
+
+    FTCustomFont(const unsigned char *pBufferBytes, size_t bufferSizeInBytes,
+                 void *p, FTGLglyph * (*makeglyph) (FT_GlyphSlot, void *))
+     : FTFont(pBufferBytes, bufferSizeInBytes),
        data(p),
        makeglyphCallback(makeglyph)
     {}
@@ -109,7 +130,10 @@ private:
 
 C_TOR(ftglCreateCustomFont, (char const *fontFilePath, void *data,
                    FTGLglyph * (*makeglyphCallback) (FT_GlyphSlot, void *)),
-      FTCustomFont, (fontFilePath, data, makeglyphCallback), FONT_CUSTOM)
+      FTCustomFont, (fontFilePath, data, makeglyphCallback), FONT_CUSTOM);
+C_TOR(ftglCreateCustomFontFromMem, (const unsigned char *bytes, size_t len,
+          void *data, FTGLglyph * (*makeglyphCallback) (FT_GlyphSlot, void *)),
+      FTCustomFont, (bytes, len, data, makeglyphCallback), FONT_CUSTOM);
 
 #define C_FUN(cret, cname, cargs, cxxerr, cxxname, cxxarg) \
     cret cname cargs \
@@ -127,7 +151,7 @@ void ftglDestroyFont(FTGLfont *f)
 {
     if(!f || !f->ptr)
     {
-        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNCTION__);
+        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNC__);
         return;
     }
     delete f->ptr;
@@ -136,64 +160,64 @@ void ftglDestroyFont(FTGLfont *f)
 
 // bool FTFont::Attach(const char* fontFilePath);
 C_FUN(int, ftglAttachFile, (FTGLfont *f, const char* path),
-      return 0, Attach, (path))
+      return 0, Attach, (path));
 
-// bool FTFont::Attach(const unsigned char *pBufferBytes
+// bool FTFont::Attach(const unsigned char *pBufferBytes,
 //                     size_t bufferSizeInBytes);
 C_FUN(int, ftglAttachData, (FTGLfont *f, const unsigned char *p, size_t s),
-      return 0, Attach, (p, s))
+      return 0, Attach, (p, s));
 
 // void FTFont::GlyphLoadFlags(FT_Int flags);
 C_FUN(void, ftglSetFontGlyphLoadFlags, (FTGLfont *f, FT_Int flags),
-      return, GlyphLoadFlags, (flags))
+      return, GlyphLoadFlags, (flags));
 
 // bool FTFont::CharMap(FT_Encoding encoding);
 C_FUN(int, ftglSetFontCharMap, (FTGLfont *f, FT_Encoding enc),
-      return 0, CharMap, (enc))
+      return 0, CharMap, (enc));
 
 // unsigned int FTFont::CharMapCount();
 C_FUN(unsigned int, ftglGetFontCharMapCount, (FTGLfont *f),
-      return 0, CharMapCount, ())
+      return 0, CharMapCount, ());
 
 // FT_Encoding* FTFont::CharMapList();
 C_FUN(FT_Encoding *, ftglGetFontCharMapList, (FTGLfont* f),
-      return NULL, CharMapList, ())
+      return NULL, CharMapList, ());
 
 // virtual bool FTFont::FaceSize(const unsigned int size,
 //                               const unsigned int res = 72);
 C_FUN(int, ftglSetFontFaceSize, (FTGLfont *f, unsigned int s, unsigned int r),
-      return 0, FaceSize, (s, r > 0 ? r : 72))
+      return 0, FaceSize, (s, r > 0 ? r : 72));
 
 // unsigned int FTFont::FaceSize() const;
 // XXX: need to call FaceSize() as FTFont::FaceSize() because of FTGLTexture
 C_FUN(unsigned int, ftglGetFontFaceSize, (FTGLfont *f),
-      return 0, FTFont::FaceSize, ())
+      return 0, FTFont::FaceSize, ());
 
 // virtual void FTFont::Depth(float depth);
-C_FUN(void, ftglSetFontDepth, (FTGLfont *f, float d), return, Depth, (d))
+C_FUN(void, ftglSetFontDepth, (FTGLfont *f, float d), return, Depth, (d));
 
 // virtual void FTFont::Outset(float front, float back);
 C_FUN(void, ftglSetFontOutset, (FTGLfont *f, float front, float back),
-      return, FTFont::Outset, (front, back))
+      return, FTFont::Outset, (front, back));
 
 // void FTFont::UseDisplayList(bool useList);
 C_FUN(void, ftglSetFontDisplayList, (FTGLfont *f, int l),
-      return, UseDisplayList, (l != 0))
+      return, UseDisplayList, (l != 0));
 
 // float FTFont::Ascender() const;
-C_FUN(float, ftglGetFontAscender, (FTGLfont *f), return 0.f, Ascender, ())
+C_FUN(float, ftglGetFontAscender, (FTGLfont *f), return 0.f, Ascender, ());
 
 // float FTFont::Descender() const;
-C_FUN(float, ftglGetFontDescender, (FTGLfont *f), return 0.f, Descender, ())
+C_FUN(float, ftglGetFontDescender, (FTGLfont *f), return 0.f, Descender, ());
 
 // float FTFont::LineHeight() const;
-C_FUN(float, ftglGetFontLineHeight, (FTGLfont *f), return 0.f, LineHeight, ())
+C_FUN(float, ftglGetFontLineHeight, (FTGLfont *f), return 0.f, LineHeight, ());
 
 // void FTFont::BBox(const char* string, float& llx, float& lly, float& llz,
 //                   float& urx, float& ury, float& urz);
 extern "C++" {
 C_FUN(static FTBBox, _ftglGetFontBBox, (FTGLfont *f, char const *s, int len),
-      return static_ftbbox, BBox, (s, len))
+      return static_ftbbox, BBox, (s, len));
 }
 
 void ftglGetFontBBox(FTGLfont *f, const char* s, int len, float c[6])
@@ -206,13 +230,13 @@ void ftglGetFontBBox(FTGLfont *f, const char* s, int len, float c[6])
 
 // float FTFont::Advance(const char* string);
 C_FUN(float, ftglGetFontAdvance, (FTGLfont *f, char const *s),
-      return 0.0, Advance, (s))
+      return 0.0, Advance, (s));
 
 // virtual void Render(const char* string, int renderMode);
 extern "C++" {
 C_FUN(static FTPoint, _ftglRenderFont, (FTGLfont *f, char const *s, int len,
                                         FTPoint pos, FTPoint spacing, int mode),
-      return static_ftpoint, Render, (s, len, pos, spacing, mode))
+      return static_ftpoint, Render, (s, len, pos, spacing, mode));
 }
 
 void ftglRenderFont(FTGLfont *f, const char *s, int mode)
@@ -221,7 +245,7 @@ void ftglRenderFont(FTGLfont *f, const char *s, int mode)
 }
 
 // FT_Error FTFont::Error() const;
-C_FUN(FT_Error, ftglGetFontError, (FTGLfont *f), return -1, Error, ())
+C_FUN(FT_Error, ftglGetFontError, (FTGLfont *f), return -1, Error, ());
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTFont/FTFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTFontImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTOutlineFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTOutlineFontImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTPixmapFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTPixmapFont.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -84,15 +84,15 @@ inline FTPoint FTPixmapFontImpl::RenderI(const T* string, const int len,
                                          FTPoint position, FTPoint spacing,
                                          int renderMode)
 {
-    // Protect GL_TEXTURE_2D and GL_BLEND, glPixelTransferf(), and blending
-    // functions.
-    glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_COLOR_BUFFER_BIT);
+    // Protect GL_TEXTURE_2D and glPixelTransferf()
+    glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_COLOR_BUFFER_BIT
+                  | GL_POLYGON_BIT);
 
     // Protect glPixelStorei() calls (made by FTPixmapGlyphImpl::RenderImpl).
     glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
 
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    // Needed on OSX
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     glDisable(GL_TEXTURE_2D);
 

--- a/thirdparty/ftgl/FTFont/FTPixmapFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTPixmapFontImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTPolygonFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTPolygonFont.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008-2010 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -85,5 +85,42 @@ FTPolygonFontImpl::FTPolygonFontImpl(FTFont *ftFont,
   outset(0.0f)
 {
     load_flags = FT_LOAD_NO_HINTING;
+}
+
+
+template <typename T>
+inline FTPoint FTPolygonFontImpl::RenderI(const T* string, const int len,
+                                          FTPoint position, FTPoint spacing,
+                                          int renderMode)
+{
+    // Protect GL_POLYGON
+    glPushAttrib(GL_POLYGON_BIT);
+
+    // Activate front and back face filling. If the caller wants only
+    // front face, it can set proper culling.
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    FTPoint tmp = FTFontImpl::Render(string, len,
+                                     position, spacing, renderMode);
+
+    glPopAttrib();
+
+    return tmp;
+}
+
+
+FTPoint FTPolygonFontImpl::Render(const char * string, const int len,
+                                  FTPoint position, FTPoint spacing,
+                                  int renderMode)
+{
+    return RenderI(string, len, position, spacing, renderMode);
+}
+
+
+FTPoint FTPolygonFontImpl::Render(const wchar_t * string, const int len,
+                                  FTPoint position, FTPoint spacing,
+                                  int renderMode)
+{
+    return RenderI(string, len, position, spacing, renderMode);
 }
 

--- a/thirdparty/ftgl/FTFont/FTPolygonFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTPolygonFontImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008-2010 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -28,6 +28,8 @@
 #define __FTPolygonFontImpl__
 
 #include "FTFontImpl.h"
+// std lib
+#include <vector>
 
 class FTGlyph;
 
@@ -45,16 +47,30 @@ class FTPolygonFontImpl : public FTFontImpl
          * Set the outset distance for the font. Only implemented by
          * FTOutlineFont, FTPolygonFont and FTExtrudeFont
          *
-         * @param depth  The outset distance.
+         * @param outset  The outset distance.
          */
         virtual void Outset(float o) { outset = o; }
 
+        virtual FTPoint Render(const char *s, const int len,
+                               FTPoint position, FTPoint spacing,
+                               int renderMode);
+
+        virtual FTPoint Render(const wchar_t *s, const int len,
+                               FTPoint position, FTPoint spacing,
+                               int renderMode);
+
+
     private:
         /**
-         * The outset distance (front and back) for the font.
+         * The outset distance for the font.
          */
         float outset;
+
+        /* Internal generic Render() implementation */
+        template <typename T>
+        inline FTPoint RenderI(const T *s, const int len,
+                               FTPoint position, FTPoint spacing, int mode);
 };
 
-#endif  //  __FTPolygonFontImpl__
+#endif // __FTPolygonFontImpl__
 

--- a/thirdparty/ftgl/FTFont/FTTextureFont.cpp
+++ b/thirdparty/ftgl/FTFont/FTTextureFont.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -74,17 +74,19 @@ FTGlyph* FTTextureFont::MakeGlyph(FT_GlyphSlot ftGlyph)
 //
 
 
-static inline GLuint NextPowerOf2(GLuint in)
+static inline GLuint ClampSize(GLuint in, GLuint maxTextureSize)
 {
-     in -= 1;
+    // Find next power of two
+    --in;
+    in |= in >> 16;
+    in |= in >> 8;
+    in |= in >> 4;
+    in |= in >> 2;
+    in |= in >> 1;
+    ++in;
 
-     in |= in >> 16;
-     in |= in >> 8;
-     in |= in >> 4;
-     in |= in >> 2;
-     in |= in >> 1;
-
-     return in + 1;
+    // Clamp to max texture size
+    return in < maxTextureSize ? in : maxTextureSize;
 }
 
 
@@ -134,8 +136,8 @@ FTTextureFontImpl::~FTTextureFontImpl()
 
 FTGlyph* FTTextureFontImpl::MakeGlyphImpl(FT_GlyphSlot ftGlyph)
 {
-    glyphHeight = static_cast<int>(charSize.Height() + 0.5);
-    glyphWidth = static_cast<int>(charSize.Width() + 0.5);
+    glyphHeight = static_cast<int>(charSize.Height() + 0.5f);
+    glyphWidth = static_cast<int>(charSize.Width() + 0.5f);
 
     if(glyphHeight < 1) glyphHeight = 1;
     if(glyphWidth < 1) glyphWidth = 1;
@@ -174,16 +176,22 @@ void FTTextureFontImpl::CalculateTextureSize()
     {
         maximumGLTextureSize = 1024;
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, (GLint*)&maximumGLTextureSize);
-        assert(maximumGLTextureSize); // If you hit this then you have an invalid OpenGL context.
+        assert(maximumGLTextureSize); // Indicates an invalid OpenGL context
     }
 
-    textureWidth = NextPowerOf2((remGlyphs * glyphWidth) + (padding * 2));
-    textureWidth = textureWidth > maximumGLTextureSize ? maximumGLTextureSize : textureWidth;
+    // Texture width required for numGlyphs glyphs. Will probably not be
+    // large enough, but we try to fit as many glyphs in one line as possible
+    textureWidth = ClampSize(glyphWidth * numGlyphs + padding * 2,
+                             maximumGLTextureSize);
 
-    int h = static_cast<int>((textureWidth - (padding * 2)) / glyphWidth + 0.5);
+    // Number of lines required for that many glyphs in a line
+    int tmp = (textureWidth - (padding * 2)) / glyphWidth;
+    tmp = tmp > 0 ? tmp : 1;
+    tmp = (numGlyphs + (tmp - 1)) / tmp; // round division up
 
-    textureHeight = NextPowerOf2(((numGlyphs / h) + 1) * glyphHeight);
-    textureHeight = textureHeight > maximumGLTextureSize ? maximumGLTextureSize : textureHeight;
+    // Texture height required for tmp lines of glyphs
+    textureHeight = ClampSize(glyphHeight * tmp + padding * 2,
+                              maximumGLTextureSize);
 }
 
 
@@ -231,13 +239,11 @@ inline FTPoint FTTextureFontImpl::RenderI(const T* string, const int len,
                                           FTPoint position, FTPoint spacing,
                                           int renderMode)
 {
-    // Protect GL_TEXTURE_2D, GL_BLEND and blending functions
-    glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
-
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // GL_ONE
+    // Protect GL_TEXTURE_2D
+    glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_TEXTURE_ENV_MODE);
 
     glEnable(GL_TEXTURE_2D);
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 
     FTTextureGlyphImpl::ResetActiveTexture();
 

--- a/thirdparty/ftgl/FTFont/FTTextureFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTTextureFontImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTFont/FTTriangleExtractorFontImpl.h
+++ b/thirdparty/ftgl/FTFont/FTTriangleExtractorFontImpl.h
@@ -1,8 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
+ * Copyright (c) 2011 Richard Ulrich <richi@paraeasy.ch>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -24,24 +23,32 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __FTBitmapFontImpl__
-#define __FTBitmapFontImpl__
+#ifndef __FTTriangleExtractorFontImpl__
+#define __FTTriangleExtractorFontImpl__
 
 #include "FTFontImpl.h"
+// std lib
+#include <vector>
 
 class FTGlyph;
 
-class FTBitmapFontImpl : public FTFontImpl
+class FTTriangleExtractorFontImpl : public FTFontImpl
 {
-    friend class FTBitmapFont;
+    friend class FTTriangleExtractorFont;
 
     protected:
-        FTBitmapFontImpl(FTFont *ftFont, const char* fontFilePath) :
-            FTFontImpl(ftFont, fontFilePath) {};
+        FTTriangleExtractorFontImpl(FTFont *ftFont, const char* fontFilePath, std::vector<float>& triangles);
 
-        FTBitmapFontImpl(FTFont *ftFont, const unsigned char *pBufferBytes,
-                         size_t bufferSizeInBytes) :
-            FTFontImpl(ftFont, pBufferBytes, bufferSizeInBytes) {};
+        FTTriangleExtractorFontImpl(FTFont *ftFont, const unsigned char *pBufferBytes,
+                          size_t bufferSizeInBytes, std::vector<float>& triangles);
+
+        /**
+         * Set the outset distance for the font. Only implemented by
+         * FTOutlineFont, FTPolygonFont and FTExtrudeFont
+         *
+         * @param outset  The outset distance.
+         */
+        virtual void Outset(float o) { outset = o; }
 
         virtual FTPoint Render(const char *s, const int len,
                                FTPoint position, FTPoint spacing,
@@ -51,12 +58,20 @@ class FTBitmapFontImpl : public FTFontImpl
                                FTPoint position, FTPoint spacing,
                                int renderMode);
 
+
     private:
+        /**
+         * The outset distance for the font.
+         */
+        float outset;
+
+        std::vector<float>& triangles_;
+
         /* Internal generic Render() implementation */
         template <typename T>
         inline FTPoint RenderI(const T *s, const int len,
                                FTPoint position, FTPoint spacing, int mode);
 };
 
-#endif  //  __FTBitmapFontImpl__
+#endif // __FTPolygonFontImpl__
 

--- a/thirdparty/ftgl/FTGL.cpp
+++ b/thirdparty/ftgl/FTGL.cpp
@@ -1,8 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
+ * Copyright (c) 2008-2010 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -24,44 +23,31 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __FTPixmapGlyphImpl__
-#define __FTPixmapGlyphImpl__
+#include "config.h"
 
-#include "FTGlyphImpl.h"
+#include "FTInternals.h"
 
-class FTPixmapGlyphImpl : public FTGlyphImpl
+namespace FTGL {
+
+char const *GetString(ConfigString config)
 {
-    friend class FTPixmapGlyph;
+    switch(config)
+    {
+    case CONFIG_VERSION:
+        return PACKAGE_VERSION;
+    }
 
-    protected:
-        FTPixmapGlyphImpl(FT_GlyphSlot glyph);
+    return 0;
+}
 
-        virtual ~FTPixmapGlyphImpl();
+} // namespace FTGL
 
-        virtual const FTPoint& RenderImpl(const FTPoint& pen, int renderMode);
+FTGL_BEGIN_C_DECLS
 
-    private:
-        /**
-         * The width of the glyph 'image'
-         */
-        int destWidth;
+char const *ftglGetString(int config)
+{
+    return FTGL::GetString(static_cast<FTGL::ConfigString>(config));
+}
 
-        /**
-         * The height of the glyph 'image'
-         */
-        int destHeight;
-
-        /**
-         * Vector from the pen position to the topleft corner of the pixmap
-         */
-        FTPoint pos;
-
-        /**
-         * Pointer to the 'image' data
-         */
-        unsigned char* data;
-
-};
-
-#endif  //  __FTPixmapGlyphImpl__
+FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGL/FTBBox.h
+++ b/thirdparty/ftgl/FTGL/FTBBox.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/thirdparty/ftgl/FTGL/FTBitmapGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTBitmapGlyph.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/thirdparty/ftgl/FTGL/FTBuffer.h
+++ b/thirdparty/ftgl/FTGL/FTBuffer.h
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGL/FTBufferFont.h
+++ b/thirdparty/ftgl/FTGL/FTBufferFont.h
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGL/FTBufferGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTBufferGlyph.h
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGL/FTExtrdGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTExtrdGlyph.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/thirdparty/ftgl/FTGL/FTFont.h
+++ b/thirdparty/ftgl/FTGL/FTFont.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -82,6 +82,7 @@ class FTGL_EXPORT FTFont
         friend class FTPixmapFont;
         friend class FTPolygonFont;
         friend class FTTextureFont;
+        friend class FTTriangleExtractorFont;
 
         /**
          * Internal FTGL FTFont constructor. For private use only.
@@ -330,6 +331,13 @@ class FTGL_EXPORT FTFont
          * @param spacing  A displacement vector to add after each character
          *                 has been displayed (optional).
          * @param renderMode  Render mode to use for display (optional).
+         *                    Gives the application the ability to
+         *                    control whether to render the font's
+         *                    front and back faces via
+         *                    FTGL::RENDER_FRONT and FTGL::RENDER_BACK
+         *                    respectively, or font sides via
+         *                    FTGL::RENDER_SIDE for extruded glyph
+         *                    fonts.
          * @return  The new pen position after the last character was output.
          */
         virtual FTPoint Render(const char* string, const int len = -1,
@@ -348,6 +356,13 @@ class FTGL_EXPORT FTFont
          * @param spacing  A displacement vector to add after each character
          *                 has been displayed (optional).
          * @param renderMode  Render mode to use for display (optional).
+         *                    Gives the application the ability to
+         *                    control whether to render the font's
+         *                    front and back faces via
+         *                    FTGL::RENDER_FRONT and FTGL::RENDER_BACK
+         *                    respectively, or font sides via
+         *                    FTGL::RENDER_SIDE for extruded glyph
+         *                    fonts.
          * @return  The new pen position after the last character was output.
          */
         virtual FTPoint Render(const wchar_t *string, const int len = -1,
@@ -411,6 +426,19 @@ FTGL_EXPORT FTGLfont *ftglCreateCustomFont(char const *fontFilePath,
                    FTGLglyph * (*makeglyphCallback) (FT_GlyphSlot, void *));
 
 /**
+ * Create a custom FTGL font object from a buffer in memory.
+ *
+ * @param bytes  the in-memory buffer
+ * @param len  the length of the buffer in bytes
+ * @param data  A pointer to private data that will be passed to callbacks.
+ * @param makeglyphCallback  A glyph-making callback function.
+ * @return  An FTGLfont* object.
+ */
+FTGL_EXPORT FTGLfont *ftglCreateCustomFontFromMem(const unsigned char *bytes,
+                                                  size_t len, void *data,
+                   FTGLglyph * (*makeglyphCallback) (FT_GlyphSlot, void *));
+
+/**
  * Destroy an FTGL font object.
  *
  * @param font  An FTGLfont* object.
@@ -440,6 +468,16 @@ FTGL_EXPORT int ftglAttachFile(FTGLfont* font, const char* path);
  */
 FTGL_EXPORT int ftglAttachData(FTGLfont* font, const unsigned char * data,
                                size_t size);
+
+/**
+ * Set the glyph loading flags. By default, fonts use the most
+ * sensible flags when loading a font's glyph using FT_Load_Glyph().
+ * This function allows to override the default flags.
+ *
+ * @param font  An FTGLfont* object.
+ * @param flags  The glyph loading flags.
+ */
+FTGL_EXPORT void ftglSetFontGlyphLoadFlags(FTGLfont* font, FT_Int flags);
 
 /**
  * Set the character map for the face.

--- a/thirdparty/ftgl/FTGL/FTGLBitmapFont.h
+++ b/thirdparty/ftgl/FTGL/FTGLBitmapFont.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -96,6 +96,18 @@ FTGL_BEGIN_C_DECLS
  * @see  FTGLfont
  */
 FTGL_EXPORT FTGLfont *ftglCreateBitmapFont(const char *file);
+
+/**
+ * Create a specialised FTGLfont object for handling bitmap fonts from
+ * a buffer in memory. Sets Error flag. The buffer is owned by the client
+ * and is NOT copied by FTGL. The pointer must be valid while using FTGL.
+ *
+ * @param bytes  the in-memory buffer
+ * @param len  the length of the buffer in bytes
+ * @return  An FTGLfont* object.
+ */
+FTGL_EXPORT FTGLfont *ftglCreateBitmapFontFromMem(const unsigned char *bytes,
+                                                  size_t len);
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGL/FTGLOutlineFont.h
+++ b/thirdparty/ftgl/FTGL/FTGLOutlineFont.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -96,6 +96,18 @@ FTGL_BEGIN_C_DECLS
  * @see  FTGLfont
  */
 FTGL_EXPORT FTGLfont *ftglCreateOutlineFont(const char *file);
+
+/**
+ * Create a specialised FTGLfont object for handling vector outline fonts
+ * from a buffer in memory. Sets Error flag. The buffer is owned by the client
+ * and is NOT copied by FTGL. The pointer must be valid while using FTGL.
+ *
+ * @param bytes  the in-memory buffer
+ * @param len  the length of the buffer in bytes
+ * @return  An FTGLfont* object.
+ */
+FTGL_EXPORT FTGLfont *ftglCreateOutlineFontFromMem(const unsigned char *bytes,
+                                                   size_t len);
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGL/FTGLPixmapFont.h
+++ b/thirdparty/ftgl/FTGL/FTGLPixmapFont.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -96,6 +96,19 @@ FTGL_BEGIN_C_DECLS
  * @see  FTGLfont
  */
 FTGL_EXPORT FTGLfont *ftglCreatePixmapFont(const char *file);
+
+/**
+ * Create a specialised FTGLfont object for handling pixmap (grey scale)
+ * fonts from a buffer in memory. Sets Error flag. The buffer is owned by
+ * the client and is NOT copied by FTGL. The pointer must be valid while
+ * using FTGL.
+ *
+ * @param bytes  the in-memory buffer
+ * @param len  the length of the buffer in bytes
+ * @return  An FTGLfont* object.
+ */
+FTGL_EXPORT FTGLfont *ftglCreatePixmapFontFromMem(const unsigned char *bytes,
+                                                  size_t len);
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGL/FTGLPolygonFont.h
+++ b/thirdparty/ftgl/FTGL/FTGLPolygonFont.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -35,6 +35,7 @@
 
 #ifdef __cplusplus
 
+#include <vector>
 
 /**
  * FTPolygonFont is a specialisation of the FTFont class for handling
@@ -68,6 +69,7 @@ class FTGL_EXPORT FTPolygonFont : public FTFont
          */
         ~FTPolygonFont();
 
+
     protected:
         /**
          * Construct a glyph of the correct type.
@@ -97,6 +99,19 @@ FTGL_BEGIN_C_DECLS
  * @see  FTGLfont
  */
 FTGL_EXPORT FTGLfont *ftglCreatePolygonFont(const char *file);
+
+/**
+ * Create a specialised FTGLfont object for handling tesselated polygon
+ * mesh fonts from a buffer in memory. Sets Error flag. The buffer is owned
+ * by the client and is NOT copied by FTGL. The pointer must be valid while
+ * using FTGL.
+ *
+ * @param bytes  the in-memory buffer
+ * @param len  the length of the buffer in bytes
+ * @return  An FTGLfont* object.
+ */
+FTGL_EXPORT FTGLfont *ftglCreatePolygonFontFromMem(const unsigned char *bytes,
+                                                   size_t len);
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGL/FTGLTextureFont.h
+++ b/thirdparty/ftgl/FTGL/FTGLTextureFont.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -96,6 +96,19 @@ FTGL_BEGIN_C_DECLS
  * @see  FTGLfont
  */
 FTGL_EXPORT FTGLfont *ftglCreateTextureFont(const char *file);
+
+/**
+ * Create a specialised FTGLfont object for handling texture-mapped fonts
+ * from a buffer in memory. Sets Error flag. The buffer is owned by the
+ * client and is NOT copied by FTGL. The pointer must be valid while using
+ * FTGL.
+ *
+ * @param bytes  the in-memory buffer
+ * @param len  the length of the buffer in bytes
+ * @return  An FTGLfont* object.
+ */
+FTGL_EXPORT FTGLfont *ftglCreateTextureFontFromMem(const unsigned char *bytes,
+                                                   size_t len);
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGL/FTGLTriangleExtractorFont.h
+++ b/thirdparty/ftgl/FTGL/FTGLTriangleExtractorFont.h
@@ -1,9 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
- * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
+ * Copyright (c) 2011 Richard Ulrich <richi@paraeasy.ch>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -30,28 +28,29 @@
 #   include <FTGL/ftgl.h>
 #endif
 
-#ifndef __FTExtrudeFont__
-#define __FTExtrudeFont__
+#ifndef __FTTriangleExtractorFont__
+#define __FTTriangleExtractorFont__
 
 #ifdef __cplusplus
 
+#include <vector>
 
 /**
- * FTExtrudeFont is a specialisation of the FTFont class for handling
- * extruded Polygon fonts
+ * FTPolygonFont is a specialisation of the FTFont class for handling
+ * tesselated Polygon Mesh fonts
  *
- * @see FTFont
- * @see FTPolygonFont
+ * @see     FTFont
  */
-class FTGL_EXPORT FTExtrudeFont : public FTFont
+class FTGL_EXPORT FTTriangleExtractorFont : public FTFont
 {
     public:
         /**
          * Open and read a font file. Sets Error flag.
          *
          * @param fontFilePath  font file path.
+         * @param triangles     the container to store the triangle data.
          */
-        FTExtrudeFont(const char* fontFilePath);
+        FTTriangleExtractorFont(const char* fontFilePath, std::vector<float>& triangles);
 
         /**
          * Open and read a font from a buffer in memory. Sets Error flag.
@@ -60,14 +59,15 @@ class FTGL_EXPORT FTExtrudeFont : public FTFont
          *
          * @param pBufferBytes  the in-memory buffer
          * @param bufferSizeInBytes  the length of the buffer in bytes
+         * @param triangles     the container to store the triangle data.
          */
-        FTExtrudeFont(const unsigned char *pBufferBytes,
-                      size_t bufferSizeInBytes);
+        FTTriangleExtractorFont(const unsigned char *pBufferBytes,
+                      size_t bufferSizeInBytes, std::vector<float>& triangles);
 
         /**
          * Destructor
          */
-        ~FTExtrudeFont();
+        ~FTTriangleExtractorFont();
 
     protected:
         /**
@@ -82,36 +82,37 @@ class FTGL_EXPORT FTExtrudeFont : public FTFont
         virtual FTGlyph* MakeGlyph(FT_GlyphSlot slot);
 };
 
-#define FTGLExtrdFont FTExtrudeFont
+#define FTGLTriangleExtractorFont FTTriangleExtractorFont
 
 #endif //__cplusplus
 
 FTGL_BEGIN_C_DECLS
 
 /**
- * Create a specialised FTGLfont object for handling extruded polygon fonts.
+ * Create a specialised FTGLfont object for handling tesselated polygon
+ * mesh fonts.
  *
  * @param file  The font file name.
  * @return  An FTGLfont* object.
  *
  * @see  FTGLfont
- * @see  ftglCreatePolygonFont
  */
-FTGL_EXPORT FTGLfont *ftglCreateExtrudeFont(const char *file);
+FTGL_EXPORT FTGLfont *ftglCreateTriangleExtractorFont(const char *file);
 
 /**
- * Create a specialised FTGLfont object for handling extruded polygon fonts
- * from a buffer in memory. Sets Error flag. The buffer is owned by the client
- * and is NOT copied by FTGL. The pointer must be valid while using FTGL.
+ * Create a specialised FTGLfont object for handling tesselated polygon
+ * mesh fonts from a buffer in memory. Sets Error flag. The buffer is owned
+ * by the client and is NOT copied by FTGL. The pointer must be valid while
+ * using FTGL.
  *
  * @param bytes  the in-memory buffer
  * @param len  the length of the buffer in bytes
  * @return  An FTGLfont* object.
  */
-FTGL_EXPORT FTGLfont *ftglCreateExtrudeFontFromMem(const unsigned char *bytes,
+FTGL_EXPORT FTGLfont *ftglCreateTriangleExtractorFontFromMem(const unsigned char *bytes,
                                                    size_t len);
 
 FTGL_END_C_DECLS
 
-#endif // __FTExtrudeFont__
+#endif  //  __FTTriangleExtractorFont__
 

--- a/thirdparty/ftgl/FTGL/FTGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTGlyph.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -74,6 +74,7 @@ class FTGL_EXPORT FTGlyph
         friend class FTPixmapGlyph;
         friend class FTPolygonGlyph;
         friend class FTTextureGlyph;
+        friend class FTTriangleExtractorGlyph;
 
     public:
         /**

--- a/thirdparty/ftgl/FTGL/FTLayout.h
+++ b/thirdparty/ftgl/FTGL/FTLayout.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/thirdparty/ftgl/FTGL/FTOutlineGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTOutlineGlyph.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/thirdparty/ftgl/FTGL/FTPixmapGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTPixmapGlyph.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -41,6 +41,8 @@
  */
 class  FTGL_EXPORT FTPixmapGlyph : public FTGlyph
 {
+        static FTGlyphImpl *NewImpl(FT_GlyphSlot glyph);
+
     public:
         /**
          * Constructor

--- a/thirdparty/ftgl/FTGL/FTPoint.h
+++ b/thirdparty/ftgl/FTGL/FTPoint.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -246,20 +246,20 @@ class FTGL_EXPORT FTPoint
         /**
          * Setters
          */
-        inline void X(FTGL_DOUBLE x) { values[0] = x; }
-        inline void Y(FTGL_DOUBLE y) { values[1] = y; }
-        inline void Z(FTGL_DOUBLE z) { values[2] = z; }
+        inline void X(FTGL_DOUBLE x) { values[0] = x; };
+        inline void Y(FTGL_DOUBLE y) { values[1] = y; };
+        inline void Z(FTGL_DOUBLE z) { values[2] = z; };
 
 
         /**
          * Getters
          */
-        inline FTGL_DOUBLE X() const { return values[0]; }
-        inline FTGL_DOUBLE Y() const { return values[1]; }
-        inline FTGL_DOUBLE Z() const { return values[2]; }
-        inline FTGL_FLOAT Xf() const { return static_cast<FTGL_FLOAT>(values[0]); }
-        inline FTGL_FLOAT Yf() const { return static_cast<FTGL_FLOAT>(values[1]); }
-        inline FTGL_FLOAT Zf() const { return static_cast<FTGL_FLOAT>(values[2]); }
+        inline FTGL_DOUBLE X() const { return values[0]; };
+        inline FTGL_DOUBLE Y() const { return values[1]; };
+        inline FTGL_DOUBLE Z() const { return values[2]; };
+        inline FTGL_FLOAT Xf() const { return static_cast<FTGL_FLOAT>(values[0]); };
+        inline FTGL_FLOAT Yf() const { return static_cast<FTGL_FLOAT>(values[1]); };
+        inline FTGL_FLOAT Zf() const { return static_cast<FTGL_FLOAT>(values[2]); };
 
     private:
         /**

--- a/thirdparty/ftgl/FTGL/FTPolyGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTPolyGlyph.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/thirdparty/ftgl/FTGL/FTSimpleLayout.h
+++ b/thirdparty/ftgl/FTGL/FTSimpleLayout.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -180,7 +180,8 @@ FTGL_EXPORT void ftglSetLayoutLineLength(FTGLlayout *, const float);
 FTGL_EXPORT float ftglGetLayoutLineLength(FTGLlayout *);
 
 FTGL_EXPORT void ftglSetLayoutAlignment(FTGLlayout *, const int);
-FTGL_EXPORT int ftglGetLayoutAlignement(FTGLlayout *);
+FTGL_EXPORT int ftglGetLayoutAlignment(FTGLlayout *);
+FTGL_EXPORT int ftglGetLayoutAlignement(FTGLlayout *); // old typo
 
 FTGL_EXPORT void ftglSetLayoutLineSpacing(FTGLlayout *, const float);
 FTGL_EXPORT float ftglGetLayoutLineSpacing(FTGLlayout *);

--- a/thirdparty/ftgl/FTGL/FTTriangleExtractorGlyph.h
+++ b/thirdparty/ftgl/FTGL/FTTriangleExtractorGlyph.h
@@ -1,9 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
- * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
+ * Copyright (c) 2011 Richard Ulrich <richi@paraeasy.ch>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -30,39 +28,37 @@
 #   include <FTGL/ftgl.h>
 #endif
 
-#ifndef __FTTextureGlyph__
-#define __FTTextureGlyph__
+#ifndef __FTTriangleExtractorGlyph__
+#define __FTTriangleExtractorGlyph__
 
 #ifdef __cplusplus
 
+#include <vector>
 
 /**
- * FTTextureGlyph is a specialisation of FTGlyph for creating texture
- * glyphs.
+ * FTPolygonGlyph is a specialisation of FTGlyph for creating tessellated
+ * polygon glyphs.
  */
-class FTGL_EXPORT FTTextureGlyph : public FTGlyph
+class FTGL_EXPORT FTTriangleExtractorGlyph : public FTGlyph
 {
     public:
         /**
-         * Constructor
+         * Constructor. Sets the Error to Invalid_Outline if the glyphs
+         * isn't an outline.
          *
-         * @param glyph     The Freetype glyph to be processed
-         * @param id        The id of the texture that this glyph will be
-         *                  drawn in
-         * @param xOffset   The x offset into the parent texture to draw
-         *                  this glyph
-         * @param yOffset   The y offset into the parent texture to draw
-         *                  this glyph
-         * @param width     The width of the parent texture
-         * @param height    The height (number of rows) of the parent texture
+         * @param glyph The Freetype glyph to be processed
+         * @param outset  The outset distance
+         * @param useDisplayList Enable or disable the use of Display Lists
+         *                       for this glyph
+         *                       <code>true</code> turns ON display lists.
+         *                       <code>false</code> turns OFF display lists.
          */
-        FTTextureGlyph(FT_GlyphSlot glyph, int id, int xOffset, int yOffset,
-                       int width, int height);
+        FTTriangleExtractorGlyph(FT_GlyphSlot glyph, float outset, std::vector<float>& triangles);
 
         /**
          * Destructor
          */
-        virtual ~FTTextureGlyph();
+        virtual ~FTTriangleExtractorGlyph();
 
         /**
          * Render this glyph at the current pen position.
@@ -74,26 +70,28 @@ class FTGL_EXPORT FTTextureGlyph : public FTGlyph
         virtual const FTPoint& Render(const FTPoint& pen, int renderMode);
 };
 
+#define FTPolyGlyph FTPolygonGlyph
+
 #endif //__cplusplus
 
 FTGL_BEGIN_C_DECLS
 
 /**
- * Create a specialisation of FTGLglyph for creating pixmaps.
+ * Create a specialisation of FTGLglyph for creating tessellated
+ * polygon glyphs.
  *
- * @param glyph The Freetype glyph to be processed.
- * @param id  The id of the texture that this glyph will be drawn in.
- * @param xOffset  The x offset into the parent texture to draw this glyph.
- * @param yOffset  The y offset into the parent texture to draw this glyph.
- * @param width  The width of the parent texture.
- * @param height  The height (number of rows) of the parent texture.
+ * @param glyph The Freetype glyph to be processed
+ * @param outset outset contour size
+ * @param useDisplayList Enable or disable the use of Display Lists
+ *                       for this glyph
+ *                       <code>true</code> turns ON display lists.
+ *                       <code>false</code> turns OFF display lists.
  * @return  An FTGLglyph* object.
  */
-FTGL_EXPORT FTGLglyph *ftglCreateTextureGlyph(FT_GlyphSlot glyph, int id,
-                                              int xOffset, int yOffset,
-                                              int width, int height);
+FTGL_EXPORT FTGLglyph *ftglCreateTriangleExtractorGlyph(FT_GlyphSlot glyph, float outset,
+                                              int useDisplayList);
 
 FTGL_END_C_DECLS
 
-#endif  //  __FTTextureGlyph__
+#endif  //  __FTTriangleExtractorGlyph__
 

--- a/thirdparty/ftgl/FTGL/ftgl.h
+++ b/thirdparty/ftgl/FTGL/ftgl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  * Copyright (c) 2008 Sean Morrison <learner@brlcad.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -65,6 +65,21 @@ namespace FTGL
         ALIGN_RIGHT   = 2,
         ALIGN_JUSTIFY = 3
     } TextAlignment;
+
+    typedef enum
+    {
+        CONFIG_VERSION = 1,
+    } ConfigString;
+
+    /**
+     * Return a string describing the current %FTGL instance
+     *
+     * @param config  Name of the string to retrieve. Can be one of:
+     *                 - CONFIG_VERSION: return the %FTGL release number.
+     * @return  A pointer to a constant string containing the requested
+     *          information, or 0 in case of invalid argument.
+     */
+    extern char const *GetString(ConfigString config);
 }
 #else
 #   define FTGL_RENDER_FRONT 0x0001
@@ -76,6 +91,18 @@ namespace FTGL
 #   define FTGL_ALIGN_CENTER  1
 #   define FTGL_ALIGN_RIGHT   2
 #   define FTGL_ALIGN_JUSTIFY 3
+
+#   define FTGL_CONFIG_VERSION 1
+
+    /**
+     * Return a string describing the current %FTGL instance
+     *
+     * @param config  Name of the string to retrieve. Can be one of:
+     *                 - FTGL_CONFIG_VERSION: return the %FTGL release number.
+     * @return  A pointer to a constant string containing the requested
+     *          information, or NULL in case of invalid argument.
+     */
+    extern char const *ftglGetString(int config);
 #endif
 
 // Compiler-specific conditional compilation
@@ -119,6 +146,7 @@ namespace FTGL
 #include <FTGL/FTPixmapGlyph.h>
 #include <FTGL/FTPolyGlyph.h>
 #include <FTGL/FTTextureGlyph.h>
+#include <FTGL/FTTriangleExtractorGlyph.h>
 
 #include <FTGL/FTFont.h>
 #include <FTGL/FTGLBitmapFont.h>
@@ -128,6 +156,7 @@ namespace FTGL
 #include <FTGL/FTGLPixmapFont.h>
 #include <FTGL/FTGLPolygonFont.h>
 #include <FTGL/FTGLTextureFont.h>
+#include <FTGL/FTGLTriangleExtractorFont.h>
 
 #include <FTGL/FTLayout.h>
 #include <FTGL/FTSimpleLayout.h>

--- a/thirdparty/ftgl/FTGlyph/FTBitmapGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTBitmapGlyph.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -107,8 +107,10 @@ FTBitmapGlyphImpl::~FTBitmapGlyphImpl()
 }
 
 
-const FTPoint& FTBitmapGlyphImpl::RenderImpl(const FTPoint& pen, int)
+const FTPoint& FTBitmapGlyphImpl::RenderImpl(const FTPoint& pen, int renderMode)
 {
+    (void)renderMode;
+
     if(data)
     {
         float dx, dy;

--- a/thirdparty/ftgl/FTGlyph/FTBitmapGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTBitmapGlyphImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -32,6 +32,7 @@
 class FTBitmapGlyphImpl : public FTGlyphImpl
 {
     friend class FTBitmapGlyph;
+    friend class FTPixmapGlyph;
 
     protected:
         FTBitmapGlyphImpl(FT_GlyphSlot glyph);

--- a/thirdparty/ftgl/FTGlyph/FTBufferGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTBufferGlyph.cpp
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -88,8 +88,10 @@ FTBufferGlyphImpl::~FTBufferGlyphImpl()
 }
 
 
-const FTPoint& FTBufferGlyphImpl::RenderImpl(const FTPoint& pen, int)
+const FTPoint& FTBufferGlyphImpl::RenderImpl(const FTPoint& pen, int renderMode)
 {
+    (void)renderMode;
+
     if(has_bitmap)
     {
         FTPoint pos(buffer->Pos() + pen + corner);
@@ -102,15 +104,32 @@ const FTPoint& FTBufferGlyphImpl::RenderImpl(const FTPoint& pen, int)
             // FIXME: change the loop bounds instead of doing this test
             if(y + dy < 0 || y + dy >= buffer->Height()) continue;
 
-            for(int x = 0; x < bitmap.width; x++)
+            if(bitmap.num_grays == 1)
             {
-                if(x + dx < 0 || x + dx >= buffer->Width()) continue;
-
-                unsigned char p = pixels[y * bitmap.pitch + x];
-
-                if(p)
+                for(int x = 0; x < bitmap.width; x++)
                 {
-                    dest[y * buffer->Width() + x] = p;
+                    if(x + dx < 0 || x + dx >= buffer->Width()) continue;
+
+                    unsigned char p = pixels[y * bitmap.pitch + x / 8];
+
+                    if((p << (x % 8)) & 0x80)
+                    {
+                        dest[y * buffer->Width() + x] = 255;
+                    }
+                }
+            }
+            else
+            {
+                for(int x = 0; x < bitmap.width; x++)
+                {
+                    if(x + dx < 0 || x + dx >= buffer->Width()) continue;
+
+                    unsigned char p = pixels[y * bitmap.pitch + x];
+
+                    if(p)
+                    {
+                        dest[y * buffer->Width() + x] = p;
+                    }
                 }
             }
         }

--- a/thirdparty/ftgl/FTGlyph/FTBufferGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTBufferGlyphImpl.h
@@ -1,7 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTExtrudeGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTExtrudeGlyph.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTExtrudeGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTExtrudeGlyphImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTGlyph.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -78,8 +78,10 @@ FT_Error FTGlyph::Error() const
 //
 
 
-FTGlyphImpl::FTGlyphImpl(FT_GlyphSlot glyph, bool) : err(0)
+FTGlyphImpl::FTGlyphImpl(FT_GlyphSlot glyph, bool useList) : err(0)
 {
+    (void)useList;
+
     if(glyph)
     {
         bBox = FTBBox(glyph);

--- a/thirdparty/ftgl/FTGlyph/FTGlyphGlue.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTGlyphGlue.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -52,7 +52,7 @@ FTGL_BEGIN_C_DECLS
 
 // FTBitmapGlyph::FTBitmapGlyph();
 C_TOR(ftglCreateBitmapGlyph, (FT_GlyphSlot glyph),
-      FTBitmapGlyph, (glyph), GLYPH_BITMAP)
+      FTBitmapGlyph, (glyph), GLYPH_BITMAP);
 
 // FTBufferGlyph::FTBufferGlyph();
 // FIXME: not implemented
@@ -61,27 +61,27 @@ C_TOR(ftglCreateBitmapGlyph, (FT_GlyphSlot glyph),
 C_TOR(ftglCreateExtrudeGlyph, (FT_GlyphSlot glyph, float depth,
                    float frontOutset, float backOutset, int useDisplayList),
       FTExtrudeGlyph, (glyph, depth, frontOutset, backOutset, (useDisplayList != 0)),
-      GLYPH_EXTRUDE)
+      GLYPH_EXTRUDE);
 
 // FTOutlineGlyph::FTOutlineGlyph();
 C_TOR(ftglCreateOutlineGlyph, (FT_GlyphSlot glyph, float outset,
                                int useDisplayList),
-      FTOutlineGlyph, (glyph, outset, (useDisplayList != 0)), GLYPH_OUTLINE)
+      FTOutlineGlyph, (glyph, outset, (useDisplayList != 0)), GLYPH_OUTLINE);
 
 // FTPixmapGlyph::FTPixmapGlyph();
 C_TOR(ftglCreatePixmapGlyph, (FT_GlyphSlot glyph),
-      FTPixmapGlyph, (glyph), GLYPH_PIXMAP)
+      FTPixmapGlyph, (glyph), GLYPH_PIXMAP);
 
 // FTPolygonGlyph::FTPolygonGlyph();
 C_TOR(ftglCreatePolygonGlyph, (FT_GlyphSlot glyph, float outset,
                                int useDisplayList),
-      FTPolygonGlyph, (glyph, outset, (useDisplayList != 0)), GLYPH_POLYGON)
+      FTPolygonGlyph, (glyph, outset, (useDisplayList != 0)), GLYPH_POLYGON);
 
 // FTTextureGlyph::FTTextureGlyph();
 C_TOR(ftglCreateTextureGlyph, (FT_GlyphSlot glyph, int id, int xOffset,
                                int yOffset, int width, int height),
       FTTextureGlyph, (glyph, id, xOffset, yOffset, width, height),
-      GLYPH_TEXTURE)
+      GLYPH_TEXTURE);
 
 // FTCustomGlyph::FTCustomGlyph();
 class FTCustomGlyph : public FTGlyph
@@ -132,7 +132,7 @@ C_TOR(ftglCreateCustomGlyph, (FTGLglyph *base, void *data,
                                  int, FTGL_DOUBLE *, FTGL_DOUBLE *),
          void (*destroyCallback) (FTGLglyph *, void *)),
       FTCustomGlyph, (base, data, renderCallback, destroyCallback),
-      GLYPH_CUSTOM)
+      GLYPH_CUSTOM);
 
 #define C_FUN(cret, cname, cargs, cxxerr, cxxname, cxxarg) \
     cret cname cargs \
@@ -150,7 +150,7 @@ void ftglDestroyGlyph(FTGLglyph *g)
 {
     if(!g || !g->ptr)
     {
-        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNCTION__);
+        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNC__);
         return;
     }
     delete g->ptr;
@@ -161,7 +161,7 @@ void ftglDestroyGlyph(FTGLglyph *g)
 extern "C++" {
 C_FUN(static const FTPoint&, _ftglRenderGlyph, (FTGLglyph *g,
                                    const FTPoint& pen, int renderMode),
-      return static_ftpoint, Render, (pen, renderMode))
+      return static_ftpoint, Render, (pen, renderMode));
 }
 
 void ftglRenderGlyph(FTGLglyph *g, FTGL_DOUBLE penx, FTGL_DOUBLE peny,
@@ -175,12 +175,12 @@ void ftglRenderGlyph(FTGLglyph *g, FTGL_DOUBLE penx, FTGL_DOUBLE peny,
 }
 
 // float FTGlyph::Advance() const;
-C_FUN(float, ftglGetGlyphAdvance, (FTGLglyph *g), return 0.0, Advance, ())
+C_FUN(float, ftglGetGlyphAdvance, (FTGLglyph *g), return 0.0, Advance, ());
 
 // const FTBBox& FTGlyph::BBox() const;
 extern "C++" {
 C_FUN(static const FTBBox&, _ftglGetGlyphBBox, (FTGLglyph *g),
-      return static_ftbbox, BBox, ())
+      return static_ftbbox, BBox, ());
 }
 
 void ftglGetGlyphBBox(FTGLglyph *g, float bounds[6])
@@ -192,7 +192,7 @@ void ftglGetGlyphBBox(FTGLglyph *g, float bounds[6])
 }
 
 // FT_Error FTGlyph::Error() const;
-C_FUN(FT_Error, ftglGetGlyphError, (FTGLglyph *g), return -1, Error, ())
+C_FUN(FT_Error, ftglGetGlyphError, (FTGLglyph *g), return -1, Error, ());
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTGlyph/FTGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTGlyphImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTOutlineGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTOutlineGlyph.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -64,6 +64,7 @@ const FTPoint& FTOutlineGlyph::Render(const FTPoint& pen, int renderMode)
 FTOutlineGlyphImpl::FTOutlineGlyphImpl(FT_GlyphSlot glyph, float _outset,
                                        bool useDisplayList)
 :   FTGlyphImpl(glyph),
+    vectoriser(0),
     glList(0)
 {
     if(ft_glyph_format_outline != glyph->format)
@@ -112,8 +113,10 @@ FTOutlineGlyphImpl::~FTOutlineGlyphImpl()
 
 
 const FTPoint& FTOutlineGlyphImpl::RenderImpl(const FTPoint& pen,
-                                              int)
+                                              int renderMode)
 {
+    (void)renderMode;
+
     glTranslatef(pen.Xf(), pen.Yf(), pen.Zf());
     if(glList)
     {

--- a/thirdparty/ftgl/FTGlyph/FTOutlineGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTOutlineGlyphImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTPolygonGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTPolygonGlyph.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -64,6 +64,7 @@ const FTPoint& FTPolygonGlyph::Render(const FTPoint& pen, int renderMode)
 FTPolygonGlyphImpl::FTPolygonGlyphImpl(FT_GlyphSlot glyph, float _outset,
                                        bool useDisplayList)
 :   FTGlyphImpl(glyph),
+    vectoriser(0),
     glList(0)
 {
     if(ft_glyph_format_outline != glyph->format)
@@ -115,8 +116,10 @@ FTPolygonGlyphImpl::~FTPolygonGlyphImpl()
 
 
 const FTPoint& FTPolygonGlyphImpl::RenderImpl(const FTPoint& pen,
-                                              int)
+                                              int renderMode)
 {
+    (void)renderMode;
+
     glTranslatef(pen.Xf(), pen.Yf(), pen.Zf());
     if(glList)
     {

--- a/thirdparty/ftgl/FTGlyph/FTPolygonGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTPolygonGlyphImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTTextureGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTTextureGlyph.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -33,11 +33,30 @@
 #include "FTInternals.h"
 #include "FTTextureGlyphImpl.h"
 
+#define FTGL_ASSERTS_SHOULD_SOFT_FAIL
+
+#ifdef FTGL_ASSERTS_SHOULD_SOFT_FAIL
+#   define FTASSERT_FAIL do {} while(0)
+#else
+#   define FTASSERT_FAIL do { int *a = (int*)0x0; *a = 0xD15EA5ED; } while(0)
+#endif
+
+#define FTASSERT(x) \
+    if (!(x)) \
+    { \
+        static int count = 0; \
+        if (count++ < 8) \
+            fprintf(stderr, "ASSERTION FAILED (%s:%d): %s\n", \
+                    __FILE__, __LINE__, #x); \
+        FTASSERT_FAIL; \
+        if (count == 8) \
+            fprintf(stderr, "\\__ last warning for this assertion\n"); \
+    }
+
 
 //
 //  FTGLTextureGlyph
 //
-
 
 FTTextureGlyph::FTTextureGlyph(FT_GlyphSlot glyph, int id, int xOffset,
                                int yOffset, int width, int height) :
@@ -59,7 +78,6 @@ const FTPoint& FTTextureGlyph::Render(const FTPoint& pen, int renderMode)
 //
 //  FTGLTextureGlyphImpl
 //
-
 
 GLint FTTextureGlyphImpl::activeTextureID = 0;
 
@@ -88,16 +106,63 @@ FTTextureGlyphImpl::FTTextureGlyphImpl(FT_GlyphSlot glyph, int id, int xOffset,
     if(destWidth && destHeight)
     {
         glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
+
         glPixelStorei(GL_UNPACK_LSB_FIRST, GL_FALSE);
         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
+        GLint w,h;
+
         glBindTexture(GL_TEXTURE_2D, glTextureID);
-        glTexSubImage2D(GL_TEXTURE_2D, 0, xOffset, yOffset, destWidth, destHeight, GL_ALPHA, GL_UNSIGNED_BYTE, bitmap.buffer);
+        glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
+        glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
+
+        FTASSERT(xOffset >= 0);
+        FTASSERT(yOffset >= 0);
+        FTASSERT(destWidth >= 0);
+        FTASSERT(destHeight >= 0);
+        FTASSERT(xOffset + destWidth <= w);
+        FTASSERT(yOffset + destHeight <= h);
+
+        if (yOffset + destHeight > h)
+        {
+            // We'll only get here if we are soft-failing our asserts. In that
+            // case, since the data we're trying to put into our texture is
+            // too long, we'll only copy a portion of the image.
+            destHeight = h - yOffset;
+        }
+        if (destHeight >= 0)
+        {
+            // convert bitmap fonts
+            std::vector <unsigned char> data_converted;
+            if(bitmap.num_grays == 1)
+            {
+                bBox = FTBBox(0, 0, 0, destWidth, destHeight, 0);
+                data_converted.resize(destWidth * destHeight, 0);
+                int n = 0;
+                for(int y = 0; y < destHeight; ++y)
+                {
+                    unsigned char* src = bitmap.pitch < 0
+                      ? bitmap.buffer + (y - destHeight + 1) * bitmap.pitch
+                      : bitmap.buffer + y * bitmap.pitch;
+                    unsigned char c;
+                    for(int x = 0; x < destWidth; ++x)
+                    {
+                        if (x % 8 == 0)
+                          c = *src++;
+                        data_converted[n++] = ((c >> (7 - (x % 8))) & 1) * 255;
+                    }
+                }
+            }
+
+            glTexSubImage2D(GL_TEXTURE_2D, 0, xOffset, yOffset,
+                            destWidth, destHeight, GL_ALPHA, GL_UNSIGNED_BYTE,
+                            !data_converted.empty() ? data_converted.data()
+                                                    : bitmap.buffer);
+        }
 
         glPopClientAttrib();
     }
-
 
 //      0
 //      +----+
@@ -121,7 +186,7 @@ FTTextureGlyphImpl::~FTTextureGlyphImpl()
 
 
 const FTPoint& FTTextureGlyphImpl::RenderImpl(const FTPoint& pen,
-                                              int)
+                                              int renderMode)
 {
     float dx, dy;
 
@@ -136,16 +201,16 @@ const FTPoint& FTTextureGlyphImpl::RenderImpl(const FTPoint& pen,
 
     glBegin(GL_QUADS);
         glTexCoord2f(uv[0].Xf(), uv[0].Yf());
-        glVertex2f(dx, dy);
+        glVertex3f(dx, dy, pen.Zf());
 
         glTexCoord2f(uv[0].Xf(), uv[1].Yf());
-        glVertex2f(dx, dy - destHeight);
+        glVertex3f(dx, dy - destHeight, pen.Zf());
 
         glTexCoord2f(uv[1].Xf(), uv[1].Yf());
-        glVertex2f(dx + destWidth, dy - destHeight);
+        glVertex3f(dx + destWidth, dy - destHeight, pen.Zf());
 
         glTexCoord2f(uv[1].Xf(), uv[0].Yf());
-        glVertex2f(dx + destWidth, dy);
+        glVertex3f(dx + destWidth, dy, pen.Zf());
     glEnd();
 
     return advance;

--- a/thirdparty/ftgl/FTGlyph/FTTextureGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTTextureGlyphImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTGlyph/FTTriangleExtractorGlyph.cpp
+++ b/thirdparty/ftgl/FTGlyph/FTTriangleExtractorGlyph.cpp
@@ -1,0 +1,165 @@
+/*
+ * FTGL - OpenGL font library
+ *
+ * Copyright (c) 2011 Richard Ulrich <richi@paraeasy.ch>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "FTGL/ftgl.h"
+
+#include "FTInternals.h"
+#include "FTTriangleExtractorGlyphImpl.h"
+#include "FTVectoriser.h"
+// std lib
+#include <cassert>
+
+//
+//  FTGLTriangleExtractorGlyph
+//
+
+
+FTTriangleExtractorGlyph::FTTriangleExtractorGlyph(FT_GlyphSlot glyph, float outset,
+                               std::vector<float>& triangles) :
+    FTGlyph(new FTTriangleExtractorGlyphImpl(glyph, outset, triangles))
+{}
+
+
+FTTriangleExtractorGlyph::~FTTriangleExtractorGlyph()
+{}
+
+
+const FTPoint& FTTriangleExtractorGlyph::Render(const FTPoint& pen, int renderMode)
+{
+    FTTriangleExtractorGlyphImpl *myimpl = dynamic_cast<FTTriangleExtractorGlyphImpl *>(impl);
+    return myimpl->RenderImpl(pen, renderMode);
+}
+
+
+//
+//  FTGLTriangleExtractorGlyphImpl
+//
+
+
+FTTriangleExtractorGlyphImpl::FTTriangleExtractorGlyphImpl(FT_GlyphSlot glyph, float _outset,
+                                       std::vector<float>& triangles)
+:   FTGlyphImpl(glyph),
+    triangles_(triangles)
+{
+    if(ft_glyph_format_outline != glyph->format)
+    {
+        err = 0x14; // Invalid_Outline
+        return;
+    }
+
+    vectoriser = new FTVectoriser(glyph);
+
+    if((vectoriser->ContourCount() < 1) || (vectoriser->PointCount() < 3))
+    {
+        delete vectoriser;
+        vectoriser = NULL;
+        return;
+    }
+
+
+    hscale = glyph->face->size->metrics.x_ppem * 64;
+    vscale = glyph->face->size->metrics.y_ppem * 64;
+    outset = _outset;
+}
+
+
+FTTriangleExtractorGlyphImpl::~FTTriangleExtractorGlyphImpl()
+{
+    delete vectoriser;
+}
+
+
+const FTPoint& FTTriangleExtractorGlyphImpl::RenderImpl(const FTPoint& pen,
+                                              int renderMode)
+{
+    (void)renderMode;
+
+	if(NULL == vectoriser)
+		return advance;
+
+    vectoriser->MakeMesh(1.0, 1, outset);
+    const FTMesh *mesh = vectoriser->GetMesh();
+
+    for(unsigned int t = 0; t < mesh->TesselationCount(); ++t)
+    {
+        const FTTesselation* subMesh = mesh->Tesselation(t);
+        const unsigned int polygonType = subMesh->PolygonType();
+
+        // convert everything to a single triangle strip.
+        // In some cases we have to insert invalid triangles to make a valid strip
+        switch(polygonType)
+        {
+            case GL_TRIANGLE_STRIP:
+                AddVertex(pen, subMesh->Point(0));
+                for(unsigned int i = 0; i < subMesh->PointCount(); ++i)
+                    AddVertex(pen, subMesh->Point(i));
+                AddVertex(pen, subMesh->Point(subMesh->PointCount() - 1));
+                break;
+            case GL_TRIANGLES:
+                assert(subMesh->PointCount() % 3 == 0);
+                for(unsigned int i = 0; i < subMesh->PointCount(); i += 3)
+                {
+                    AddVertex(pen, subMesh->Point(i));
+                    AddVertex(pen, subMesh->Point(i));
+                    AddVertex(pen, subMesh->Point(i+1));
+                    AddVertex(pen, subMesh->Point(i+2));
+                    AddVertex(pen, subMesh->Point(i+2));
+                }
+                break;
+            case GL_TRIANGLE_FAN:
+            {
+                const FTPoint& centerPoint = subMesh->Point(0);
+                AddVertex(pen, centerPoint);
+
+                for(unsigned int i = 1; i < subMesh->PointCount()-1; ++i)
+                {
+                    AddVertex(pen, centerPoint);
+                    AddVertex(pen, subMesh->Point(i));
+                    AddVertex(pen, subMesh->Point(i+1));
+                    AddVertex(pen, centerPoint);
+                }
+                AddVertex(pen, centerPoint);
+                break;
+            }
+            default:
+                assert(!"please implement...");
+            ;
+        }
+
+
+    }
+
+    return advance;
+}
+
+void FTTriangleExtractorGlyphImpl::AddVertex(const FTPoint& pen, const FTPoint& point)
+{
+    triangles_.push_back(pen.Xf() + point.Xf() / 64.0);
+    triangles_.push_back(pen.Yf() + point.Yf() / 64.0);
+    triangles_.push_back(pen.Zf());
+}
+

--- a/thirdparty/ftgl/FTGlyph/FTTriangleExtractorGlyphImpl.h
+++ b/thirdparty/ftgl/FTGlyph/FTTriangleExtractorGlyphImpl.h
@@ -1,8 +1,7 @@
 /*
  * FTGL - OpenGL font library
  *
- * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
+ * Copyright (c) 2011 Richard Ulrich <richi@paraeasy.ch>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -24,44 +23,37 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __FTPixmapGlyphImpl__
-#define __FTPixmapGlyphImpl__
+#ifndef __FTTriangleExtractorGlyphImpl__
+#define __FTTriangleExtractorGlyphImpl__
 
 #include "FTGlyphImpl.h"
 
-class FTPixmapGlyphImpl : public FTGlyphImpl
+class FTVectoriser;
+
+class FTTriangleExtractorGlyphImpl : public FTGlyphImpl
 {
-    friend class FTPixmapGlyph;
+    friend class FTTriangleExtractorGlyph;
 
-    protected:
-        FTPixmapGlyphImpl(FT_GlyphSlot glyph);
+    public:
+        FTTriangleExtractorGlyphImpl(FT_GlyphSlot glyph, float outset,
+                           std::vector<float>& triangles);
 
-        virtual ~FTPixmapGlyphImpl();
+        virtual ~FTTriangleExtractorGlyphImpl();
 
         virtual const FTPoint& RenderImpl(const FTPoint& pen, int renderMode);
 
     private:
-        /**
-         * The width of the glyph 'image'
-         */
-        int destWidth;
+
+        void AddVertex(const FTPoint& pen, const FTPoint& point);
 
         /**
-         * The height of the glyph 'image'
+         * Private rendering variables.
          */
-        int destHeight;
-
-        /**
-         * Vector from the pen position to the topleft corner of the pixmap
-         */
-        FTPoint pos;
-
-        /**
-         * Pointer to the 'image' data
-         */
-        unsigned char* data;
-
+        unsigned int hscale, vscale;
+        FTVectoriser *vectoriser;
+        float outset;
+        std::vector<float>& triangles_;
 };
 
-#endif  //  __FTPixmapGlyphImpl__
+#endif  //  __FTTriangleExtractorGlyphImpl__
 

--- a/thirdparty/ftgl/FTGlyphContainer.cpp
+++ b/thirdparty/ftgl/FTGlyphContainer.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -76,10 +76,11 @@ void FTGlyphContainer::Add(FTGlyph* tempGlyph, const unsigned int charCode)
 }
 
 
-const FTGlyph* FTGlyphContainer::Glyph(const unsigned int charCode) const
+const FTGlyph* const FTGlyphContainer::Glyph(const unsigned int charCode) const
 {
     unsigned int index = charMap->GlyphListIndex(charCode);
-    return glyphs[index];
+
+    return (index < glyphs.size()) ? glyphs[index] : NULL;
 }
 
 
@@ -94,8 +95,12 @@ float FTGlyphContainer::Advance(const unsigned int charCode,
 {
     unsigned int left = charMap->FontIndex(charCode);
     unsigned int right = charMap->FontIndex(nextCharCode);
+    const FTGlyph *glyph = Glyph(charCode);
 
-    return face->KernAdvance(left, right).Xf() + Glyph(charCode)->Advance();
+    if (!glyph)
+      return 0.0f;
+
+    return face->KernAdvance(left, right).Xf() + glyph->Advance();
 }
 
 
@@ -111,7 +116,8 @@ FTPoint FTGlyphContainer::Render(const unsigned int charCode,
     if(!face->Error())
     {
         unsigned int index = charMap->GlyphListIndex(charCode);
-        kernAdvance += glyphs[index]->Render(penPosition, renderMode);
+        if (index < glyphs.size())
+            kernAdvance += glyphs[index]->Render(penPosition, renderMode);
     }
 
     return kernAdvance;

--- a/thirdparty/ftgl/FTGlyphContainer.h
+++ b/thirdparty/ftgl/FTGlyphContainer.h
@@ -92,7 +92,7 @@ class FTGlyphContainer
          * @return              An FTGlyph or <code>null</code> is it hasn't been
          * loaded.
          */
-        const FTGlyph* Glyph(const unsigned int characterCode) const;
+        const FTGlyph* const Glyph(const unsigned int characterCode) const;
 
         /**
          * Get the bounding box for a character.

--- a/thirdparty/ftgl/FTInternals.h
+++ b/thirdparty/ftgl/FTInternals.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -48,7 +48,7 @@
 #endif
 
 
-#ifdef WIN32
+#ifdef _WIN32
 
     // Under windows avoid including <windows.h> is overrated.
     // Sure, it can be avoided and "name space pollution" can be
@@ -93,7 +93,7 @@ typedef enum
     GLYPH_OUTLINE,
     GLYPH_POLYGON,
     GLYPH_EXTRUDE,
-    GLYPH_TEXTURE
+    GLYPH_TEXTURE,
 } GlyphType;
 
 struct _FTGLglyph
@@ -111,7 +111,7 @@ typedef enum
     FONT_OUTLINE,
     FONT_POLYGON,
     FONT_EXTRUDE,
-    FONT_TEXTURE
+    FONT_TEXTURE,
 } FontType;
 
 struct _FTGLfont
@@ -122,7 +122,7 @@ struct _FTGLfont
 
 typedef enum
 {
-    LAYOUT_SIMPLE
+    LAYOUT_SIMPLE,
 } LayoutType;
 
 struct _FTGLlayout

--- a/thirdparty/ftgl/FTLayout/FTLayout.cpp
+++ b/thirdparty/ftgl/FTLayout/FTLayout.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTLayout/FTLayoutGlue.cpp
+++ b/thirdparty/ftgl/FTLayout/FTLayoutGlue.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
  * Copyright (c) 2008 Éric Beets <ericbeets@free.fr>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -49,7 +49,7 @@ FTGL_BEGIN_C_DECLS
     }
 
 // FTSimpleLayout::FTSimpleLayout();
-C_TOR(ftglCreateSimpleLayout, (), FTSimpleLayout, (), LAYOUT_SIMPLE)
+C_TOR(ftglCreateSimpleLayout, (), FTSimpleLayout, (), LAYOUT_SIMPLE);
 
 #define C_FUN(cret, cname, cargs, cxxerr, cxxname, cxxarg) \
     cret cname cargs \
@@ -67,7 +67,7 @@ void ftglDestroyLayout(FTGLlayout *l)
 {
     if(!l || !l->ptr)
     {
-        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNCTION__);
+        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNC__);
         return;
     }
     delete l->ptr;
@@ -76,13 +76,13 @@ void ftglDestroyLayout(FTGLlayout *l)
 
 // virtual FTBBox FTLayout::BBox(const char* string)
 extern "C++" {
-C_FUN(static FTBBox, _ftgGetlLayoutBBox, (FTGLlayout *l, const char *s),
-      return static_ftbbox, BBox, (s))
+C_FUN(static FTBBox, _ftglGetLayoutBBox, (FTGLlayout *l, const char *s),
+      return static_ftbbox, BBox, (s));
 }
 
-void ftgGetlLayoutBBox(FTGLlayout *l, const char * s, float c[6])
+void ftglGetLayoutBBox(FTGLlayout *l, const char * s, float c[6])
 {
-    FTBBox ret = _ftgGetlLayoutBBox(l, s);
+    FTBBox ret = _ftglGetLayoutBBox(l, s);
     FTPoint lower = ret.Lower(), upper = ret.Upper();
     c[0] = lower.Xf(); c[1] = lower.Yf(); c[2] = lower.Zf();
     c[3] = upper.Xf(); c[4] = upper.Yf(); c[5] = upper.Zf();
@@ -90,23 +90,23 @@ void ftgGetlLayoutBBox(FTGLlayout *l, const char * s, float c[6])
 
 // virtual void FTLayout::Render(const char* string, int renderMode);
 C_FUN(void, ftglRenderLayout, (FTGLlayout *l, const char *s, int r),
-      return, Render, (s, r))
+      return, Render, (s, -1, FTPoint(), r));
 
 // FT_Error FTLayout::Error() const;
-C_FUN(FT_Error, ftglGetLayoutError, (FTGLlayout *l), return -1, Error, ())
+C_FUN(FT_Error, ftglGetLayoutError, (FTGLlayout *l), return -1, Error, ());
 
 // void FTSimpleLayout::SetFont(FTFont *fontInit)
 void ftglSetLayoutFont(FTGLlayout *l, FTGLfont *font)
 {
     if(!l || !l->ptr)
     {
-        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNCTION__);
+        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNC__);
         return;
     }
     if(l->type != FTGL::LAYOUT_SIMPLE)
     {
         fprintf(stderr, "FTGL warning: %s not implemented for %d\n",
-                        __FUNCTION__, l->type);
+                        __FUNC__, l->type);
     }
     l->font = font;
     return dynamic_cast<FTSimpleLayout*>(l->ptr)->SetFont(font->ptr);
@@ -117,13 +117,13 @@ FTGLfont *ftglGetLayoutFont(FTGLlayout *l)
 {
     if(!l || !l->ptr)
     {
-        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNCTION__);
+        fprintf(stderr, "FTGL warning: NULL pointer in %s\n", __FUNC__);
         return NULL;
     }
     if(l->type != FTGL::LAYOUT_SIMPLE)
     {
         fprintf(stderr, "FTGL warning: %s not implemented for %d\n",
-                        __FUNCTION__, l->type);
+                        __FUNC__, l->type);
     }
     return l->font;
 }
@@ -141,7 +141,7 @@ FTGLfont *ftglGetLayoutFont(FTGLlayout *l)
         if(l->type != FTGL::LAYOUT_SIMPLE) \
         { \
             fprintf(stderr, "FTGL warning: %s not implemented for %d\n", \
-                            __FUNCTION__, l->type); \
+                            __FUNC__, l->type); \
             cxxerr; \
         } \
         return dynamic_cast<FTSimpleLayout*>(l->ptr)->cxxname cxxarg; \
@@ -149,23 +149,25 @@ FTGLfont *ftglGetLayoutFont(FTGLlayout *l)
 
 // void FTSimpleLayout::SetLineLength(const float LineLength);
 C_FUN(void, ftglSetLayoutLineLength, (FTGLlayout *l, const float length),
-      return, SetLineLength, (length))
+      return, SetLineLength, (length));
 
 // float FTSimpleLayout::GetLineLength() const
 C_FUN(float, ftglGetLayoutLineLength, (FTGLlayout *l),
-      return 0.0f, GetLineLength, ())
+      return 0.0f, GetLineLength, ());
 
 // void FTSimpleLayout::SetAlignment(const TextAlignment Alignment)
 C_FUN(void, ftglSetLayoutAlignment, (FTGLlayout *l, const int a),
-      return, SetAlignment, ((FTGL::TextAlignment)a))
+      return, SetAlignment, ((FTGL::TextAlignment)a));
 
 // TextAlignment FTSimpleLayout::GetAlignment() const
+C_FUN(int, ftglGetLayoutAlignment, (FTGLlayout *l),
+      return FTGL::ALIGN_LEFT, GetAlignment, ());
 C_FUN(int, ftglGetLayoutAlignement, (FTGLlayout *l),
-      return FTGL::ALIGN_LEFT, GetAlignment, ())
+      return FTGL::ALIGN_LEFT, GetAlignment, ()); // old typo
 
 // void FTSimpleLayout::SetLineSpacing(const float LineSpacing)
 C_FUN(void, ftglSetLayoutLineSpacing, (FTGLlayout *l, const float f),
-      return, SetLineSpacing, (f))
+      return, SetLineSpacing, (f));
 
 FTGL_END_C_DECLS
 

--- a/thirdparty/ftgl/FTLayout/FTLayoutImpl.h
+++ b/thirdparty/ftgl/FTLayout/FTLayoutImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTLayout/FTSimpleLayout.cpp
+++ b/thirdparty/ftgl/FTLayout/FTSimpleLayout.cpp
@@ -2,7 +2,8 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
+ * Copyright (c) 2008 Daniel Remenak <dtremenak@users.sourceforge.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -27,7 +28,7 @@
 #include "config.h"
 
 #include <ctype.h>
-#include <wchar.h>
+#include <wctype.h>
 
 #include "FTInternals.h"
 #include "FTUnicode.h"
@@ -194,7 +195,6 @@ inline void FTSimpleLayoutImpl::WrapTextI(const T *buf, const int len,
                                           FTPoint position, int renderMode,
                                           FTBBox *bounds)
 {
-    (void) len;
     FTUnicodeStringItr<T> breakItr(buf);          // points to the last break character
     FTUnicodeStringItr<T> lineStart(buf);         // points to the line start
     float nextStart = 0.0;     // total width of the current line
@@ -262,7 +262,7 @@ inline void FTSimpleLayoutImpl::WrapTextI(const T *buf, const int len,
                 ++breakChar; --charCount;
             }
 
-            if (breakCharCount >= 0)
+            if(breakCharCount >= 0)
             {
                 OutputWrapped(lineStart.getBufferFromHere(), breakCharCount,
                               //breakItr.getBufferFromHere() - lineStart.getBufferFromHere(),
@@ -405,9 +405,11 @@ void FTSimpleLayoutImpl::OutputWrapped(const wchar_t *buf, const int len,
 
 template <typename T>
 inline void FTSimpleLayoutImpl::RenderSpaceI(const T *string, const int len,
-                                             FTPoint, int renderMode,
+                                             FTPoint position, int renderMode,
                                              const float extraSpace)
 {
+    (void)position;
+
     float space = 0.0;
 
     // If there is space to distribute, count the number of spaces

--- a/thirdparty/ftgl/FTLayout/FTSimpleLayoutImpl.h
+++ b/thirdparty/ftgl/FTLayout/FTSimpleLayoutImpl.h
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -39,7 +39,7 @@ class FTSimpleLayoutImpl : public FTLayoutImpl
     protected:
         FTSimpleLayoutImpl();
 
-        virtual ~FTSimpleLayoutImpl() {}
+        virtual ~FTSimpleLayoutImpl() {};
 
         virtual FTBBox BBox(const char* string, const int len,
                             FTPoint position);

--- a/thirdparty/ftgl/FTLibrary.cpp
+++ b/thirdparty/ftgl/FTLibrary.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 
 #include "FTLibrary.h"
-
+#include "FTCleanup.h"
 
 const FTLibrary&  FTLibrary::Instance()
 {
@@ -37,6 +37,8 @@ const FTLibrary&  FTLibrary::Instance()
 
 FTLibrary::~FTLibrary()
 {
+    FTCleanup::Instance()->DestroyAll();
+
     if(library != 0)
     {
         FT_Done_FreeType(*library);
@@ -44,14 +46,6 @@ FTLibrary::~FTLibrary()
         delete library;
         library= 0;
     }
-
-//  if(manager != 0)
-//  {
-//      FTC_Manager_Done(manager);
-//
-//      delete manager;
-//      manager= 0;
-//  }
 }
 
 
@@ -78,14 +72,7 @@ bool FTLibrary::Initialise()
         return false;
     }
 
-//  FTC_Manager* manager;
-//
-//  if(FTC_Manager_New(lib, 0, 0, 0, my_face_requester, 0, manager)
-//  {
-//      delete manager;
-//      manager= 0;
-//      return false;
-//  }
+    FTCleanup::Instance();
 
     return true;
 }

--- a/thirdparty/ftgl/FTPoint.cpp
+++ b/thirdparty/ftgl/FTPoint.cpp
@@ -2,7 +2,7 @@
  * FTGL - OpenGL font library
  *
  * Copyright (c) 2001-2004 Henry Maddocks <ftgl@opengl.geek.nz>
- * Copyright (c) 2008 Sam Hocevar <sam@zoy.org>
+ * Copyright (c) 2008 Sam Hocevar <sam@hocevar.net>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/thirdparty/ftgl/FTUnicode.h
+++ b/thirdparty/ftgl/FTUnicode.h
@@ -33,8 +33,6 @@
 #ifndef    __FTUnicode__
 #define    __FTUnicode__
 
-#include <iostream>
-
 /**
  * Provides a way to easily walk multibyte unicode strings in the various
  * Unicode encodings (UTF-8, UTF-16, UTF-32, UCS-2, and UCS-4).  Encodings
@@ -53,7 +51,7 @@ public:
     FTUnicodeStringItr(const T* string) : curPos(string), nextPos(string)
     {
         (*this)++;
-    }
+    };
 
     /**
      * Pre-increment operator.  Reads the next unicode character and sets
@@ -150,7 +148,7 @@ private:
     const T* nextPos;
 
     // unicode magic numbers
-    static const char utf8bytes[256];
+    static const unsigned char utf8bytes[256];
     static const unsigned long offsetsFromUTF8[6];
     static const unsigned long highSurrogateStart;
     static const unsigned long highSurrogateEnd;
@@ -163,7 +161,7 @@ private:
 /* The first character in a UTF8 sequence indicates how many bytes
  * to read (among other things) */
 template <typename T>
-const char FTUnicodeStringItr<T>::utf8bytes[256] = {
+const unsigned char FTUnicodeStringItr<T>::utf8bytes[256] = {
   1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
   1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
   1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
@@ -187,64 +185,20 @@ const unsigned long FTUnicodeStringItr<T>::offsetsFromUTF8[6] = { 0x00000000UL, 
 template <typename T>
 inline void FTUnicodeStringItr<T>::readUTF8()
 {
-  /*
     unsigned int ch = 0;
     unsigned int extraBytesToRead = utf8bytes[(unsigned char)(*nextPos)];
     // falls through
     switch (extraBytesToRead)
     {
-    case 6: ch += *nextPos++; ch <<= 6; // remember, illegal UTF-8
-    case 5: ch += *nextPos++; ch <<= 6; // remember, illegal UTF-8
-    case 4: ch += *nextPos++; ch <<= 6;
-    case 3: ch += *nextPos++; ch <<= 6;
-    case 2: ch += *nextPos++; ch <<= 6;
-    case 1: ch += *nextPos++;
+          case 6: ch += *nextPos++; ch <<= 6; /* remember, illegal UTF-8 */
+          case 5: ch += *nextPos++; ch <<= 6; /* remember, illegal UTF-8 */
+          case 4: ch += *nextPos++; ch <<= 6;
+          case 3: ch += *nextPos++; ch <<= 6;
+          case 2: ch += *nextPos++; ch <<= 6;
+          case 1: ch += *nextPos++;
     }
     ch -= offsetsFromUTF8[extraBytesToRead-1];
     curChar = ch;
-  */
-  // check invalid UTF8
-  unsigned int ch = 0;
-  unsigned char *u = (unsigned char *) nextPos;
-  unsigned int len =  utf8bytes[*u];
-  switch (len) {
-  case 2:
-    ch = *u & 0x1F;
-    break;
-  case 3:
-    ch = *u & 0x0F;
-    break;
-  case 4:
-    ch = *u & 0x07;
-    break;
-  default:
-    // len > 4 are invalid
-    // return it as extended-ASCII
-    curChar = *nextPos++;
-    return; 
-  }
-  ++u;
-  // read the remaining bytes
-  for (unsigned int i = 1; i < len; ++u, ++i) {
-    if ((*u & 0xC0) != 0x80) {
-      // invalid UTF8
-      // return it as an extended-ASCII
-      curChar = *nextPos++;
-      return;
-    }
-    // build the Unicode
-    ch = (ch<<6) | (*u & 0x3F);
-  } 
-  // According to Unicode 5.0 
-  // codes in the range 0xD800 to 0xDFFF 
-  // are invalid
-  /*if (((ch) >= 0xD800) || ((ch) <= 0xDFFF)) {
-    // replace it with question mark
-    ch = '?';
-    len = 1;
-    }*/
-  nextPos += len;
-  curChar = ch;
 }
 
 // Magic numbers for UTF-16 conversions

--- a/thirdparty/ftgl/config.h
+++ b/thirdparty/ftgl/config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#if defined ( _WIN32 )
+  #define __FUNC__ __FUNCTION__
+#else
+  #define __FUNC__ __func__
+#endif

--- a/thirdparty/libtess2/CMakeLists.txt
+++ b/thirdparty/libtess2/CMakeLists.txt
@@ -1,8 +1,8 @@
 IF(WIN32)
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDLL_TESS2")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDLL_TESS2")
 ENDIF(WIN32)
 
-SET(LibTess2_SRCS
+SET(libtess2_SRCS
     Source/bucketalloc.c
     Source/dict.c
     Source/geom.c
@@ -13,7 +13,7 @@ SET(LibTess2_SRCS
 
 INCLUDE_DIRECTORIES(${Tess2Include})
 
-ADD_LIBRARY(${Tess2Library} SHARED ${LibTess2_SRCS})
+ADD_LIBRARY(${Tess2Library} SHARED ${libtess2_SRCS})
 
 INSTALL(TARGETS ${Tess2Library}
         RUNTIME DESTINATION ${TulipBinInstallDir}

--- a/thirdparty/libtess2/Include/tesselator.h
+++ b/thirdparty/libtess2/Include/tesselator.h
@@ -1,5 +1,5 @@
 /*
-** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008) 
+** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
 ** Copyright (C) [dates of first publication] Silicon Graphics, Inc.
 ** All Rights Reserved.
 **
@@ -9,10 +9,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 ** of the Software, and to permit persons to whom the Software is furnished to do so,
 ** subject to the following conditions:
-** 
+**
 ** The above copyright notice including the dates of first publication and either this
 ** permission notice or a reference to http://oss.sgi.com/projects/FreeB/ shall be
-** included in all copies or substantial portions of the Software. 
+** included in all copies or substantial portions of the Software.
 **
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 ** INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -20,7 +20,7 @@
 ** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 ** OR OTHER DEALINGS IN THE SOFTWARE.
-** 
+**
 ** Except as contained in this notice, the name of Silicon Graphics, Inc. shall not
 ** be used in advertising or otherwise to promote the sale, use or other dealings in
 ** this Software without prior written authorization from Silicon Graphics, Inc.
@@ -51,11 +51,11 @@ extern "C" {
 // http://www.glprogramming.com/red/chapter11.html
 enum TessWindingRule
 {
-    TESS_WINDING_ODD,
-    TESS_WINDING_NONZERO,
-    TESS_WINDING_POSITIVE,
-    TESS_WINDING_NEGATIVE,
-    TESS_WINDING_ABS_GEQ_TWO
+	TESS_WINDING_ODD,
+	TESS_WINDING_NONZERO,
+	TESS_WINDING_POSITIVE,
+	TESS_WINDING_NEGATIVE,
+	TESS_WINDING_ABS_GEQ_TWO,
 };
 
 // The contents of the tessGetElements() depends on element type being passed to tessTesselate().
@@ -117,12 +117,27 @@ enum TessWindingRule
 //         }
 //         glEnd();
 //     }
-//
+
 enum TessElementType
 {
-    TESS_POLYGONS,
-    TESS_CONNECTED_POLYGONS,
-    TESS_BOUNDARY_CONTOURS
+	TESS_POLYGONS,
+	TESS_CONNECTED_POLYGONS,
+	TESS_BOUNDARY_CONTOURS,
+};
+
+
+// TESS_CONSTRAINED_DELAUNAY_TRIANGULATION
+//   If enabled, the initial triagulation is improved with non-robust Constrained Delayney triangulation.
+//   Disable by default.
+//
+// TESS_REVERSE_CONTOURS
+//   If enabled, tessAddContour() will treat CW contours as CCW and vice versa
+//   Disabled by default.
+
+enum TessOption
+{
+	TESS_CONSTRAINED_DELAUNAY_TRIANGULATION,
+	TESS_REVERSE_CONTOURS
 };
 
 typedef float TESSreal;
@@ -144,12 +159,12 @@ typedef struct TESSalloc TESSalloc;
 // how often to allocate memory from the system versus how much extra space the system
 // should allocate. Reasonable defaults are show in commects below, they will be used if
 // the bucket sizes are zero.
-// 
+//
 // The use may left the memrealloc to be null. In that case, the tesselator will not try to
 // dynamically grow int's internal arrays. The tesselator only needs the reallocation when it
 // has found intersecting segments and needs to add new vertex. This defency can be cured by
 // allocating some extra vertices beforehand. The 'extraVertices' variable allows to specify
-// number of expected extra vertices.  
+// number of expected extra vertices.
 struct TESSalloc
 {
 	void *(*memalloc)( void *userData, unsigned int size );
@@ -195,6 +210,12 @@ TESS2_SCOPE void tessDeleteTess( TESStesselator *tess );
 //   count - number of vertices in contour.
 TESS2_SCOPE void tessAddContour( TESStesselator *tess, int size, const void* pointer, int stride, int count );
 
+// tessSetOption() - Toggles optional tessellation parameters
+// Parameters:
+//  option - one of TessOption
+//  value - 1 if enabled, 0 if disabled.
+TESS2_SCOPE void tessSetOption( TESStesselator *tess, int option, int value );
+
 // tessTesselate() - tesselate contours.
 // Parameters:
 //   tess - pointer to tesselator object.
@@ -218,7 +239,7 @@ TESS2_SCOPE const TESSreal* tessGetVertices( TESStesselator *tess );
 // Every point added using tessAddContour() will get a new index starting at 0.
 // New vertices generated at the intersections of segments are assigned value TESS_UNDEF.
 TESS2_SCOPE const TESSindex* tessGetVertexIndices( TESStesselator *tess );
-	
+
 // tessGetElementCount() - Returns number of elements in the the tesselated output.
 TESS2_SCOPE int tessGetElementCount( TESStesselator *tess );
 

--- a/thirdparty/libtess2/README.md
+++ b/thirdparty/libtess2/README.md
@@ -12,7 +12,7 @@ Simple bucketed memory allocator (see Graphics Gems III for reference) was added
 The API was changed to loosely resemble the OpenGL vertex array API. The processed data can be accessed via getter functions. The code is able to output contours, polygons and connected polygons. The output of the tesselator can be also used as input for new run. I.e. the user may first want to calculate an union all the input contours and the triangulate them.
 
 The code is released under SGI FREE SOFTWARE LICENSE B Version 2.0.
-http://oss.sgi.com/projects/FreeB/
+https://directory.fsf.org/wiki/License:SGIFreeBv2
 
 
 Mikko Mononen

--- a/thirdparty/libtess2/Source/geom.c
+++ b/thirdparty/libtess2/Source/geom.c
@@ -1,5 +1,5 @@
 /*
-** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008) 
+** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
 ** Copyright (C) [dates of first publication] Silicon Graphics, Inc.
 ** All Rights Reserved.
 **
@@ -9,10 +9,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 ** of the Software, and to permit persons to whom the Software is furnished to do so,
 ** subject to the following conditions:
-** 
+**
 ** The above copyright notice including the dates of first publication and either this
 ** permission notice or a reference to http://oss.sgi.com/projects/FreeB/ shall be
-** included in all copies or substantial portions of the Software. 
+** included in all copies or substantial portions of the Software.
 **
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 ** INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -20,7 +20,7 @@
 ** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 ** OR OTHER DEALINGS IN THE SOFTWARE.
-** 
+**
 ** Except as contained in this notice, the name of Silicon Graphics, Inc. shall not
 ** be used in advertising or otherwise to promote the sale, use or other dealings in
 ** this Software without prior written authorization from Silicon Graphics, Inc.
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include "mesh.h"
 #include "geom.h"
+#include <math.h>
 
 int tesvertLeq( TESSvertex *u, TESSvertex *v )
 {
@@ -258,4 +259,35 @@ void tesedgeIntersect( TESSvertex *o1, TESSvertex *d1,
 		if( z1+z2 < 0 ) { z1 = -z1; z2 = -z2; }
 		v->t = Interpolate( z1, o2->t, z2, d2->t );
 	}
+}
+
+TESSreal inCircle( TESSvertex *v, TESSvertex *v0, TESSvertex *v1, TESSvertex *v2 ) {
+	TESSreal adx, ady, bdx, bdy, cdx, cdy;
+	TESSreal abdet, bcdet, cadet;
+	TESSreal alift, blift, clift;
+
+	adx = v0->s - v->s;
+	ady = v0->t - v->t;
+	bdx = v1->s - v->s;
+	bdy = v1->t - v->t;
+	cdx = v2->s - v->s;
+	cdy = v2->t - v->t;
+
+	abdet = adx * bdy - bdx * ady;
+	bcdet = bdx * cdy - cdx * bdy;
+	cadet = cdx * ady - adx * cdy;
+
+	alift = adx * adx + ady * ady;
+	blift = bdx * bdx + bdy * bdy;
+	clift = cdx * cdx + cdy * cdy;
+
+	return alift * bcdet + blift * cadet + clift * abdet;
+}
+
+/*
+	Returns 1 is edge is locally delaunay
+ */
+int tesedgeIsLocallyDelaunay( TESShalfEdge *e )
+{
+	return inCircle(e->Sym->Lnext->Lnext->Org, e->Lnext->Org, e->Lnext->Lnext->Org, e->Org) < 0;
 }

--- a/thirdparty/libtess2/Source/geom.h
+++ b/thirdparty/libtess2/Source/geom.h
@@ -59,6 +59,7 @@
 
 #define EdgeGoesLeft(e) VertLeq( (e)->Dst, (e)->Org )
 #define EdgeGoesRight(e) VertLeq( (e)->Org, (e)->Dst )
+#define EdgeIsInternal(e) e->Rface && e->Rface->inside
 
 #define ABS(x) ((x) < 0 ? -(x) : (x))
 #define VertL1dist(u,v) (ABS(u->s - v->s) + ABS(u->t - v->t))
@@ -72,5 +73,6 @@ TESSreal	testransEval( TESSvertex *u, TESSvertex *v, TESSvertex *w );
 TESSreal	testransSign( TESSvertex *u, TESSvertex *v, TESSvertex *w );
 int tesvertCCW( TESSvertex *u, TESSvertex *v, TESSvertex *w );
 void tesedgeIntersect( TESSvertex *o1, TESSvertex *d1, TESSvertex *o2, TESSvertex *d2, TESSvertex *v );
+int tesedgeIsLocallyDelaunay( TESShalfEdge *e );
 
 #endif

--- a/thirdparty/libtess2/Source/mesh.c
+++ b/thirdparty/libtess2/Source/mesh.c
@@ -80,6 +80,7 @@ static TESShalfEdge *MakeEdge( TESSmesh* mesh, TESShalfEdge *eNext )
 	e->Lface = NULL;
 	e->winding = 0;
 	e->activeRegion = NULL;
+	e->mark = 0;
 
 	eSym->Sym = e;
 	eSym->Onext = eSym;
@@ -88,6 +89,7 @@ static TESShalfEdge *MakeEdge( TESSmesh* mesh, TESShalfEdge *eNext )
 	eSym->Lface = NULL;
 	eSym->winding = 0;
 	eSym->activeRegion = NULL;
+	eSym->mark = 0;
 
 	return e;
 }
@@ -697,57 +699,132 @@ static int CountFaceVerts( TESSface *f )
 
 int tessMeshMergeConvexFaces( TESSmesh *mesh, int maxVertsPerFace )
 {
-	TESSface *f;
-	TESShalfEdge *eCur, *eNext, *eSym;
-	TESSvertex *vStart;
-	int curNv, symNv;
+	TESShalfEdge *e, *eNext, *eSym;
+	TESShalfEdge *eHead = &mesh->eHead;
+	TESSvertex *va, *vb, *vc, *vd, *ve, *vf;
+	int leftNv, rightNv;
 	
-	for( f = mesh->fHead.next; f != &mesh->fHead; f = f->next )
+	for( e = eHead->next; e != eHead; e = eNext )
 	{
-		// Skip faces which are outside the result.
-		if( !f->inside )
+		eNext = e->next;
+		eSym = e->Sym;
+		if( !eSym )
+			continue;
+		
+		// Both faces must be inside
+		if( !e->Lface || !e->Lface->inside )
+			continue;
+		if( !eSym->Lface || !eSym->Lface->inside )
 			continue;
 
-		eCur = f->anEdge;
-		vStart = eCur->Org;
-			
-		while (1)
-		{
-			eNext = eCur->Lnext;
-			eSym = eCur->Sym;
+		leftNv = CountFaceVerts( e->Lface );
+		rightNv = CountFaceVerts( eSym->Lface );
+		if( (leftNv+rightNv-2) > maxVertsPerFace )
+			continue;
 
-			// Try to merge if the neighbour face is valid.
-			if( eSym && eSym->Lface && eSym->Lface->inside )
-			{
-				// Try to merge the neighbour faces if the resulting polygons
-				// does not exceed maximum number of vertices.
-				curNv = CountFaceVerts( f );
-				symNv = CountFaceVerts( eSym->Lface );
-				if( (curNv+symNv-2) <= maxVertsPerFace )
-				{
-					// Merge if the resulting poly is convex.
-					if( VertCCW( eCur->Lprev->Org, eCur->Org, eSym->Lnext->Lnext->Org ) &&
-						VertCCW( eSym->Lprev->Org, eSym->Org, eCur->Lnext->Lnext->Org ) )
-					{
-						eNext = eSym->Lnext;
-						if( !tessMeshDelete( mesh, eSym ) )
-							return 0;
-						eCur = 0;
-					}
-				}
-			}
-			
-			if( eCur && eCur->Lnext->Org == vStart )
-				break;
-				
-			// Continue to next edge.
-			eCur = eNext;
+		// Merge if the resulting poly is convex.
+		//
+		//      vf--ve--vd
+		//          ^|
+		// left   e ||   right
+		//          |v
+		//      va--vb--vc
+
+		va = e->Lprev->Org;
+		vb = e->Org;
+		vc = e->Sym->Lnext->Dst;
+
+		vd = e->Sym->Lprev->Org;
+		ve = e->Sym->Org;
+		vf = e->Lnext->Dst;
+
+		if( VertCCW( va, vb, vc ) && VertCCW( vd, ve, vf ) ) {
+			if( e == eNext || e == eNext->Sym ) { eNext = eNext->next; }
+			if( !tessMeshDelete( mesh, e ) )
+				return 0;
 		}
 	}
-	
+
 	return 1;
 }
 
+void tessMeshFlipEdge( TESSmesh *mesh, TESShalfEdge *edge )
+{
+	TESShalfEdge *a0 = edge;
+	TESShalfEdge *a1 = a0->Lnext;
+	TESShalfEdge *a2 = a1->Lnext;
+	TESShalfEdge *b0 = edge->Sym;
+	TESShalfEdge *b1 = b0->Lnext;
+	TESShalfEdge *b2 = b1->Lnext;
+
+	TESSvertex *aOrg = a0->Org;
+	TESSvertex *aOpp = a2->Org;
+	TESSvertex *bOrg = b0->Org;
+	TESSvertex *bOpp = b2->Org;
+
+	TESSface *fa = a0->Lface;
+	TESSface *fb = b0->Lface;
+
+	assert(EdgeIsInternal(edge));
+	assert(a2->Lnext == a0);
+	assert(b2->Lnext == b0);
+
+	a0->Org = bOpp;
+	a0->Onext = b1->Sym;
+	b0->Org = aOpp;
+	b0->Onext = a1->Sym;
+	a2->Onext = b0;
+	b2->Onext = a0;
+	b1->Onext = a2->Sym;
+	a1->Onext = b2->Sym;
+
+	a0->Lnext = a2;
+	a2->Lnext = b1;
+	b1->Lnext = a0;
+
+	b0->Lnext = b2;
+	b2->Lnext = a1;
+	a1->Lnext = b0;
+
+	a1->Lface = fb;
+	b1->Lface = fa;
+
+	fa->anEdge = a0;
+	fb->anEdge = b0;
+
+	if (aOrg->anEdge == a0) aOrg->anEdge = b1;
+	if (bOrg->anEdge == b0) bOrg->anEdge = a1;
+
+	assert( a0->Lnext->Onext->Sym == a0 );
+	assert( a0->Onext->Sym->Lnext == a0 );
+	assert( a0->Org->anEdge->Org == a0->Org );
+
+
+	assert( a1->Lnext->Onext->Sym == a1 );
+	assert( a1->Onext->Sym->Lnext == a1 );
+	assert( a1->Org->anEdge->Org == a1->Org );
+
+	assert( a2->Lnext->Onext->Sym == a2 );
+	assert( a2->Onext->Sym->Lnext == a2 );
+	assert( a2->Org->anEdge->Org == a2->Org );
+
+	assert( b0->Lnext->Onext->Sym == b0 );
+	assert( b0->Onext->Sym->Lnext == b0 );
+	assert( b0->Org->anEdge->Org == b0->Org );
+
+	assert( b1->Lnext->Onext->Sym == b1 );
+	assert( b1->Onext->Sym->Lnext == b1 );
+	assert( b1->Org->anEdge->Org == b1->Org );
+
+	assert( b2->Lnext->Onext->Sym == b2 );
+	assert( b2->Onext->Sym->Lnext == b2 );
+	assert( b2->Org->anEdge->Org == b2->Org );
+
+	assert(aOrg->anEdge->Org == aOrg);
+	assert(bOrg->anEdge->Org == bOrg);
+
+	assert(a0->Oprev->Onext->Org == a0->Org);
+}
 
 #ifdef DELETE_BY_ZAPPING
 
@@ -793,7 +870,6 @@ void tessMeshCheckMesh( TESSmesh *mesh )
 	TESSvertex *v, *vPrev;
 	TESShalfEdge *e, *ePrev;
 
-	fPrev = fHead;
 	for( fPrev = fHead ; (f = fPrev->next) != fHead; fPrev = f) {
 		assert( f->prev == fPrev );
 		e = f->anEdge;
@@ -808,7 +884,6 @@ void tessMeshCheckMesh( TESSmesh *mesh )
 	}
 	assert( f->prev == fPrev && f->anEdge == NULL );
 
-	vPrev = vHead;
 	for( vPrev = vHead ; (v = vPrev->next) != vHead; vPrev = v) {
 		assert( v->prev == vPrev );
 		e = v->anEdge;
@@ -823,7 +898,6 @@ void tessMeshCheckMesh( TESSmesh *mesh )
 	}
 	assert( v->prev == vPrev && v->anEdge == NULL );
 
-	ePrev = eHead;
 	for( ePrev = eHead ; (e = ePrev->next) != eHead; ePrev = e) {
 		assert( e->Sym->next == ePrev->Sym );
 		assert( e->Sym != e );

--- a/thirdparty/libtess2/Source/mesh.h
+++ b/thirdparty/libtess2/Source/mesh.h
@@ -143,6 +143,7 @@ struct TESShalfEdge {
 	ActiveRegion *activeRegion;  /* a region with this upper edge (sweep.c) */
 	int winding;    /* change in winding number when crossing
 						  from the right face to the left face */
+	int mark; /* Used by the Edge Flip algorithm */
 };
 
 #define Rface   Sym->Lface
@@ -154,7 +155,6 @@ struct TESShalfEdge {
 #define Rprev   Sym->Onext
 #define Dnext   Rprev->Sym  /* 3 pointers */
 #define Rnext   Oprev->Sym  /* 3 pointers */
-
 
 struct TESSmesh {
 	TESSvertex vHead;      /* dummy header for vertex list */
@@ -257,6 +257,8 @@ TESSmesh *tessMeshUnion( TESSalloc* alloc, TESSmesh *mesh1, TESSmesh *mesh2 );
 int tessMeshMergeConvexFaces( TESSmesh *mesh, int maxVertsPerFace );
 void tessMeshDeleteMesh( TESSalloc* alloc, TESSmesh *mesh );
 void tessMeshZapFace( TESSmesh *mesh, TESSface *fZap );
+
+void tessMeshFlipEdge( TESSmesh *mesh, TESShalfEdge *edge );
 
 #ifdef NDEBUG
 #define tessMeshCheckMesh( mesh )

--- a/thirdparty/libtess2/Source/sweep.c
+++ b/thirdparty/libtess2/Source/sweep.c
@@ -493,7 +493,7 @@ static int CheckForRightSplice( TESStesselator *tess, ActiveRegion *regUp )
 			SpliceMergeVertices( tess, eLo->Oprev, eUp );
 		}
 	} else {
-		if( EdgeSign( eUp->Dst, eLo->Org, eUp->Org ) < 0 ) return FALSE;
+		if( EdgeSign( eUp->Dst, eLo->Org, eUp->Org ) <= 0 ) return FALSE;
 
 		/* eLo->Org appears to be above eUp, so splice eLo->Org into eUp */
 		RegionAbove(regUp)->dirty = regUp->dirty = TRUE;
@@ -1118,15 +1118,14 @@ static void InitEdgeDict( TESStesselator *tess )
 	tess->dict = dictNewDict( &tess->alloc, tess, (int (*)(void *, DictKey, DictKey)) EdgeLeq );
 	if (tess->dict == NULL) longjmp(tess->env,1);
 
-	w = (tess->bmax[0] - tess->bmin[0]);
-	h = (tess->bmax[1] - tess->bmin[1]);
+	/* If the bbox is empty, ensure that sentinels are not coincident by slightly enlarging it. */
+	w = (tess->bmax[0] - tess->bmin[0]) + (TESSreal)0.01;
+	h = (tess->bmax[1] - tess->bmin[1]) + (TESSreal)0.01;
 
-        /* If the bbox is empty, ensure that sentinels are not coincident by
-           slightly enlarging it. */
-	smin = tess->bmin[0] - (w > 0 ? w : 0.01);
-        smax = tess->bmax[0] + (w > 0 ? w : 0.01);
-        tmin = tess->bmin[1] - (h > 0 ? h : 0.01);
-        tmax = tess->bmax[1] + (h > 0 ? h : 0.01);
+	smin = tess->bmin[0] - w;
+    smax = tess->bmax[0] + w;
+    tmin = tess->bmin[1] - h;
+    tmax = tess->bmax[1] + h;
 
 	AddSentinel( tess, smin, smax, tmin );
 	AddSentinel( tess, smin, smax, tmax );

--- a/thirdparty/libtess2/Source/tess.h
+++ b/thirdparty/libtess2/Source/tess.h
@@ -1,5 +1,5 @@
 /*
-** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008) 
+** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
 ** Copyright (C) [dates of first publication] Silicon Graphics, Inc.
 ** All Rights Reserved.
 **
@@ -9,10 +9,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 ** of the Software, and to permit persons to whom the Software is furnished to do so,
 ** subject to the following conditions:
-** 
+**
 ** The above copyright notice including the dates of first publication and either this
 ** permission notice or a reference to http://oss.sgi.com/projects/FreeB/ shall be
-** included in all copies or substantial portions of the Software. 
+** included in all copies or substantial portions of the Software.
 **
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 ** INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -20,7 +20,7 @@
 ** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 ** OR OTHER DEALINGS IN THE SOFTWARE.
-** 
+**
 ** Except as contained in this notice, the name of Silicon Graphics, Inc. shall not
 ** be used in advertising or otherwise to promote the sale, use or other dealings in
 ** this Software without prior written authorization from Silicon Graphics, Inc.
@@ -61,6 +61,9 @@ struct TESStesselator {
 	TESSreal bmin[2];
 	TESSreal bmax[2];
 
+	int processCDT;	/* option to run Constrained Delayney pass. */
+	int reverseContours; /* tessAddContour() will treat CCW contours as CW and vice versa */
+    
 	/*** state needed for the line sweep ***/
 	int	windingRule;	/* rule for determining polygon interior */
 
@@ -71,7 +74,7 @@ struct TESStesselator {
 	struct BucketAlloc* regionPool;
 
 	TESSindex vertexIndexCounter;
-	
+
 	TESSreal *vertices;
 	TESSindex *vertexIndices;
 	int vertexCount;
@@ -79,7 +82,7 @@ struct TESStesselator {
 	int elementCount;
 
 	TESSalloc alloc;
-	
+
 	jmp_buf env;			/* place to jump to when memAllocs fail */
 };
 

--- a/thirdparty/libtess2/alg_outline.md
+++ b/thirdparty/libtess2/alg_outline.md
@@ -223,3 +223,11 @@ triangles into fans and strips.  We do this using a greedy approach.
 The triangulation itself is not optimized to reduce the number of
 primitives; we just try to get a reasonable decomposition of the
 computed triangulation.
+
+Optionally, it's possible to output a Constrained Delaunay Triangulation.
+This is done by doing a delaunay refinement with the normal triangulation as
+a basis. The Edge Flip algorithm is used, which is guaranteed to terminate in O(n^2).
+
+Note: We don't use robust predicates to check if edges are locally
+delaunay, but currently us a naive epsilon of 0.01 radians to ensure
+termination.


### PR DESCRIPTION
I took some time to upgrade the two libraries used by Tulip to render fonts and icons through the OpenGL engine: [ftgl](https://github.com/ulrichard/ftgl) and [libtess2](https://github.com/memononen/libtess2).

Current HEAD of ftgl is https://github.com/ulrichard/ftgl/commit/16f7667cbd4b1e988ae24128c5dea54479926f85
Current HEAD of libtess2 is  https://github.com/memononen/libtess2/commit/56d5c87b596bfe792f79b2e41fde83b769f6406d

Both upgrades come with bugs and memory leaks fixes but also performance improvements.

All CI builds are green (https://ci.appveyor.com/project/anlambert/tulip/builds/21561913, https://travis-ci.org/anlambert/tulip/builds/478471396?utm_source=github_status&utm_medium=notification) so you can safely merge that PR.
