### PR TITLE
Windows build fixes

### DIFF
--- a/appveyor_msys2.bat
+++ b/appveyor_msys2.bat
@@ -49,6 +49,9 @@ bash -lc "pacman --noconfirm -S --needed --force mingw-w64-%MSYS2_ARCH%-libpng"
 bash -lc "pacman --noconfirm -S --needed --force mingw-w64-%MSYS2_ARCH%-qt5"
 bash -lc "pacman --noconfirm -S --needed --force mingw-w64-%MSYS2_ARCH%-quazip"
 bash -lc "pacman --noconfirm -S --needed --force mingw-w64-%MSYS2_ARCH%-qtwebkit"
+rem Workaround a MSYS2 packaging issue for Qt5
+rem (see https://github.com/msys2/MINGW-packages/issues/5253)
+bash -lc "sed -i -e 's/C:\/building\/msys32/C:\/msys64/g' C:/msys64/mingw64/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake"
 set TULIP_BUILD_DOC=ON
 goto tulip_build
 

--- a/library/tulip-core/include/tulip/Dikjstra.h
+++ b/library/tulip-core/include/tulip/Dikjstra.h
@@ -34,7 +34,7 @@
 
 namespace tlp {
 
-class Dikjstra {
+class TLP_SCOPE Dikjstra {
 public:
   //============================================================
   Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,


### PR DESCRIPTION
A couple of fixes for windows build:
- workaround a packaging issue for Qt5 on MSYS2 that recently broke builds (https://github.com/msys2/MINGW-packages/issues/5253)
- add missing TLP_SCOPE

By the way, there is a nice typo in Tulip source code: it's not Di**kj**stra but [Di**jk**stra](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm), see grep output below:
```
$ grep -ri dikjstra *
library/tulip-core/include/tulip/Dikjstra.h:#ifndef DIKJSTRA_TOOL_H
library/tulip-core/include/tulip/Dikjstra.h:#define DIKJSTRA_TOOL_H
library/tulip-core/include/tulip/Dikjstra.h:class TLP_SCOPE Dikjstra {
library/tulip-core/include/tulip/Dikjstra.h:  Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,
library/tulip-core/include/tulip/Dikjstra.h:  struct DikjstraElement {
library/tulip-core/include/tulip/Dikjstra.h:    DikjstraElement(const double dist = DBL_MAX, const node previous = node(),
library/tulip-core/include/tulip/Dikjstra.h:    bool operator==(const DikjstraElement &b) const {
library/tulip-core/include/tulip/Dikjstra.h:    bool operator!=(const DikjstraElement &b) const {
library/tulip-core/include/tulip/Dikjstra.h:  struct LessDikjstraElement {
library/tulip-core/include/tulip/Dikjstra.h:    bool operator()(const DikjstraElement *const a, const DikjstraElement *const b) const {
library/tulip-core/include/tulip/Dikjstra.h:#endif // DIKJSTRA_H
library/tulip-core/include/tulip/GraphMeasure.h: * Edge weights can be given, Dikjstra's algorithm is then used
library/tulip-core/src/Dikjstra.cpp:#include <tulip/Dikjstra.h>
library/tulip-core/src/Dikjstra.cpp:Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,
library/tulip-core/src/Dikjstra.cpp:  set<DikjstraElement *, LessDikjstraElement> dikjstraTable;
library/tulip-core/src/Dikjstra.cpp:  NodeStaticProperty<DikjstraElement *> mapDik(graph);
library/tulip-core/src/Dikjstra.cpp:    DikjstraElement *tmp;
library/tulip-core/src/Dikjstra.cpp:      tmp = new DikjstraElement(DBL_MAX / 2. + 10., node(), n);
library/tulip-core/src/Dikjstra.cpp:      tmp = new DikjstraElement(0, n, n);
library/tulip-core/src/Dikjstra.cpp:    dikjstraTable.insert(tmp);
library/tulip-core/src/Dikjstra.cpp:  while (!dikjstraTable.empty()) {
library/tulip-core/src/Dikjstra.cpp:    set<DikjstraElement *, LessDikjstraElement>::iterator it = dikjstraTable.begin();
library/tulip-core/src/Dikjstra.cpp:    DikjstraElement &u = *(*it);
library/tulip-core/src/Dikjstra.cpp:    dikjstraTable.erase(it);
library/tulip-core/src/Dikjstra.cpp:        dikjstraTable.erase(dEle);
library/tulip-core/src/Dikjstra.cpp:        dikjstraTable.insert(dEle);
library/tulip-core/src/Dikjstra.cpp:    DikjstraElement *dEle = mapDik[i++];
library/tulip-core/src/Dikjstra.cpp:bool Dikjstra::searchPath(node n, BooleanProperty *result) {
library/tulip-core/src/Dikjstra.cpp:void Dikjstra::internalSearchPaths(node n, BooleanProperty *result) {
library/tulip-core/src/Dikjstra.cpp:bool Dikjstra::searchPaths(node n, BooleanProperty *result) {
library/tulip-core/src/Dikjstra.cpp:bool Dikjstra::ancestors(unordered_map<node, std::list<node> > &result){
library/tulip-core/src/GraphMeasure.cpp:#include <tulip/Dikjstra.h>
library/tulip-core/src/GraphMeasure.cpp:    Dikjstra dikjstra(graph, graph->nodes()[nPos], eWeights, distance, getEdges, &queueNode, &nb_paths);
library/tulip-core/src/GraphTools.cpp:#include <tulip/Dikjstra.h>
library/tulip-core/src/GraphTools.cpp:  Dikjstra dikjstra(graph, src, eWeights, nodeDistance, getEdges);
library/tulip-core/src/GraphTools.cpp:    return dikjstra.searchPath(tgt, result);
library/tulip-core/src/GraphTools.cpp:  return dikjstra.searchPaths(tgt, result);
library/tulip-core/src/CMakeLists.txt:Dikjstra.cpp
plugins/metric/BetweennessCentrality.cpp:#include <tulip/Dikjstra.h>
plugins/metric/BetweennessCentrality.cpp:          computeDikjstra(s,directed,weight,S,P,sigma);
plugins/metric/BetweennessCentrality.cpp:  void computeDikjstra(node s,bool directed, NumericProperty* weight, stack<node>& S,unordered_map<node, list<node>>& P,MutableContainer<int>& sigma){
plugins/metric/BetweennessCentrality.cpp:      Dikjstra dikjstra(graph, s, eWeights, nodeDistance, getEdges, &S, &sigma);
plugins/metric/BetweennessCentrality.cpp:      dikjstra.ancestors(P);
plugins/general/EdgeBundling/Dijkstra.cpp:  set<DijkstraElement *, LessDijkstraElement> dikjstraTable;
plugins/general/EdgeBundling/Dijkstra.cpp:      dikjstraTable.insert(tmp);
plugins/general/EdgeBundling/Dijkstra.cpp:      dikjstraTable.insert(tmp);
plugins/general/EdgeBundling/Dijkstra.cpp:  while (!dikjstraTable.empty()) {
plugins/general/EdgeBundling/Dijkstra.cpp:    set<DijkstraElement *, LessDijkstraElement>::iterator it = dikjstraTable.begin();
plugins/general/EdgeBundling/Dijkstra.cpp:    dikjstraTable.erase(it);
plugins/general/EdgeBundling/Dijkstra.cpp:        dikjstraTable.erase(&dEle);
plugins/general/EdgeBundling/Dijkstra.cpp:        dikjstraTable.insert(&dEle);
plugins/general/EdgeBundling/Dijkstra.h:#ifndef DIKJSTRA_H
plugins/general/EdgeBundling/Dijkstra.h:#define DIKJSTRA_H
plugins/general/EdgeBundling/Dijkstra.h:#endif // DIKJSTRA_H
```