### PR TITLE
DataSet.sip: Fix memory leak (#82)

### DIFF
--- a/library/tulip-python/bindings/tulip-core/DataSet.sip
+++ b/library/tulip-python/bindings/tulip-core/DataSet.sip
@@ -67,6 +67,7 @@ extern tlp::DataSet* convertPyDictToTlpDataSet(PyObject *dict, tlp::DataSet *ref
       ret = NULL;
       break;
     }
+    delete keyStr;
   }
   enableErrorMessages(true);
   return ret;


### PR DESCRIPTION
Fix a nasty memory leak in Python bindings internals, see issue #82