### PR TITLE
tulip-gui/InteractorConfigWidget: Cosmetic fixes after #76 merge

### DIFF
--- a/library/tulip-gui/designer/InteractorConfigWidget.ui
+++ b/library/tulip-gui/designer/InteractorConfigWidget.ui
@@ -17,6 +17,18 @@
    <string notr="true">#contents { background-color: white; border: 1px solid #C9C9C9; }</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -32,6 +44,12 @@
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QScrollArea" name="scrollAreaDoc">
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">background: white</string>
+         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -40,8 +58,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>372</width>
-            <height>185</height>
+            <width>384</width>
+            <height>213</height>
            </rect>
           </property>
          </widget>
@@ -64,8 +82,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>372</width>
-            <height>185</height>
+            <width>384</width>
+            <height>213</height>
            </rect>
           </property>
          </widget>

--- a/library/tulip-gui/include/tulip/InteractorConfigWidget.h
+++ b/library/tulip-gui/include/tulip/InteractorConfigWidget.h
@@ -27,11 +27,12 @@ namespace Ui {
 class InteractorConfigWidget;
 }
 
+class QShowEvent;
+
 namespace tlp {
 class Interactor;
 
 class InteractorConfigWidget : public QDialog {
-  Q_OBJECT
 
   Ui::InteractorConfigWidget *_ui;
   Interactor *_interactor;
@@ -42,10 +43,10 @@ public:
   bool setWidgets(Interactor *interactor);
   void clearWidgets();
 
-signals:
+  void showEvent(QShowEvent *) override;
 
-public slots:
 };
 
-#endif // INTERACTORCONFIGWIDGET_H
 }
+
+#endif // INTERACTORCONFIGWIDGET_H

--- a/library/tulip-gui/src/CMakeLists.txt
+++ b/library/tulip-gui/src/CMakeLists.txt
@@ -233,7 +233,6 @@ QTX_WRAP_CPP(MOC_SRCS
   ../include/tulip/ShapeDialog.h
   ../include/tulip/ViewActionsManager.h
   ../include/tulip/ViewToolTipAndUrlManager.h
-  ../include/tulip/InteractorConfigWidget.h
 )
 
 QTX_ADD_RESOURCES(RCC_SRCS ../resources/TulipGUIResource.qrc)

--- a/library/tulip-gui/src/InteractorConfigWidget.cpp
+++ b/library/tulip-gui/src/InteractorConfigWidget.cpp
@@ -22,6 +22,7 @@
 
 #include <QScrollArea>
 #include <QLabel>
+#include <QShowEvent>
 
 #include <tulip/TlpQtTools.h>
 #include <tulip/Interactor.h>
@@ -31,6 +32,7 @@ using namespace tlp;
 InteractorConfigWidget::InteractorConfigWidget(QWidget *parent)
     : QDialog(parent), _ui(new Ui::InteractorConfigWidget), _interactor(nullptr) {
   _ui->setupUi(this);
+  resize(500, 600);
 }
 
 InteractorConfigWidget::~InteractorConfigWidget() {
@@ -98,7 +100,7 @@ bool InteractorConfigWidget::setWidgets(Interactor *interactor) {
     hide();
     return false;
   } else {
-    setWindowTitle(tlpStringToQString(interactor->name()));
+    setWindowTitle(tlpStringToQString(interactor->info()));
     // removes widget from the layout to not delete the object and give back parenthood. It is up to
     // the interactor developer to delete its config widget
     if (_interactor != nullptr) {
@@ -133,4 +135,12 @@ bool InteractorConfigWidget::setWidgets(Interactor *interactor) {
     _interactor = interactor;
   }
   return true;
+}
+
+void InteractorConfigWidget::showEvent(QShowEvent *ev) {
+  QDialog::showEvent(ev);
+
+  if (parentWidget())
+    move(parentWidget()->window()->frameGeometry().topLeft() +
+         parentWidget()->window()->rect().center() - rect().center());
 }


### PR DESCRIPTION
Make the interactor config widget great again after recently introduced changes (#76)
 
  - set better windows title
 
  - resinstate white background for the documentation

  - remove dialog margins

  - set a default size in order to get a decent display of the dialog content

  - center the dialog above the Tulip window when displaying it

Before:
![image](https://user-images.githubusercontent.com/5493543/56067908-2dab3180-5d7d-11e9-8900-40883e924f59.png)

After:
![image](https://user-images.githubusercontent.com/5493543/56067928-4582b580-5d7d-11e9-92a5-132136c49fc7.png)

