### PR TITLE
TravisCI: Migrate Linux builds from trusty to xenial 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 # Tulip continuous integration on Linux and Mac OS platforms through TravisCI.
 # Two type of builds are performed by os:
-#  - a "legacy" Tulip build using default system compiler (GCC 4.8 on Linux, clang 3.5 on Mac OS), C++11 standard Qt 5 and Python 2.7
-#  - a "modern" Tulip build using a recent compiler (GCC 7.1 on linux, clang from Xcode10.1 on Mac OS), C++11 standard,
-#    Qt 5.10 on Linux / Qt 5.12 on Mac OS, and Python 3.6 on Linux / Python 2.7 on Mac OS
-# As TravisCI limits build jobs to 45 minutes timeout, we build Tulip in two successive build stages:
+#  - a "legacy" Tulip build using :
+#     * default system compiler (GCC 5.4 on Linux, clang from Xcode7.3 on Mac OS)
+#     * Qt 5.5 on Linux, Qt 5.9 on MacOS
+#     * Python 2.7
+#  - a "modern" Tulip build using:
+#     * recent compiler (GCC 8.1 on Linux, clang 7.0 from MacPorts or Homebrew on Mac OS)
+#     * Qt 5.11 on Linux, Qt 5.12 on MacOS
+#     * Python 3.7 on Linux, Python 2.7 on MacOS
+# As TravisCI limits build job times to 45 minutes, Tulip is built in two successive stages
+# to avoid timeouts (which happened often with MacOs builds):
 #  - a core build with no Tulip OpenGL and Qt components
 #  - a complete build including OpenGL and Qt components
-# The trick is to use travis build cache and ccache to cache already compiled object files between stages
-# and thus not exceeding Travis build timeout limits (which systematically happens 
-# before when compiling Tulip on MacOS with C++11 standard activated).
+# The trick is to use travis build cache and ccache to cache already compiled object
+# files between stages and thus not exceeding Travis build timeout limits
 
 # inform travis that we are building a cpp project
 language: cpp
@@ -26,7 +31,7 @@ jobs:
     - stage: Tulip core build (Linux)
     # legacy Tulip core build on Linux
       os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       cache: ccache
       addons:
@@ -43,19 +48,6 @@ jobs:
             - libpython2.7-dev
             - libcppunit-dev
             - binutils-dev
-            # the dependencies below are not required for a Tulip core build but travis build cache does not work
-            # as expected in the complete build stage that follows (due to cache slug depending on the environment),
-            # so install them anyway
-            - qt5-default
-            - libqt5webkit5-dev
-            - libglew-dev
-            - libpng-dev
-            - libjpeg-dev
-            - libfreetype6-dev
-            - python-pip
-      install:
-        # install sphinx in order to have the same build environment as in the complete build (for cache slug)
-        - sudo pip install sphinx
       env:
         # use Python 2.7
         - PYTHON_EXECUTABLE=/usr/bin/python2.7
@@ -74,49 +66,35 @@ jobs:
     # modern Tulip core build on Linux
     -
       os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       cache: ccache
       addons:
         apt:
-          # we get GCC 7.x and Python 3.6 from external ppas
+          # we get GCC 8.x and Python 3.7 from external ppas
           sources:
             - ubuntu-toolchain-r-test
             - deadsnakes
           # install Tulip build dependencies
           packages:
-            - g++-7
+            - g++-8
             - cmake
             - ccache
             - ninja-build
             - libqhull-dev
             - libyajl-dev
-            - python3.6
-            - libpython3.6-dev
+            - python3.7
+            - libpython3.7-dev
             - libcppunit-dev
             - binutils-dev
-            # the dependencies below are not required for a Tulip core build but travis build cache does not work
-            # as expected in the complete build stage that follows (as cache slug depends on the environment),
-            # so install them anyway
-            - libglew-dev
-            - libpng-dev
-            - libjpeg-dev
-            - libfreetype6-dev
       before_install:
-        # set up external ppa for Qt 5.10.1 not registered in travis
-        - sudo add-apt-repository -y ppa:beineri/opt-qt-5.10.1-trusty
-        # update packages list
-        - sudo apt-get -qy update
-        # force the use of GCC 7
+        # force the use of GCC 8
         - eval "${MATRIX_EVAL}"
-      install:
-        # install Qt 5.10 from external ppa (not required for this build though but needed for travis build cache to work correctly between builds stages)
-        - sudo apt-get -qy install qt510-meta-minimal qt510webengine
       env:
-        # use Python 3.6
-        - PYTHON_EXECUTABLE=/usr/bin/python3.6
+        # use Python 3.7
+        - PYTHON_EXECUTABLE=/usr/bin/python3.7
         # use GCC 7
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
       script:
         # create build directory
         - mkdir build && cd build
@@ -133,9 +111,11 @@ jobs:
     - stage: Tulip complete build (Linux)
       # legacy Tulip complete build on Linux, we also build the documentation in this one
       os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       cache: ccache
+      services:
+        - xvfb
       addons:
         apt:
           # install Tulip build dependencies
@@ -152,7 +132,9 @@ jobs:
             - libcppunit-dev
             - binutils-dev
             - qt5-default
+            - libqt5opengl5-dev
             - libqt5webkit5-dev
+            - libquazip5-dev
             - libglew-dev
             - libpng-dev
             - libjpeg-dev
@@ -163,11 +145,6 @@ jobs:
       env:
         # use Python 2.7
         - PYTHON_EXECUTABLE=/usr/bin/python2.7
-      before_script:
-        # run xvfb to simulate a display (needed to instantiate a QApplication for unit tests)
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - sleep 3 # give xvfb some time to start
       script:
         # create build directory
         - mkdir build && cd build
