### PR TITLE
Fix typo in Tulip source code: dikjstra -> dijkstra

### DIFF
--- a/library/tulip-core/include/tulip/Dijkstra.h
+++ b/library/tulip-core/include/tulip/Dijkstra.h
@@ -18,8 +18,9 @@
  */
 
 ///@cond DOXYGEN_HIDDEN
-#ifndef DIKJSTRA_TOOL_H
-#define DIKJSTRA_TOOL_H
+#ifndef DIJKSTRA_H
+#define DIJKSTRA_H
+
 #include <vector>
 #include <set>
 #include <stack>
@@ -35,10 +36,10 @@
 
 namespace tlp {
 
-class Dikjstra {
+class Dijkstra {
 public:
   //============================================================
-  Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,
+  Dijkstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,
            NodeStaticProperty<double> &nodeDistance, EDGE_TYPE direction,
            std::stack<node> *qN = nullptr, MutableContainer<int> *nP = nullptr);
   //========================================================
@@ -51,14 +52,14 @@ public:
 private:
   void internalSearchPaths(node n, BooleanProperty *result);
   //=========================================================
-  struct DikjstraElement {
-    DikjstraElement(const double dist = DBL_MAX, const node previous = node(),
+  struct DijkstraElement {
+    DijkstraElement(const double dist = DBL_MAX, const node previous = node(),
                     const node n = node())
         : dist(dist), previous(previous), n(n) {}
-    bool operator==(const DikjstraElement &b) const {
+    bool operator==(const DijkstraElement &b) const {
       return n == b.n;
     }
-    bool operator!=(const DikjstraElement &b) const {
+    bool operator!=(const DijkstraElement &b) const {
       return n != b.n;
     }
     double dist;
@@ -67,8 +68,8 @@ private:
     std::vector<edge> usedEdge;
   };
 
-  struct LessDikjstraElement {
-    bool operator()(const DikjstraElement *const a, const DikjstraElement *const b) const {
+  struct LessDijkstraElement {
+    bool operator()(const DijkstraElement *const a, const DijkstraElement *const b) const {
       if (fabs(a->dist - b->dist) > 1.E-9) {
         return (a->dist < b->dist);
       } else {
@@ -84,6 +85,7 @@ private:
   std::stack<node> *queueNodes;
   MutableContainer<int> *numberOfPaths;
 };
-} // namespace tlp
-#endif // DIKJSTRA_H
+}
+
+#endif // DIJKSTRA_H
 ///@endcond

--- a/library/tulip-core/include/tulip/GraphMeasure.h
+++ b/library/tulip-core/include/tulip/GraphMeasure.h
@@ -125,7 +125,7 @@ TLP_SCOPE unsigned int maxDistance(const Graph *graph, const unsigned int nPos,
  * and store it into distance, (stored value is DBL_MAX for non connected nodes),
  * if direction is set to UNDIRECTED use undirected graph, DIRECTED use directed graph
  * and INV_DIRECTED use reverse directed graph (ie. all edges are reversed)
- * Edge weights can be given, Dikjstra's algorithm is then used
+ * Edge weights can be given, Dijkstra's algorithm is then used
  * (the complexity is then o((m + n)log n)) otherwise
  * all the edge's weight is set to 1. (it uses a bfs thus the complexity is o(m), m = |E|).
  */

--- a/library/tulip-core/src/CMakeLists.txt
+++ b/library/tulip-core/src/CMakeLists.txt
@@ -12,7 +12,7 @@ ConnectedTest.cpp
 ConvexHull.cpp
 DataSet.cpp
 Delaunay.cpp
-Dikjstra.cpp
+Dijkstra.cpp
 DoubleProperty.cpp
 DrawingTools.cpp
 FaceIterator.cpp

--- a/library/tulip-core/src/Dijkstra.cpp
+++ b/library/tulip-core/src/Dijkstra.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include <tulip/Dikjstra.h>
+#include <tulip/Dijkstra.h>
 #include <tulip/LayoutProperty.h>
 #include <tulip/BooleanProperty.h>
 #include <tulip/GraphTools.h>
@@ -26,7 +26,7 @@ using namespace tlp;
 using namespace std;
 
 //============================================================
-Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,
+Dijkstra::Dijkstra(const Graph *const graph, node src, const EdgeStaticProperty<double> &weights,
                    NodeStaticProperty<double> &nd, EDGE_TYPE direction, std::stack<node> *qN,
                    MutableContainer<int> *nP)
     : nodeDistance(nd), queueNodes(qN), numberOfPaths(nP) {
@@ -34,8 +34,8 @@ Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<
   this->graph = graph;
   usedEdges.setAll(false);
   this->src = src;
-  set<DikjstraElement *, LessDikjstraElement> dikjstraTable;
-  NodeStaticProperty<DikjstraElement *> mapDik(graph);
+  set<DijkstraElement *, LessDijkstraElement> dijkstraTable;
+  NodeStaticProperty<DijkstraElement *> mapDik(graph);
   mapDik.setAll(nullptr);
   if (queueNodes)
     while (!queueNodes->empty())
@@ -47,26 +47,26 @@ Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<
 
   unsigned int i = 0;
   for (auto n : graph->nodes()) {
-    DikjstraElement *tmp;
+    DijkstraElement *tmp;
     if (n != src)
       // init all nodes to +inf
-      tmp = new DikjstraElement(DBL_MAX / 2. + 10., node(), n);
+      tmp = new DijkstraElement(DBL_MAX / 2. + 10., node(), n);
     else
       // init starting node to 0
-      tmp = new DikjstraElement(0, n, n);
+      tmp = new DijkstraElement(0, n, n);
 
-    dikjstraTable.insert(tmp);
+    dijkstraTable.insert(tmp);
 
     mapDik[i++] = tmp;
   }
 
   auto getEdges = getEdgesIterator(direction);
 
-  while (!dikjstraTable.empty()) {
+  while (!dijkstraTable.empty()) {
     // select the first element in the list the one with min value
-    set<DikjstraElement *, LessDikjstraElement>::iterator it = dikjstraTable.begin();
-    DikjstraElement &u = *(*it);
-    dikjstraTable.erase(it);
+    set<DijkstraElement *, LessDijkstraElement>::iterator it = dijkstraTable.begin();
+    DijkstraElement &u = *(*it);
+    dijkstraTable.erase(it);
     if (queueNodes)
       queueNodes->push(u.n);
 
@@ -84,12 +84,12 @@ Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<
         // we find a node closer with that path
         dEle->usedEdge.clear();
         //**********************************************
-        dikjstraTable.erase(dEle);
+        dijkstraTable.erase(dEle);
 
         dEle->dist = u.dist + eWeight;
         dEle->previous = u.n;
         dEle->usedEdge.push_back(e);
-        dikjstraTable.insert(dEle);
+        dijkstraTable.insert(dEle);
         if (numberOfPaths)
           numberOfPaths->set(v.id, numberOfPaths->get(u.n.id));
       }
@@ -99,7 +99,7 @@ Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<
   usedEdges.setAll(false);
   i = 0;
   for (auto n : graph->nodes()) {
-    DikjstraElement *dEle = mapDik[i++];
+    DijkstraElement *dEle = mapDik[i++];
     nodeDistance[n] = dEle->dist;
 
     for (auto e : dEle->usedEdge) {
@@ -110,7 +110,7 @@ Dikjstra::Dikjstra(const Graph *const graph, node src, const EdgeStaticProperty<
   }
 }
 //=============================================================================
-bool Dikjstra::searchPath(node n, BooleanProperty *result) {
+bool Dijkstra::searchPath(node n, BooleanProperty *result) {
   bool ok = true;
 
   while (ok) {
@@ -150,7 +150,7 @@ bool Dikjstra::searchPath(node n, BooleanProperty *result) {
   return true;
 }
 //=======================================================================
-void Dikjstra::internalSearchPaths(node n, BooleanProperty *result) {
+void Dijkstra::internalSearchPaths(node n, BooleanProperty *result) {
   result->setNodeValue(n, true);
   for (auto e : graph->getInOutEdges(n)) {
     if (!usedEdges.get(e.id))
@@ -170,7 +170,7 @@ void Dikjstra::internalSearchPaths(node n, BooleanProperty *result) {
   }
 }
 //========================================
-bool Dikjstra::searchPaths(node n, BooleanProperty *result) {
+bool Dijkstra::searchPaths(node n, BooleanProperty *result) {
   internalSearchPaths(n, result);
   if (!result->getNodeValue(src)) {
     result->setAllNodeValue(false);
@@ -182,7 +182,7 @@ bool Dikjstra::searchPaths(node n, BooleanProperty *result) {
 }
 
 //========================================
-bool Dikjstra::ancestors(unordered_map<node, std::list<node>> &result) {
+bool Dijkstra::ancestors(unordered_map<node, std::list<node>> &result) {
   result.clear();
   result[src].push_back(src);
   for (auto n : graph->getNodes()) {

--- a/library/tulip-core/src/GraphMeasure.cpp
+++ b/library/tulip-core/src/GraphMeasure.cpp
@@ -24,7 +24,7 @@
 #include <tulip/GraphMeasure.h>
 #include <tulip/Graph.h>
 #include <tulip/GraphParallelTools.h>
-#include <tulip/Dikjstra.h>
+#include <tulip/Dijkstra.h>
 
 using namespace std;
 using namespace tlp;
@@ -90,7 +90,7 @@ double tlp::maxDistance(const Graph *graph, const unsigned int nPos,
 
   std::stack<node> queueNode;
   MutableContainer<int> nb_paths;
-  Dikjstra dikjstra(graph, graph->nodes()[nPos], eWeights, distance, direction, &queueNode,
+  Dijkstra dijkstra(graph, graph->nodes()[nPos], eWeights, distance, direction, &queueNode,
                     &nb_paths);
   // compute max distance from graph->nodes()[nPos]
   // by taking first reachable node in the queue

--- a/library/tulip-core/src/GraphTools.cpp
+++ b/library/tulip-core/src/GraphTools.cpp
@@ -31,7 +31,7 @@
 #include <tulip/Ordering.h>
 #include <tulip/PlanarConMap.h>
 #include <tulip/GraphParallelTools.h>
-#include <tulip/Dikjstra.h>
+#include <tulip/Dijkstra.h>
 
 #include <queue>
 #include <stack>
@@ -796,11 +796,11 @@ bool selectShortestPaths(const Graph *const graph, node src, node tgt, ShortestP
   }
 
   NodeStaticProperty<double> nodeDistance(graph);
-  Dikjstra dikjstra(graph, src, eWeights, nodeDistance, direction);
+  Dijkstra dijkstra(graph, src, eWeights, nodeDistance, direction);
 
   if (uint(pathType) < ShortestPathType::AllPaths)
-    return dikjstra.searchPath(tgt, result);
-  return dikjstra.searchPaths(tgt, result);
+    return dijkstra.searchPath(tgt, result);
+  return dijkstra.searchPaths(tgt, result);
 }
 
 void markReachableNodes(const Graph *graph, const node startNode, TLP_HASH_MAP<node, bool> &result,
@@ -838,8 +838,8 @@ void computeDijkstra(const Graph *const graph, node src, const EdgeStaticPropert
                      NodeStaticProperty<double> &nodeDistance, EDGE_TYPE direction,
                      unordered_map<node, std::list<node>> &ancestors, std::stack<node> *queueNodes,
                      MutableContainer<int> *numberOfPaths) {
-  Dikjstra dikjstra(graph, src, weights, nodeDistance, direction, queueNodes, numberOfPaths);
-  dikjstra.ancestors(ancestors);
+  Dijkstra dijkstra(graph, src, weights, nodeDistance, direction, queueNodes, numberOfPaths);
+  dijkstra.ancestors(ancestors);
 }
 
 } // namespace tlp

--- a/plugins/general/EdgeBundling/Dijkstra.cpp
+++ b/plugins/general/EdgeBundling/Dijkstra.cpp
@@ -52,7 +52,7 @@ void Dijkstra::initDijkstra(const tlp::Graph *const forbidden, tlp::node srcTlp,
 
   usedEdges.setAll(false);
 
-  set<DijkstraElement *, LessDijkstraElement> dikjstraTable;
+  set<DijkstraElement *, LessDijkstraElement> dijkstraTable;
   set<DijkstraElement *, LessDijkstraElement> focusTable;
 
   mapDik.setAll(0);
@@ -64,7 +64,7 @@ void Dijkstra::initDijkstra(const tlp::Graph *const forbidden, tlp::node srcTlp,
   for (auto n : graph.nodes()) {
     if (n != src) { // init all nodes to +inf
       DijkstraElement *tmp = new DijkstraElement(DBL_MAX / 2. + 10., node(), n);
-      dikjstraTable.insert(tmp);
+      dijkstraTable.insert(tmp);
 
       if (focus[n])
         focusTable.insert(tmp);
@@ -72,7 +72,7 @@ void Dijkstra::initDijkstra(const tlp::Graph *const forbidden, tlp::node srcTlp,
       mapDik[n] = tmp;
     } else { // init starting node to 0
       DijkstraElement *tmp = new DijkstraElement(0, n, n);
-      dikjstraTable.insert(tmp);
+      dijkstraTable.insert(tmp);
       mapDik[n] = tmp;
     }
   }
@@ -80,11 +80,11 @@ void Dijkstra::initDijkstra(const tlp::Graph *const forbidden, tlp::node srcTlp,
   nodeDistance.setAll(DBL_MAX);
   nodeDistance[src] = 0;
 
-  while (!dikjstraTable.empty()) {
+  while (!dijkstraTable.empty()) {
     // select the first element in the list the one with min value
-    set<DijkstraElement *, LessDijkstraElement>::iterator it = dikjstraTable.begin();
+    set<DijkstraElement *, LessDijkstraElement>::iterator it = dijkstraTable.begin();
     DijkstraElement &u = *(*it);
-    dikjstraTable.erase(it);
+    dijkstraTable.erase(it);
 
     if (!focusTable.empty()) {
       set<DijkstraElement *, LessDijkstraElement>::reverse_iterator it = focusTable.rbegin();
@@ -110,7 +110,7 @@ void Dijkstra::initDijkstra(const tlp::Graph *const forbidden, tlp::node srcTlp,
         // we find a node closer with that path
         dEle.usedEdge.clear();
         //**********************************************
-        dikjstraTable.erase(&dEle);
+        dijkstraTable.erase(&dEle);
 
         if (focus[dEle.n]) {
           focusTable.erase(&dEle);
@@ -119,7 +119,7 @@ void Dijkstra::initDijkstra(const tlp::Graph *const forbidden, tlp::node srcTlp,
         dEle.dist = u.dist + eWeight;
         dEle.previous = n;
         dEle.usedEdge.push_back(e);
-        dikjstraTable.insert(&dEle);
+        dijkstraTable.insert(&dEle);
 
         if (focus[dEle.n]) {
           focusTable.insert(&dEle);

--- a/plugins/general/EdgeBundling/Dijkstra.h
+++ b/plugins/general/EdgeBundling/Dijkstra.h
@@ -17,8 +17,9 @@
  *
  */
 
-#ifndef DIKJSTRA_H
-#define DIKJSTRA_H
+#ifndef DIJKSTRA_H
+#define DIJKSTRA_H
+
 #include <vector>
 #include <set>
 #include <climits>
@@ -150,4 +151,4 @@ private:
   }
 };
 
-#endif // DIKJSTRA_H
+#endif // DIJKSTRA_H


### PR DESCRIPTION
Let's show [Dijkstra](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) some respect by not mispelling his name.

Fortunately, the Dijkstra class in tulip-core is part of the private API so this can be merged for Tulip 5.3.1