### PR TITLE
Code cleanup for PythonCppTypesConverter.cpp

### DIFF
--- a/library/tulip-python/src/PythonCppTypesConverter.cpp
+++ b/library/tulip-python/src/PythonCppTypesConverter.cpp
@@ -265,28 +265,8 @@ PyObject *getPyObjectFromCppObject(const T &cppObject) {
 
 template <typename T>
 T getCppObjectFromPyObject(PyObject *pyObj) {
-  T v;
+  T v {};
   PyObjectToCppObjectConvertor<T> convertor;
-  convertor.convert(pyObj, v);
-  return v;
-}
-
-// specialized the previous template for unsigned long
-// to fix a GCC warning about v being uninitialized
-template <>
-unsigned long getCppObjectFromPyObject(PyObject *pyObj) {
-  unsigned long v = 0;
-  PyObjectToCppObjectConvertor<unsigned long> convertor;
-  convertor.convert(pyObj, v);
-  return v;
-}
-
-// specialized the previous template for long
-// to fix a GCC warning about v being uninitialized
-template <>
-long getCppObjectFromPyObject(PyObject *pyObj) {
-  long v = 0;
-  PyObjectToCppObjectConvertor<long> convertor;
   convertor.convert(pyObj, v);
   return v;
 }


### PR DESCRIPTION
I just found out a cool C++11 feature that I did not know of: [value initialization](https://en.cppreference.com/w/cpp/language/value_initialization). More details can
also be found [here](https://www.developpez.com/index/redirect/70891/Apprendre-l-initialisation-par-valeur-avec-Cplusplus-moderne-un-tutoriel-de-Andrzej-Krzemie-324-ski/).

This immediately rings a bell to me regarding some workarounds introduced a couple of years
ago to fix GCC compilation warnings. That PR removes them in favor of modern C++. 