@@ -183,56 +160,52 @@ jobs:
     # modern Tulip complete build on Linux
     -
       os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       cache: ccache
+      services:
+        - xvfb
       addons:
         apt:
-          # we get GCC 7.x and Python 3.6 from external ppas
+          # we get GCC 8.x, Python 3.7 and Qt 5.11 from external ppas
           sources:
             - ubuntu-toolchain-r-test
             - deadsnakes
+            - sourceline: 'deb http://archive.neon.kde.org/user/ xenial main'
+              key_url: 'http://archive.neon.kde.org/public.key'
           # install Tulip build dependencies
           packages:
-            - g++-7
+            - g++-8
             - cmake
             - ccache
             - ninja-build
             - libqhull-dev
             - libyajl-dev
-            - python3.6
-            - libpython3.6-dev
+            - python3.7
+            - libpython3.7-dev
             - libcppunit-dev
             - binutils-dev
+            - qt5-default
+            - libqt5opengl5-dev
+            - libqt5webkit5-dev
+            - libquazip5-dev
             - libglew-dev
             - libpng-dev
             - libjpeg-dev
             - libfreetype6-dev
       before_install:
-        # set up external ppa for Qt 5.10.1 not registered in travis
-        - sudo add-apt-repository -y ppa:beineri/opt-qt-5.10.1-trusty
-        # update packages list
-        - sudo apt-get -qy update
-        # force the use of GCC 7
+        # force the use of GCC 8
         - eval "${MATRIX_EVAL}"
-      install:
-        # install Qt 5.10 from external ppa
-        - sudo apt-get -qy install qt510-meta-minimal qt510webengine
       env:
-        # use Python 3.6
-        - PYTHON_EXECUTABLE=/usr/bin/python3.6
+        # use Python 3.7
+        - PYTHON_EXECUTABLE=/usr/bin/python3.7
         # use GCC 7
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-      before_script:
-        # run xvfb to simulate a display (needed to instantiate a QApplication for unit tests)
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - sleep 3 # give xvfb some time to start
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
       script:
         # create build directoty
         - mkdir build && cd build
         # configure Tulip complete build using cmake
-        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/qt510/ -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_TESTS=ON -DTULIP_BUILD_DOC=OFF -DTULIP_USE_CCACHE=ON -DTULIP_PYTHON_SITE_INSTALL=ON || travis_terminate 1
+        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_TESTS=ON -DTULIP_BUILD_DOC=OFF -DTULIP_USE_CCACHE=ON -DTULIP_PYTHON_SITE_INSTALL=ON || travis_terminate 1
         # compile Tulip using ninja for faster builds
         - ninja -j4  || travis_terminate 1
         - sudo ninja -j4 install || travis_terminate 1
@@ -332,7 +305,7 @@ jobs:
         - sudo ninja -j4 install || travis_terminate 1
         # run Tulip unit tests
         - ninja runTests
-    
+
     #--------------------------------------------------------------------------------------------------------------------------------------------------------------
     # modern Tulip core build on Mac OS (MacPorts)
     -
@@ -372,7 +345,7 @@ jobs:
         - sudo ninja -j4 install || travis_terminate 1
         # run Tulip unit tests
         - ninja runTests
-    
+
     #--------------------------------------------------------------------------------------------------------------------------------------------------------------
     # modern Tulip core build on Mac OS (Homebrew)
     -
@@ -460,10 +433,10 @@ jobs:
         - ninja runTests || travis_terminate 1
         # build Tulip bundle
         - ninja bundle
-    
+
     #--------------------------------------------------------------------------------------------------------------------------------------------------------------
     # modern Tulip complete build on Mac OS (MacPorts)
-    - 
+    -
       os: osx
       # use xcode10.1 travis image to get a recent clang compiler and qt5 package
       osx_image: xcode10.1
@@ -500,7 +473,7 @@ jobs:
       env:
         # use system Python 2.7
         - PYTHON_EXECUTABLE=/usr/bin/python2.7
-        
+
       script:
         # create build directory
         - mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -375,7 +375,7 @@ jobs:
         # create build directory
         - mkdir build && cd build
         # configure Tulip core build using cmake
-        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DOpenMP_C_FLAGS=-fopenmp -DOpenMP_CXX_FLAGS=-fopenmp -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_CORE_ONLY=ON -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON || travis_terminate 1
+        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_CXX_LIB_NAMES=libomp -DOpenMP_libomp_LIBRARY=libomp -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DTULIP_BUILD_CORE_ONLY=ON -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON || travis_terminate 1
         # compile Tulip using ninja for faster builds
         - ninja -j4 || travis_terminate 1
         - sudo ninja -j4 install || travis_terminate 1
@@ -529,7 +529,7 @@ jobs:
         # create build directory
         - mkdir build && cd build
         # configure Tulip build using cmake
-        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DOpenMP_C_FLAGS=-fopenmp -DOpenMP_CXX_FLAGS=-fopenmp -DCMAKE_PREFIX_PATH=/usr/local/opt/qt -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DSPHINX_EXECUTABLE=$HOME/Library/Python/bin/sphinx-build -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON || travis_terminate 1
+        - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_CXX_LIB_NAMES=libomp -DOpenMP_libomp_LIBRARY=libomp -DCMAKE_PREFIX_PATH=/usr/local/opt/qt -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DSPHINX_EXECUTABLE=$HOME/Library/Python/bin/sphinx-build -DTULIP_BUILD_TESTS=ON -DTULIP_USE_CCACHE=ON || travis_terminate 1
         # compile Tulip using ninja for faster builds
         - ninja -j4 || travis_terminate 1
         - sudo ninja -j4 install || travis_terminate 1

