### PR TITLE
Improve edge extremities icon rendering

### DIFF
--- a/library/tulip-gui/src/TulipItemDelegate.cpp
+++ b/library/tulip-gui/src/TulipItemDelegate.cpp
@@ -290,13 +290,21 @@ QVariant TulipItemDelegate::showEditorDialog(tlp::ElementType elType, tlp::Prope
   if (dlg == nullptr) {
     QString title(
         QString("Set %1 %2").arg(elType == NODE ? "node" : "edge").arg(valid ? "value" : "values"));
+    bool displayPropertyName = true;
+    // adjust dialog title for some view properties
+    if (pi->getName() == "viewShape" && elType == EDGE) {
+      title = "Select an edge shape";
+      displayPropertyName = false;
+    }
     // create a dialog on the fly
     dlg = new QDialog(dialogParent);
     dlg->setWindowTitle(title);
     QVBoxLayout *layout = new QVBoxLayout;
     dlg->setLayout(layout);
     dlg->setMinimumWidth(250);
-    layout->addWidget(new QLabel(pi->getName().c_str()));
+    if (displayPropertyName) {
+      layout->addWidget(new QLabel(pi->getName().c_str()));
+    }
     layout->addWidget(w);
     QDialogButtonBox *buttonBox =
         new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok, Qt::Horizontal);

--- a/library/tulip-gui/src/TulipItemEditorCreators.cpp
+++ b/library/tulip-gui/src/TulipItemEditorCreators.cpp
@@ -738,8 +738,10 @@ QWidget *EdgeExtremityShapeEditorCreator::createWidget(QWidget *parent) const {
     shapes.push_back(std::make_pair(shapeName, pixmap));
   }
 
-  return new ShapeDialog(shapes,
-                         Perspective::instance() ? Perspective::instance()->mainWindow() : parent);
+  ShapeDialog *shapeDialog = new ShapeDialog(shapes,
+      Perspective::instance() ? Perspective::instance()->mainWindow() : parent);
+  shapeDialog->setWindowTitle("Select an edge extremity shape");
+  return shapeDialog;
 }
 
 void EdgeExtremityShapeEditorCreator::setEditorData(QWidget *w, const QVariant &data, bool,

--- a/plugins/glyph/fonticon.cpp
+++ b/plugins/glyph/fonticon.cpp
@@ -324,7 +324,7 @@ public:
 
   EEFontIconGlyph(const tlp::PluginContext *context) : EdgeExtremityGlyph(context) {}
 
-  void draw(edge e, node, const Color &glyphColor, const Color &borderColor, float) override {
+  void draw(edge e, node n, const Color &glyphColor, const Color &borderColor, float) override {
     StringProperty *viewIcon = edgeExtGlGraphInputData->getElementIcon();
     const string &iconName = viewIcon->getEdgeValue(e);
 
@@ -332,7 +332,18 @@ public:
                          edgeExtGlGraphInputData->getElementTexture()->getEdgeValue(e);
     float borderWidth = edgeExtGlGraphInputData->getElementBorderWidth()->getEdgeValue(e);
 
-    glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+    // apply some rotation before rendering the icon in order
+    // to visually encode the edge direction
+    if (edgeExtGlGraphInputData->getGraph()->source(e) == n) {
+      // anchor the bottom of the icon to the source node
+      glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+    } else {
+      // anchor the top of the icon to the target node
+      glRotatef(-90.0f, 0.0f, 0.0f, 1.0f);
+    }
+
+    // icon must be mirrored along its Y axis to get a correct rendering
+    glScalef(-1.0f, 1.0f, 1.0f);
 
     drawIcon(getFontIcon(iconName), glyphColor, borderColor, borderWidth, edgeTexture);
   }


### PR DESCRIPTION
This PR improves the rendering of edge extremities as icons (see #104).

The purpose is to better encode the edge direction through icon rotations.
As interesting icons to use as edge extremities are usually symmetric along
their Y axis, the idea to encode edge direction is to:
- anchor the bottom of the icon to the source node
- anchor the top of the icon to the target node

I have also noted that the icon must also be mirrored along its Y-axis to get
a correct rendering.

For instance, when one wants to use the following fontawesome icons as edge extremities: 
![image](https://user-images.githubusercontent.com/5493543/57096509-bdf1ec00-6d15-11e9-940f-09ed49ea843a.png)
![image](https://user-images.githubusercontent.com/5493543/57096538-d2ce7f80-6d15-11e9-96dd-0c339eb4a1d2.png)

On the following graph:
![image](https://user-images.githubusercontent.com/5493543/57096709-2fca3580-6d16-11e9-8ded-badc731dd7f4.png)


Before that PR, the rendering of edge extremities as icons was the following:
![image](https://user-images.githubusercontent.com/5493543/57097042-f1814600-6d16-11e9-9bef-dc3f673229a0.png)

![image](https://user-images.githubusercontent.com/5493543/57097084-0fe74180-6d17-11e9-8be8-da21e1facb17.png)


After that PR, the rendering of edge extremities as icons is now the following:
![image](https://user-images.githubusercontent.com/5493543/57096853-833c8380-6d16-11e9-811f-fe3dace1150a.png)

![image](https://user-images.githubusercontent.com/5493543/57096921-a830f680-6d16-11e9-8ea5-a8248151f83c.png)

Nevertheless, we should give the user more flexibility to customize edge extremities rendering
as icons. Notably setting different icons for each extremity and enabling to manually specify the
rotations to apply. We should implement those new features for the 5.4.0 release of Tulip.

I also improved some dialog titles related to edge shapes. 
