### PR TITLE
Reactivate TravisCI and some improvements related to MacOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -386,15 +386,15 @@ jobs:
       addons:
         homebrew:
           # install Tulip core build dependencies
-	  packages:
-	  - ccache
-	  - cmake
-	  - ninja
-	  - llvm
-	  - qhull
-	  - yajl
-	  - cppunit
-	  - pkg-config
+          packages:
+            - ccache
+            - cmake
+            - ninja
+            - llvm
+            - qhull
+            - yajl
+            - cppunit
+            - pkg-config
 
       env:
         # use system Python 2.7
@@ -526,21 +526,21 @@ jobs:
       addons:
         homebrew:
           # install Tulip complete build dependencies
-	  packages:
-	  - ccache
-	  - cmake
-	  - ninja
-	  - llvm
-	  - qhull
-	  - yajl
-	  - cppunit
-	  - pkg-config
-	  - glew
-	  - freetype
-	  - jpeg
-	  - libpng
-	  - qt5
-	  - quazip
+          packages:
+            - ccache
+            - cmake
+            - ninja
+            - llvm
+            - qhull
+            - yajl
+            - cppunit
+            - pkg-config
+            - glew
+            - freetype
+            - jpeg
+            - libpng
+            - qt5
+            - quazip
 
       install:
         # set columns in terminal, required for curl to work correctly:

--- a/.travis.yml
+++ b/.travis.yml
@@ -395,6 +395,7 @@ jobs:
             - yajl
             - cppunit
             - pkg-config
+          update: true
 
       env:
         # use system Python 2.7
@@ -541,6 +542,7 @@ jobs:
             - libpng
             - qt5
             - quazip
+          update: true
 
       install:
         # set columns in terminal, required for curl to work correctly:
@@ -556,7 +558,7 @@ jobs:
         # create build directory
         - mkdir build && cd build
         # configure Tulip build using cmake
-        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DOpenMP_C_FLAGS=-fopenmp -DOpenMP_CXX_FLAGS=-fopenmp -DCMAKE_PREFIX_PATH=/usr/local/opt/qt -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DSPHINX_EXECUTABLE=$HOME/Library/Python/bin/sphinx-build -DTULIP_BUILD_CORE_ONLY=ON -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON || travis_terminate 1
+        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DOpenMP_C_FLAGS=-fopenmp -DOpenMP_CXX_FLAGS=-fopenmp -DCMAKE_PREFIX_PATH=/usr/local/opt/qt -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DSPHINX_EXECUTABLE=$HOME/Library/Python/bin/sphinx-build -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON || travis_terminate 1
         # compile Tulip using ninja for faster builds
         - ninja -j4 || travis_terminate 1
         - sudo ninja -j4 install || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -316,9 +316,6 @@ jobs:
         - sudo port -N install ninja
         - sudo port -N install qhull
         - sudo port -N install yajl
-        - sudo port -N install autoconf
-        - sudo port -N install automake
-        - sudo port -N install libtool
         - sudo port -N install pkgconfig
         - sudo port -N install cppunit
       env:
@@ -354,6 +351,7 @@ jobs:
         - export PATH=/opt/local/bin:$PATH
         # install Tulip core build dependencies
         - sudo port -N install cmake
+        - sudo port -N install clang-7.0
         - sudo port -N install ccache
         - sudo port -N install ninja
         - sudo port -N install qhull
@@ -368,7 +366,7 @@ jobs:
         # create build directory
         - mkdir build && cd build
         # configure Tulip core build using cmake
-        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON -DTULIP_BUILD_CORE_ONLY=ON || travis_terminate 1
+        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/opt/local/bin/clang-mp-7.0 -DCMAKE_CXX_COMPILER=/opt/local/bin/clang++-mp-7.0 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON -DTULIP_BUILD_CORE_ONLY=ON || travis_terminate 1
         # compile Tulip using ninja for faster builds
         - ninja -j4 || travis_terminate 1
         - sudo ninja -j4 install || travis_terminate 1
@@ -433,16 +431,14 @@ jobs:
         - sudo port -N install ninja
         - sudo port -N install qt59-qtbase
         - sudo port -N install qt59-qttools
-        - sudo port -N install qt59-qtwebengine
+        - sudo port -N install qt59-qtwebkit
+        - sudo port -N install quazip
         - sudo port -N install freetype
         - sudo port -N install glew
         - sudo port -N install libpng
         - sudo port -N install jpeg
         - sudo port -N install qhull
         - sudo port -N install yajl
-        - sudo port -N install autoconf
-        - sudo port -N install automake
-        - sudo port -N install libtool
         - sudo port -N install pkgconfig
         - sudo port -N install cppunit
         - curl -O https://bootstrap.pypa.io/get-pip.py
@@ -483,11 +479,13 @@ jobs:
         - export PATH=/opt/local/bin:$PATH
         # install Tulip complete build dependencies
         - sudo port -N install cmake