--- a/bundlers/linux/tulip_appimage_centos6_build.sh
+++ b/bundlers/linux/tulip_appimage_centos6_build.sh
@@ -20,42 +20,24 @@ yum -y install devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
 yum -y install zlib-devel qhull-devel
 yum -y install freetype-devel libpng-devel libjpeg-devel glew-devel
 
-# needed for generating the appimage
+# needed for generating the AppImage
 yum -y install fuse fuse-libs
 
+# set USR_LIB (needed to set CMAKE_PREFIX_PATH)
 if [ "$(uname -p)" = "x86_64" ]; then
-
-# install python 2.7 and the corresponding sphinx version
-yum install -y centos-release-scl
-yum install -y python27-python-devel python27-python-sphinx
-# setup python
-source /opt/rh/python27/enable
-# set USR_LIB (needed to set CMAKE_PREFIX_PATH)
-USR_LIB=/usr/lib64
-
+  USR_LIB=/usr/lib64
 else
-
-# download, compile and install Python 2.7 because there is
-# no 32 bit version of centos-release-scl
-yum install -y zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel expat-devel
-wget http://python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz
-tar xf Python-2.7.14.tar.xz
-cd Python-2.7.14
-./configure --prefix=/usr --enable-unicode=ucs4 --enable-shared --enable-optimizations CC="ccache /opt/rh/devtoolset-2/root/usr/bin/gcc" CXX="ccache /opt/rh/devtoolset-2/root/usr/bin/g++"
-make -j4 && make altinstall
-
-# install pip in order to grab the latest sphinx version
-wget https://bootstrap.pypa.io/get-pip.py
-python2.7 get-pip.py
-pip2.7 install sphinx
-
-# set USR_LIB (needed to set CMAKE_PREFIX_PATH)
-USR_LIB=/usr/lib
-
+  USR_LIB=/usr/lib
 fi
 
 # install qt5
 yum install -y qt5-qtbase-devel qt5-qtwebkit-devel
+
+# install Python 3.5 from the IUS Community Project
+wget https://centos6.iuscommunity.org/ius-release.rpm
+rpm -Uvh ius-release*rpm
+yum -y install python35u-devel python35u-pip
+pip3.5 install sphinx
 
 # build and install tulip
 if [ -d /tulip/build ]; then
@@ -63,7 +45,7 @@ if [ -d /tulip/build ]; then
 fi
 mkdir /tulip/build
 cd /tulip/build
-cmake -DCMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install -DCMAKE_PREFIX_PATH=$USR_LIB/qt5 -DTULIP_USE_CCACHE=ON -DTULIP_BUILD_FOR_APPIMAGE=ON ..
+cmake -DCMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install -DCMAKE_PREFIX_PATH=$USR_LIB/qt5 -DPYTHON_EXECUTABLE=/usr/bin/python3.5 -DTULIP_USE_CCACHE=ON -DTULIP_BUILD_FOR_APPIMAGE=ON ..
 make -j4 install
 
 # build a bundle dir suitable for AppImageKit

--- a/plugins/interactor/InteractorAddEdge.cpp
+++ b/plugins/interactor/InteractorAddEdge.cpp
@@ -42,18 +42,18 @@ public:
   InteractorAddEdge(const tlp::PluginContext *)
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_addedge.png", "Add nodes/edges") {
     setPriority(StandardInteractorPriority::AddNodesOrEdges);
-    setConfigurationWidgetText("<h3>Add nodes/edges</h3>To add a node: <b>Mouse left</b> click "
-                               "outside any node.<br/>To add an edge: <b>Mouse left</b> click on "
-                               "the source node,<br/>then <b>Mouse left</b> click on the target "
-                               "node.<br/>Any <b>Mouse left</b> click outside a node before the "
-                               "click on the target node will add an edge bend,<br/><b>Mouse "
-                               "middle</b> click will cancel the current edge construction.");
   }
 
   /**
    * Construct chain of responsibility
    */
   void construct() override {
+    setConfigurationWidgetText("<h3>Add nodes/edges</h3>To add a node: <b>Mouse left</b> click "
+                               "outside any node.<br/>To add an edge: <b>Mouse left</b> click on "
+                               "the source node,<br/>then <b>Mouse left</b> click on the target "
+                               "node.<br/>Any <b>Mouse left</b> click outside a node before the "
+                               "click on the target node will add an edge bend,<br/><b>Mouse "
+                               "middle</b> click will cancel the current edge construction.");
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseNodeBuilder);
     push_back(new MouseEdgeBuilder);

--- a/plugins/interactor/InteractorDeleteElement.cpp
+++ b/plugins/interactor/InteractorDeleteElement.cpp
@@ -38,15 +38,15 @@ public:
   InteractorDeleteElement(const tlp::PluginContext *)
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_del.png", "Delete nodes or edges") {
     setPriority(StandardInteractorPriority::DeleteElement);
-    setConfigurationWidgetText(QString("<h3>Delete nodes or edges</h3>") +
-                               "<b>Mouse left</b> click on an element to delete it.<br/>No "
-                               "deletion confirmation will be asked.");
   }
 
   /**
    * Construct chain of responsibility
    */
   void construct() override {
+    setConfigurationWidgetText(QString("<h3>Delete nodes or edges</h3>") +
+                               "<b>Mouse left</b> click on an element to delete it.<br/>No "
+                               "deletion confirmation will be asked.");
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseElementDeleter);
   }

--- a/plugins/interactor/InteractorEditEdgeBends.cpp
+++ b/plugins/interactor/InteractorEditEdgeBends.cpp
@@ -42,6 +42,12 @@ public:
   InteractorEditEdgeBends(const tlp::PluginContext *)
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_bends.png", "Edit edge bends") {
     setPriority(StandardInteractorPriority::EditEdgeBends);
