### PR TITLE
Improve Tulip AppImage GUI look and feel

### DIFF
--- a/bundlers/linux/make_appimage_bundle.sh.in
+++ b/bundlers/linux/make_appimage_bundle.sh.in
@@ -64,7 +64,7 @@ echo "#!/bin/sh" > $APPRUN_FILE
 echo "BUNDLE_DIR=\"\$(dirname \$0)\"" >> $APPRUN_FILE
 echo "export PYTHONHOME=\${BUNDLE_DIR}/usr" >> $APPRUN_FILE
 echo "export TLP_DIR=\${BUNDLE_DIR}/usr/lib" >> $APPRUN_FILE
-echo "\${BUNDLE_DIR}/usr/bin/tulip_perspective -p $PERSPECTIVE -style plastique" >> $APPRUN_FILE
+echo "\${BUNDLE_DIR}/usr/bin/tulip_perspective -p $PERSPECTIVE" >> $APPRUN_FILE
 chmod 755 $APPRUN_FILE
 
 # create desktop file
@@ -102,6 +102,9 @@ mkdir $BUNDLE_USR_DIR/plugins
 cp -v -Rp @QT_PLUGINS_DIR@/imageformats $BUNDLE_USR_DIR/plugins
 if [ -e @QT_PLUGINS_DIR@/platforms ]; then
   cp -v -Rp @QT_PLUGINS_DIR@/platforms $BUNDLE_USR_DIR/plugins
+fi
+if [ -e @QT_PLUGINS_DIR@/platformthemes ]; then
+  cp -v -Rp @QT_PLUGINS_DIR@/platformthemes $BUNDLE_USR_DIR/plugins
 fi
 if [ -e @QT_PLUGINS_DIR@/xcbglintegrations ]; then
   cp -v -Rp @QT_PLUGINS_DIR@/xcbglintegrations $BUNDLE_USR_DIR/plugins
@@ -189,7 +192,7 @@ popd > /dev/null 2>&1
 # tweak OS/ABI header part of libraries (System V instead of Linux)
 for LIB in $(find $BUNDLE_LIB_DIR -name '*.so*')
 do
-  # LIB may be in read only mode, make it writable before stripping it 
+  # LIB may be in read only mode, make it writable before stripping it
   chmod +w $LIB
   strip --strip-unneeded $LIB
 done;


### PR DESCRIPTION
Tulip AppImage GUI was looking sad and quite outdated, see screenshot below:

![image](https://user-images.githubusercontent.com/5493543/54457489-d73cda00-4761-11e9-8324-1e45c78cda03.png)


That PR ensures that Tulip AppImage GUI will look more contemporary (thanks to qt gtk2 platformthemes plugin), see screenshot below:

![image](https://user-images.githubusercontent.com/5493543/54457537-f76c9900-4761-11e9-95d4-c03eebf0c133.png)

You can download a Tulip AppImage including this fix [here](https://bintray.com/tulip-dev/tulip_binaries/download_file?file_path=Tulip-5.3.0-dev-x86_64.AppImage)