+        - sudo port -N install clang-7.0
         - sudo port -N install ccache
         - sudo port -N install ninja
         - sudo port -N install qt5-qtbase
         - sudo port -N install qt5-qttools
-        - sudo port -N install qt5-qtwebengine
+        - sudo port -N install qt5-qtwebkit
+        - sudo port -N install quazip
         - sudo port -N install freetype
         - sudo port -N install glew
         - sudo port -N install libpng
@@ -507,7 +505,7 @@ jobs:
         # create build directory
         - mkdir build && cd build
         # configure Tulip complete build using cmake
-        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON -DZLIB_INCLUDE_DIR=/opt/local/include -DZLIB_LIBRARY_RELEASE=/opt/local/lib/libz.dylib -DPNG_INCLUDE_DIR=/opt/local/include -DPNG_LIBRARY_RELEASE=/opt/local/lib/libpng.dylib -DJPEG_INCLUDE_DIR=/opt/local/include -DJPEG_LIBRARY=/opt/local/lib/libjpeg.dylib
+        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/opt/local/bin/clang-mp-7.0 -DCMAKE_CXX_COMPILER=/opt/local/bin/clang++-mp-7.0 -DCMAKE_INSTALL_PREFIX=$PWD/install -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON -DZLIB_INCLUDE_DIR=/opt/local/include -DZLIB_LIBRARY_RELEASE=/opt/local/lib/libz.dylib -DPNG_INCLUDE_DIR=/opt/local/include -DPNG_LIBRARY_RELEASE=/opt/local/lib/libpng.dylib -DJPEG_INCLUDE_DIR=/opt/local/include -DJPEG_LIBRARY=/opt/local/lib/libjpeg.dylib
         # compile Tulip using ninja for faster builds
         - ninja -j4
         - ninja -j4 install

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ The following dependencies are required to build Tulip:
   * [zlib](http://zlib.net)
   * [libjpeg](https://libjpeg-turbo.org/)
   * [libpng](http://www.libpng.org/pub/png/libpng.html)
-  * [Qt](https://www.qt.io) >= 4.6.0
+  * [Qt](https://www.qt.io) >= 5.0.0
   * [OpenGL](https://www.opengl.org) >= 2.0
   * [GLEW](http://glew.sourceforge.net/) >= 1.4
 
 In order to build the Python components, the following dependencies are needed:
 
   * [Python](https://www.python.org) >= 2.6
-  * [SIP](https://www.riverbankcomputing.com/software/sip/intro) >= 4.19.3
+  * [SIP](https://www.riverbankcomputing.com/software/sip/intro) >= 4.19.12
   (if SIP can not be found or its version does not match the required one, 
   it will be compiled using a copy of its source code in the Tulip tree)
   
@@ -129,7 +129,7 @@ In order to generate the documentation, the following tools must be installed:
 
 If you are a Linux user, all these dependencies can be installed with the package manager of your distribution. 
 
-If you are a MacOS user, we recommend to use [MacPorts](https://www.macports.org/) in order to easily install all these dependencies.
+If you are a MacOS user, we recommend to use [MacPorts](https://www.macports.org/) or [Homebrew](https://brew.sh/) in order to easily install all these dependencies.
 
 If you are a Windows user, we recommend to use [MSYS2](http://www.msys2.org/) as it facilitates a lot the build of Tulip on
 that platform (notably by providing up to date compilers and precompiled dependencies).

--- a/cmake/TulipPython.cmake
+++ b/cmake/TulipPython.cmake
@@ -22,21 +22,21 @@ import sys
 from distutils.sysconfig import get_python_lib
 py_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
 if sys.version_info >= (2, 7):
-for path in site.getsitepackages():
-# check that we select a valid install path
-if path.startswith('${CMAKE_INSTALL_PREFIX}') and py_version in path:
-  # avoid to install in /usr/local when CMAKE_INSTALL_PREFIX is /usr on debian
-  if '${CMAKE_INSTALL_PREFIX}' == '/usr' and '/usr/local' in path:
-    continue
-  print(path)
-  exit()
-print(site.getusersitepackages())
+  for path in site.getsitepackages():
+    # check that we select a valid install path
+    if path.startswith('${CMAKE_INSTALL_PREFIX}') and py_version in path:
+      # avoid to install in /usr/local when CMAKE_INSTALL_PREFIX is /usr on debian
+      if '${CMAKE_INSTALL_PREFIX}' == '/usr' and '/usr/local' in path:
+        continue
+      print(path)
+      exit()
+  print(site.getusersitepackages())
 else:
-path = get_python_lib(1)
-if path.startswith('${CMAKE_INSTALL_PREFIX}') and py_version in path:
-print(path)
-exit()
-print(site.USER_SITE)
+  path = get_python_lib(1)
+  if path.startswith('${CMAKE_INSTALL_PREFIX}') and py_version in path:
+    print(path)
+    exit()
+  print(site.USER_SITE)
 "
                   OUTPUT_VARIABLE TulipPythonModulesInstallDir)
   STRING(REPLACE "\n" "" TulipPythonModulesInstallDir "${TulipPythonModulesInstallDir}")

--- a/library/tulip-gui/src/GlOffscreenRenderer.cpp
+++ b/library/tulip-gui/src/GlOffscreenRenderer.cpp
@@ -123,9 +123,7 @@ void GlOffscreenRenderer::clearScene(bool deleteGlEntities) {
 
 void GlOffscreenRenderer::initFrameBuffers(const bool antialiased) {
 
-#if !defined(__APPLE__) || defined(QT_MAC_USE_COCOA)
   antialiasedFbo = antialiased && QGLFramebufferObject::hasOpenGLFramebufferBlit();
-#endif
 
   if (glFrameBuf != nullptr &&
       (vPWidth != uint(glFrameBuf->width()) || vPHeight != uint(glFrameBuf->height()))) {
@@ -136,7 +134,6 @@ void GlOffscreenRenderer::initFrameBuffers(const bool antialiased) {
   }
 
   if (glFrameBuf == nullptr) {
-#if !defined(__APPLE__) || defined(QT_MAC_USE_COCOA)
     QGLFramebufferObjectFormat fboFmt;
     fboFmt.setAttachment(QGLFramebufferObject::CombinedDepthStencil);
 
@@ -150,11 +147,6 @@ void GlOffscreenRenderer::initFrameBuffers(const bool antialiased) {
     glFrameBuf2 = new QGLFramebufferObject(vPWidth, vPHeight);
   }
 
-#else
-    glFrameBuf =
-        new QGLFramebufferObject(vPWidth, vPHeight, QGLFramebufferObject::CombinedDepthStencil);
-  }
-#endif
 }
 
 void GlOffscreenRenderer::renderScene(const bool centerScene, const bool antialiased) {
@@ -200,14 +192,10 @@ void GlOffscreenRenderer::renderScene(const bool centerScene, const bool antiali
   scene.draw();
   glFrameBuf->release();
 
-#if !defined(__APPLE__) || defined(QT_MAC_USE_COCOA)
-
   if (antialiasedFbo)
     QGLFramebufferObject::blitFramebuffer(
         glFrameBuf2, QRect(0, 0, glFrameBuf2->width(), glFrameBuf2->height()), glFrameBuf,
         QRect(0, 0, glFrameBuf->width(), glFrameBuf->height()));
-
-#endif
 
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();
@@ -244,14 +232,10 @@ void GlOffscreenRenderer::renderExternalScene(GlScene *scene, const bool antiali
   scene->draw();
   glFrameBuf->release();
 
-#if !defined(__APPLE__) || defined(QT_MAC_USE_COCOA)
-
   if (antialiasedFbo)
     QGLFramebufferObject::blitFramebuffer(
         glFrameBuf2, QRect(0, 0, glFrameBuf2->width(), glFrameBuf2->height()), glFrameBuf,
         QRect(0, 0, glFrameBuf->width(), glFrameBuf->height()));
-
-#endif
 
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();

--- a/library/tulip-ogl/include/tulip/OpenGlConfigManager.h
+++ b/library/tulip-ogl/include/tulip/OpenGlConfigManager.h
@@ -26,7 +26,7 @@
 #include <map>
 #include <string>
 
-#define BUFFER_OFFSET(bytes) (static_cast<GLubyte *>(nullptr) + (bytes))
+#define BUFFER_OFFSET(bytes) (reinterpret_cast<GLubyte *>(bytes))
 
 namespace tlp {
 

--- a/library/tulip-ogl/src/TulipFontAwesome.cpp
+++ b/library/tulip-ogl/src/TulipFontAwesome.cpp
@@ -19,7 +19,15 @@
 
 #include <cassert>
 #include <cstring>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 #include <FTLibrary.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #include <tulip/TulipFontAwesome.h>
 #include <tulip/TlpTools.h>

--- a/library/tulip-python/src/CMakeLists.txt
+++ b/library/tulip-python/src/CMakeLists.txt
@@ -3,6 +3,9 @@ IF(SIP_OK)
 
 IF(WIN32)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDLL_TULIP_PYTHON")
+ELSE(WIN32)
+  # to disable deprecated register warnings with Python 2.7.13 headers
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-register")
 ENDIF(WIN32)
 
 INCLUDE_DIRECTORIES(BEFORE ${SIP_INCLUDE_DIR})


### PR DESCRIPTION
I noticed Travis builds were down due to a parsing error of the yml file (tabs are not allowed for indentation in YAML). Apart from that fix, I wanted to submit some improvements regarding MacOS builds, here is a pull request compiling a couple of commits related to the subject.

Notably on Travis, the modern MacOS build based on MacPorts now uses latest upstream clang version (7.0.1) and links against qt-webkit and quazip provided by MacPorts. 

I also fixed some annoying compiler warnings that were polluting the build logs.

A couple of minor improvements and fixes are also introduced.