+  }
+
+  /**
+   * Construct chain of responsibility
+   */
+  void construct() override {
     setConfigurationWidgetText(
         QString("<h3>Edit edge bends</h3>") + "Modify edge bends<br/><br/>" +
         "Select edge: <ul><li>use rectangle selection</li></ul>" +
@@ -56,12 +62,6 @@ public:
         "Delete bend: <ul><li><b>Alt + Mouse left</b> click on a selected bend</li></ul>"
 #endif
     );
-  }
-
-  /**
-   * Construct chain of responsibility
-   */
-  void construct() override {
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseSelector);
     push_back(new MouseEdgeBendEditor);

--- a/plugins/interactor/InteractorGetInformation.cpp
+++ b/plugins/interactor/InteractorGetInformation.cpp
@@ -42,16 +42,16 @@ public:
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_select.png",
                                            "Display node or edge properties") {
     setPriority(StandardInteractorPriority::GetInformation);
-    setConfigurationWidgetText(QString("<h3>Display node or edge properties</h3>") +
-                               "<b>Mouse left click</b> on an element to display its "
-                               "properties.<br/>then <b>Mouse left click</b> on a row to edit the "
-                               "corresponding value.");
   }
 
   /**
    * Construct chain of responsibility
    */
   void construct() override {
+    setConfigurationWidgetText(QString("<h3>Display node or edge properties</h3>") +
+                               "<b>Mouse left click</b> on an element to display its "
+                               "properties.<br/>then <b>Mouse left click</b> on a row to edit the "
+                               "corresponding value.");
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseShowElementInfo);
   }

--- a/plugins/interactor/InteractorNavigation.cpp
+++ b/plugins/interactor/InteractorNavigation.cpp
@@ -41,6 +41,12 @@ public:
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_navigation.png",
                                            "Navigate in graph") {
     setPriority(StandardInteractorPriority::Navigation);
+  }
+
+  /**
+   * Construct chain of responsibility
+   */
+  void construct() override {
     setConfigurationWidgetText(
         QString("<h3>Navigate in graph</h3>") + "3D Navigation in the graph<br/><br/>" +
         "Translation: <ul><li><b>Mouse left</b> down + moves</li><li>or <b>Arrow</b> keys "
@@ -61,12 +67,6 @@ public:
         +
         "Meta node navigation: <ul><li><b>double Mouse left click</b> go inside the metanode</li>" +
         "<li><b>Ctrl + double Mouse left click</b> go outside the metanode</li></ul>");
-  }
-
-  /**
-   * Construct chain of responsibility
-   */
-  void construct() override {
     push_back(new MouseNKeysNavigator);
   }
 

--- a/plugins/interactor/InteractorRectangleZoom.cpp
+++ b/plugins/interactor/InteractorRectangleZoom.cpp
@@ -41,16 +41,16 @@ public:
   InteractorRectangleZoom(const tlp::PluginContext *)
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_zoom.png", "Zoom on rectangle") {
     setPriority(StandardInteractorPriority::ZoomOnRectangle);
-    setConfigurationWidgetText(QString("<h3>Zoom on rectangle</h3>") +
-                               "Zoom on selected rectangle.<br><b>Mouse left</b> down indicates "
-                               "the first corner.<br> <b>Mouse left</b> up indicates the opposite "
-                               "corner.<br> <b>Mouse left Doucle click</b> to center the view.");
   }
 
   /**
    * Construct chain of responsibility
    */
   void construct() override {
+    setConfigurationWidgetText(QString("<h3>Zoom on rectangle</h3>") +
+                               "Zoom on selected rectangle.<br><b>Mouse left</b> down indicates "
+                               "the first corner.<br> <b>Mouse left</b> up indicates the opposite "
+                               "corner.<br> <b>Mouse left Doucle click</b> to center the view.");
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseBoxZoomer);
   }

--- a/plugins/interactor/InteractorSelection.cpp
+++ b/plugins/interactor/InteractorSelection.cpp
@@ -42,6 +42,12 @@ public:
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_selection.png",
                                            "Select nodes/edges in a rectangle") {
     setPriority(StandardInteractorPriority::RectangleSelection);
+  }
+
+  /**
+   * Construct chain of responsibility
+   */
+  void construct() override {
     setConfigurationWidgetText(
         QString("<h3>Selection nodes/edges in a rectangle</h3>") +
         "Draw selection rectangle.<br/><b>Mouse left</b> down indicates the first corner, <b>Mouse "
@@ -53,12 +59,6 @@ public:
         "Add/Remove from selection: <ul><li><b>Alt + Mouse left</b> click</li></ul>" +
 #endif
         "Remove from selection: <ul><li><b>Shift + Mouse</b> click</li></ul>");
-  }
-
-  /**
-   * Construct chain of responsibility
-   */
-  void construct() override {
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseSelector);
   }

--- a/plugins/interactor/InteractorSelectionModifier.cpp
+++ b/plugins/interactor/InteractorSelectionModifier.cpp
@@ -43,6 +43,12 @@ public:
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_move.png",
                                            "Move/Reshape rectangle selection") {
     setPriority(StandardInteractorPriority::RectangleSelectionModifier);
+  }
+
+  /**
+   * Construct chain of responsibility
+   */
+  void construct() override {
     setConfigurationWidgetText(
         QString("<h3>Move/Reshape rectangle selection</h3>") + "Modify selection<br/><br/>" +
         "Resize : <ul><li><b>Mouse left</b> down on triangle + moves</li></ul>" +
@@ -60,12 +66,6 @@ public:
         "right zone</li></ul>" +
         "Align left/right/top/bottom : <ul><li><b>Mouse left</b> click on simple arrow icon in top "
         "right zone</li></ul>");
-  }
-
-  /**
-   * Construct chain of responsibility
-   */
-  void construct() override {
     push_back(new MousePanNZoomNavigator);
     push_back(new MouseSelector);
     push_back(new MouseSelectionEditor);

--- a/plugins/interactor/MouseLassoNodesSelector/MouseLassoNodesSelector.cpp
+++ b/plugins/interactor/MouseLassoNodesSelector/MouseLassoNodesSelector.cpp
@@ -37,11 +37,6 @@ using namespace tlp;
 MouseLassoNodesSelectorInteractor::MouseLassoNodesSelectorInteractor(const tlp::PluginContext *)
     : NodeLinkDiagramComponentInteractor(":/i_lasso.png", "Select nodes in a freehand drawn region",
                                          StandardInteractorPriority::FreeHandSelection) {
-  setConfigurationWidgetText(QString("<h3>Select nodes in a freehand drawn region</h3>") +
-                             "<b>Mouse left</b> down begins the freehand drawing of the selection "
-                             "region,<br/><b>Mouse left</b> up ends the drawing of the "
-                             "region.<br/>All the nodes enclosed in the region are selected and "
-                             "the edges linking them too.");
 }
 
 bool MouseLassoNodesSelectorInteractor::isCompatible(const std::string &viewName) const {
@@ -53,6 +48,11 @@ bool MouseLassoNodesSelectorInteractor::isCompatible(const std::string &viewName
 }
 
 void MouseLassoNodesSelectorInteractor::construct() {
+  setConfigurationWidgetText(QString("<h3>Select nodes in a freehand drawn region</h3>") +
+                             "<b>Mouse left</b> down begins the freehand drawing of the selection "
+                             "region,<br/><b>Mouse left</b> up ends the drawing of the "
+                             "region.<br/>All the nodes enclosed in the region are selected and "
+                             "the edges linking them too.");
   push_back(new MouseLassoNodesSelectorInteractorComponent());
   push_back(new MousePanNZoomNavigator());
 }

--- a/plugins/view/GeographicView/GeographicViewInteractors.cpp
+++ b/plugins/view/GeographicView/GeographicViewInteractors.cpp
@@ -249,15 +249,15 @@ PLUGIN(GeographicViewInteractorNavigation)
 GeographicViewInteractorAddEdges::GeographicViewInteractorAddEdges(const PluginContext *)
     : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_addedge.png", "Add nodes/edges") {
   setPriority(StandardInteractorPriority::AddNodesOrEdges);
+}
+
+void GeographicViewInteractorAddEdges::construct() {
   setConfigurationWidgetText("<h3>Add nodes/edges</h3>To add a node: <b>Mouse left</b> click "
                              "outside any node.<br/>To add an edge: <b>Mouse left</b> click on the "
                              "source node,<br/>then <b>Mouse left</b> click on the target "
                              "node.<br/>Any <b>Mouse left</b> click outside a node before the "
                              "click on the target node will add an edge bend,<br/><b>Mouse "
                              "middle</b> click will cancel the current edge construction.");
-}
-
-void GeographicViewInteractorAddEdges::construct() {
   push_back(new GeographicViewNavigator);
   push_back(new MouseNodeBuilder);
   push_back(new MouseEdgeBuilder);
@@ -276,19 +276,6 @@ PLUGIN(GeographicViewInteractorAddEdges)
 GeographicViewInteractorEditEdgeBends::GeographicViewInteractorEditEdgeBends(const PluginContext *)
     : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_bends", "Edit edge bends") {
   setPriority(StandardInteractorPriority::EditEdgeBends);
-  setConfigurationWidgetText(
-      QString("<h3>Edit edge bends</h3>") + "Modify edge bends<br/><br/>" +
-      "Select edge: <ul><li>use rectangle selection</li></ul>" +
-      "Translate bend: <ul><li><b>Mouse left</b> down on a selected bend + moves</li></ul>" +
-      "Change source node: <ul><li><b>Drag and drop circle on source node</li></ul>" +
-      "Change target node: <ul><li><b>Drag and drop triangle on target node</li></ul>" +
-      "Add bend: <ul><li><b>Double click with mouse left</b> click on the selected edge</li></ul>" +
-#if !defined(__APPLE__)
-      "Delete bend: <ul><li><b>Ctrl + Mouse left</b> click on a selected bend</li></ul>"
-#else
-      "Delete bend: <ul><li><b>Alt + Mouse left</b> click on a selected bend</li></ul>"
-#endif
-  );
 }
 
 void GeographicViewInteractorEditEdgeBends::construct() {

--- a/plugins/view/GeographicView/GeographicViewShowElementInfo.cpp
+++ b/plugins/view/GeographicView/GeographicViewShowElementInfo.cpp
@@ -77,8 +77,6 @@ public:
   GeographicViewInteractorGetInformation(const tlp::PluginContext *)
       : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_select.png",
                                            "Get information on nodes/edges") {
-    setConfigurationWidgetText(QString("<h3>Get information interactor</h3>") +
-                               "<b>Mouse left</b> click on an element to display its properties");
     setPriority(StandardInteractorPriority::GetInformation);
   }
 
@@ -86,6 +84,8 @@ public:
    * Construct chain of responsibility
    */
   void construct() override {
+    setConfigurationWidgetText(QString("<h3>Get information interactor</h3>") +
+                               "<b>Mouse left</b> click on an element to display its properties");
     push_back(new GeographicViewNavigator);
     push_back(new GeographicViewShowElementInfo);
   }

--- a/plugins/view/HistogramView/HistogramInteractors.cpp
+++ b/plugins/view/HistogramView/HistogramInteractors.cpp
@@ -47,6 +47,10 @@ PLUGIN(HistogramInteractorGetInformation)
 
 HistogramInteractorNavigation::HistogramInteractorNavigation(const PluginContext *)
     : HistogramInteractor(":/tulip/gui/icons/i_navigation.png", "Navigate in view") {
+  setPriority(StandardInteractorPriority::Navigation);
+}
+
+void HistogramInteractorNavigation::construct() {
   setConfigurationWidgetText(
       QString("<html><head><title></title></head><body><h3>View navigation interactor</h3>") +
       "<p>This interactor allows to navigate in the histogram view.</p>" +
@@ -62,16 +66,16 @@ HistogramInteractorNavigation::HistogramInteractorNavigation(const PluginContext
       "<b>Shift + Mouse</b> : rotation<br>" + "<b>Key up/down</b> : up/down<br>" +
       "<b>Key left/right</b> : left/right<br>" + "<b>Key page up/down</b> : zoom<br>" +
       "<b>Key insert</b> : rotate<br>" + "</body></html>");
-  setPriority(StandardInteractorPriority::Navigation);
-}
-
-void HistogramInteractorNavigation::construct() {
   push_back(new HistogramViewNavigator);
   push_back(new MouseNKeysNavigator);
 }
 
 HistogramInteractorMetricMapping::HistogramInteractorMetricMapping(const PluginContext *)
     : HistogramInteractor(":/i_histo_color_mapping.png", "Metric Mapping") {
+  setPriority(StandardInteractorPriority::ViewInteractor1);
+}
+
+void HistogramInteractorMetricMapping::construct() {
   setConfigurationWidgetText(
       QString("<html><head><title></title></head><body>") + "<h3>Metric mapping interactor</h3>" +
       "<p>This interactor allows to perform a metric mapping on nodes colors, nodes borders "
@@ -139,11 +143,6 @@ HistogramInteractorMetricMapping::HistogramInteractorMetricMapping(const PluginC
       "<img src=\":/HistoColorMapping.png\" width=\"280\" height=\"260\" border=\"0\" alt=\"\"><br "
       "/>" +
       "</p>" + "</body></html>");
-  setPriority(StandardInteractorPriority::ViewInteractor1);
-}
-
-void HistogramInteractorMetricMapping::construct() {
-
   push_back(new HistogramMetricMapping);
   push_back(new MousePanNZoomNavigator);
 }
@@ -228,13 +227,13 @@ HistogramInteractorGetInformation::HistogramInteractorGetInformation(const tlp::
     : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_select.png",
                                          "Display node or edge properties") {
   setPriority(StandardInteractorPriority::GetInformation);
+}
+
+void HistogramInteractorGetInformation::construct() {
   setConfigurationWidgetText(QString("<h3>Display node or edge properties</h3>") +
                              "<b>Mouse left click</b> on an element to display its "
                              "properties.<br/>then <b>Mouse left click</b> on a row to edit the "
                              "corresponding value.");
-}
-
-void HistogramInteractorGetInformation::construct() {
   push_back(new MousePanNZoomNavigator);
   push_back(new HistogramMouseShowElementInfo);
 }

--- a/plugins/view/ParallelCoordinatesView/ParallelCoordinatesInteractors.cpp
+++ b/plugins/view/ParallelCoordinatesView/ParallelCoordinatesInteractors.cpp
@@ -55,6 +55,10 @@ PLUGIN(InteractorAxisSpacer)
 
 InteractorParallelCoordsSelection::InteractorParallelCoordsSelection(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/tulip/gui/icons/i_selection.png", "Select elements") {
+  setPriority(StandardInteractorPriority::RectangleSelection);
+}
+
+void InteractorParallelCoordsSelection::construct() {
   setConfigurationWidgetText(
       QString("<html><head>") + "<title></title>" + "</head>" + "<body>" +
       "<h3>Elements selection interactor</h3>" +
@@ -74,16 +78,16 @@ InteractorParallelCoordsSelection::InteractorParallelCoordsSelection(const tlp::
       "<p>To reset the current selection, position the mouse cursor so that there is no elements "
       "under it and do a left click" +
       "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::RectangleSelection);
-}
-
-void InteractorParallelCoordsSelection::construct() {
   push_back(new ParallelCoordsElementsSelector);
   push_back(new MousePanNZoomNavigator);
 }
 
 InteractorHighLighter::InteractorHighLighter(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/i_element_highlighter.png", "Highlight elements") {
+  setPriority(StandardInteractorPriority::ViewInteractor1);
+}
+
+void InteractorHighLighter::construct() {
   setConfigurationWidgetText(
       QString("<html><head>") + "<title></title>" + "</head>" + "<body>" +
       "<h3>Elements highlighter interactor</h3>" +
@@ -109,16 +113,17 @@ InteractorHighLighter::InteractorHighLighter(const tlp::PluginContext *)
       "<p>To select the highlighted elements, do a right click in the drawing and choose the "
       "\"Select highlighted elements\" entry in the popup menu which appears.</p>" +
       "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::ViewInteractor1);
-}
 
-void InteractorHighLighter::construct() {
   push_back(new ParallelCoordsElementHighlighter);
   push_back(new MousePanNZoomNavigator);
 }
 
 InteractorAxisSwapper::InteractorAxisSwapper(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/i_axis_swapper.png", "Axis swapper") {
+  setPriority(StandardInteractorPriority::ViewInteractor2);
+}
+
+void InteractorAxisSwapper::construct() {
   setConfigurationWidgetText(
       QString("<html>") + "<head>" + "<title></title>" + "</head>" + "<body>" +
       "<h3>Axis swapper interactor</h3>" +
@@ -130,16 +135,16 @@ InteractorAxisSwapper::InteractorAxisSwapper(const tlp::PluginContext *)
       "the axis. To swap the axis with an other, release the mouse button when a translucent green "
       "rectangle appears around the other axis to swap.</p>" +
       "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::ViewInteractor2);
-}
-
-void InteractorAxisSwapper::construct() {
   push_back(new ParallelCoordsAxisSwapper);
   push_back(new MousePanNZoomNavigator);
 }
 
 InteractorAxisSliders::InteractorAxisSliders(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/i_axis_sliders.png", "Axis sliders") {
+  setPriority(StandardInteractorPriority::ViewInteractor3);
+}
+
+void InteractorAxisSliders::construct() {
   setConfigurationWidgetText(
       QString("<html>") + "<head>" + "<title></title>" + "</head>" + "<body>" +
       "<h3>Axis sliders interactor</h3>" +
@@ -165,16 +170,17 @@ InteractorAxisSliders::InteractorAxisSliders(const tlp::PluginContext *)
       "move automatically to show in which ranges the highlighted data are included on the other "
       "dimensions.</p>" +
       "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::ViewInteractor3);
-}
 
-void InteractorAxisSliders::construct() {
   push_back(new ParallelCoordsAxisSliders);
   push_back(new MousePanNZoomNavigator);
 }
 
 InteractorBoxPlot::InteractorBoxPlot(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/i_axis_boxplot.png", "Axis box plot") {
+  setPriority(StandardInteractorPriority::ViewInteractor4);
+}
+
+void InteractorBoxPlot::construct() {
   setConfigurationWidgetText(
       QString("<html>") + "<head>" + "<title></title>" + "</head>" + "<body>" +
       "<h3>Axis boxplot interactor</h3>" +
@@ -201,10 +207,7 @@ InteractorBoxPlot::InteractorBoxPlot(const tlp::PluginContext *)
       "highlight data</b>. To highlight the data included in the interquartile range, put the "
       "mouse pointer near the median line and the interquartile range will be selected.</p>" +
       "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::ViewInteractor4);
-}
 
-void InteractorBoxPlot::construct() {
   push_back(new ParallelCoordsAxisBoxPlot);
   push_back(new MousePanNZoomNavigator);
 }
@@ -212,6 +215,10 @@ void InteractorBoxPlot::construct() {
 InteractorShowElementInfo::InteractorShowElementInfo(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/tulip/gui/icons/i_select.png",
                                     "Get information on nodes/edges") {
+  setPriority(StandardInteractorPriority::GetInformation);
+}
+
+void InteractorShowElementInfo::construct() {
   setConfigurationWidgetText(QString("<html>") + "<head>" + "<title></title>" + "</head>" +
                              "<body>" + "<h3>Show element properties interactor</h3>" +
                              "<p>This interactor allows to view the properties associated to an "
@@ -219,10 +226,6 @@ InteractorShowElementInfo::InteractorShowElementInfo(const tlp::PluginContext *)
                              "properties of that node/edge using the Element tab of the Graph "
                              "Editor sub-window</p>" +
                              "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::GetInformation);
-}
-
-void InteractorShowElementInfo::construct() {
   push_back(new ParallelCoordsElementShowInfo);
   push_back(new MousePanNZoomNavigator);
 }
@@ -230,6 +233,10 @@ void InteractorShowElementInfo::construct() {
 InteractorAxisSpacer::InteractorAxisSpacer(const tlp::PluginContext *)
     : ParallelCoordinatesInteractor(":/i_axis_spacer.png",
                                     "Modify space between consecutive axis") {
+  setPriority(StandardInteractorPriority::ViewInteractor5);
+}
+
+void InteractorAxisSpacer::construct() {
   setConfigurationWidgetText(
       QString("<html>") + "<head>" + "<title></title>" + "</head>" + "<body>" +
       "<h3>Axis spacer interactor</h3>" +
@@ -242,10 +249,6 @@ InteractorAxisSpacer::InteractorAxisSpacer(const tlp::PluginContext *)
       "<p>The axis postions will also be reset to default when the number of selected dimensions "
       "changes.</p>" +
       "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::ViewInteractor5);
-}
-
-void InteractorAxisSpacer::construct() {
   push_back(new MousePanNZoomNavigator);
   push_back(new ParallelCoordsAxisSpacer());
 }

--- a/plugins/view/PixelOrientedView/PixelOrientedInteractors.cpp
+++ b/plugins/view/PixelOrientedView/PixelOrientedInteractors.cpp
@@ -41,6 +41,10 @@ PLUGIN(PixelOrientedInteractorNavigation)
 
 PixelOrientedInteractorNavigation::PixelOrientedInteractorNavigation(const PluginContext *)
     : PixelOrientedInteractor(":/tulip/gui/icons/i_navigation.png", "Navigate in view") {
+  setPriority(StandardInteractorPriority::Navigation);
+}
+
+void PixelOrientedInteractorNavigation::construct() {
   setConfigurationWidgetText(
       QString("<html><head>") + "<title></title>" + "</head>" + "<body>" +
       "<h3>View navigation interactor</h3>" +
@@ -57,10 +61,6 @@ PixelOrientedInteractorNavigation::PixelOrientedInteractorNavigation(const Plugi
       "<b>Shift + Mouse</b> : rotation<br>" + "<b>Key up/down</b> : up/down<br>" +
       "<b>Key left/right</b> : left/right<br>" + "<b>Key page up/down</b> : zoom<br>" +
       "<b>Key insert</b> : rotate<br>" + "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::Navigation);
-}
-
-void PixelOrientedInteractorNavigation::construct() {
   push_back(new PixelOrientedViewNavigator);
   push_back(new MouseNKeysNavigator);
 }

--- a/plugins/view/SOMView/SOMViewInteractor.cpp
+++ b/plugins/view/SOMView/SOMViewInteractor.cpp
@@ -77,14 +77,14 @@ void SOMViewProperties::construct() {
 SOMViewThreshold::SOMViewThreshold(PluginContext *)
     : SOMViewInteractor(":/i_slider.png", "Threshold Selection") {
   setPriority(StandardInteractorPriority::ViewInteractor1);
+}
+
+void SOMViewThreshold::construct() {
   setConfigurationWidgetText(QString(
       "<H1>Threshold Interactor</H1><p>This interactor is used to select nodes with a value "
       "between those indicated by the two sliders</p><p>Move the each slider to change the "
       "bound.</p><p>Press the Ctrl button to add the new threshold selection to the current "
       "selection. If Ctrl is not pressed the old selection will be replaced</p>"));
-}
-
-void SOMViewThreshold::construct() {
   push_back(new MouseNKeysNavigator());
   push_back(new ThresholdInteractor());
 }

--- a/plugins/view/ScatterPlot2DView/ScatterPlot2DInteractors.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2DInteractors.cpp
@@ -50,6 +50,10 @@ PLUGIN(ScatterPlot2DInteractorGetInformation)
 
 ScatterPlot2DInteractorNavigation::ScatterPlot2DInteractorNavigation(const tlp::PluginContext *)
     : ScatterPlot2DInteractor(":/tulip/gui/icons/i_navigation.png", "Navigate in view") {
+  setPriority(StandardInteractorPriority::Navigation);
+}
+
+void ScatterPlot2DInteractorNavigation::construct() {
   setConfigurationWidgetText(
       QString("<html><head>") + "<title></title>" + "</head>" + "<body>" +
       "<h3>View navigation interactor</h3>" +
@@ -66,10 +70,6 @@ ScatterPlot2DInteractorNavigation::ScatterPlot2DInteractorNavigation(const tlp::
       "<b>Shift + Mouse</b> : rotation<br>" + "<b>Key up/down</b> : up/down<br>" +
       "<b>Key left/right</b> : left/right<br>" + "<b>Key page up/down</b> : zoom<br>" +
       "<b>Key insert</b> : rotate<br>" + "</body>" + "</html>");
-  setPriority(StandardInteractorPriority::Navigation);
-}
-
-void ScatterPlot2DInteractorNavigation::construct() {
   push_back(new ScatterPlot2DViewNavigator);
   push_back(new MouseNKeysNavigator);
 }
@@ -159,13 +159,13 @@ ScatterPlot2DInteractorGetInformation::ScatterPlot2DInteractorGetInformation(
     : NodeLinkDiagramComponentInteractor(":/tulip/gui/icons/i_select.png",
                                          "Display node or edge properties") {
   setPriority(StandardInteractorPriority::GetInformation);
+}
+
+void ScatterPlot2DInteractorGetInformation::construct() {
   setConfigurationWidgetText(QString("<h3>Display node or edge properties</h3>") +
                              "<b>Mouse left click</b> on an element to display its "
                              "properties.<br/>then <b>Mouse left click</b> on a row to edit the "
                              "corresponding value.");
-}
-
-void ScatterPlot2DInteractorGetInformation::construct() {
   push_back(new MousePanNZoomNavigator);
   push_back(new ScatterPlot2DMouseShowElementInfo);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ MACRO(UNIT_TEST)
     SET(NEWPATH "${NEWPATH};${CMAKE_BINARY_DIR}/thirdparty/libtess2;${CMAKE_BINARY_DIR}/thirdparty/OGDF;${CMAKE_BINARY_DIR}/library/tulip-ogdf;${CMAKE_BINARY_DIR}/library/tulip-python/src;$ENV{PATH}")
     STRING(REPLACE "\\;" ";" NEWPATH "${NEWPATH}")
     STRING(REPLACE ";" "\\;" NEWPATH "${NEWPATH}")
+  ELSE(WIN32)
+    SET(NEWPATH "$ENV{PATH}")
   ENDIF(WIN32)
   # add Tulip modules path to PYTHONPATH in order to run the Python tests
   SET(PYTHONPATH "${CMAKE_BINARY_DIR}/library/tulip-python/modules/;${TULIP_PYTHON_ROOT_FOLDER};${TULIPGUI_PYTHON_ROOT_FOLDER};${CMAKE_BINARY_DIR}/thirdparty/sip-${SIP_VERSION_STR}/siplib")


### PR DESCRIPTION
First PR regarding the maintenance of Tulip CI builds.

Now that's Qt4 support has been dropped and Ubuntu xenial is available as base image on TravisCI, I thought is was time to upgrade the Linux builds of Tulip to a more contemporary environment. 

Ubuntu trusty was used as the base image before but it's quite old nowadays for compiling desktop applications (its Qt5 version is 5.2.0 for instance). Migrating the builds to xenial offers updated packages with versions close to those of debian stretch (stable). Il also enables to perform legacy / modern build of Tulip (in terms of compiler, Qt and Python version) with a more concise Travis configuration. Last but not least, it gives more contemporary hints on how to build Tulip on debian based distribution.

The versions of the compilers / dependencies of these updated builds are the following:

- **legacy build:** GCC 5.4, Qt 5.5 and Python 2.7.

- **modern build:** GCC 8.1, Qt 5.11 and Python 3.7.

In order to benefit from a recent Qt5 version, I used the [repository](http://archive.neon.kde.org/) from the [kde neon](https://neon.kde.org/) project allowing to benefit from upstream KDE/Qt software on top of Ubuntu LTS. I also noticed a deadlock when running a unit test with recent Qt5 version, I had to slightly patch some files to remove it.

That PR also fixes the detection of OpenMP with CMake when using clang provided by Homebrew and change the Python version used to build AppImages from 2.7 to 3.5 (Python 2 is close to its [death](https://pythonclock.org/) so Python 3 should be the preferred version to bundle when distributing Tulip).