### PR TITLE
Add directed parameters to SimpleTest based methods and plugins.

### DIFF
--- a/library/tulip-core/include/tulip/SimpleTest.h
+++ b/library/tulip-core/include/tulip/SimpleTest.h
@@ -20,7 +20,7 @@
 #ifndef TULIP_SIMPLETEST_H
 #define TULIP_SIMPLETEST_H
 
-#include <tulip/tuliphash.h>
+#include <unordered_map>
 #include <tulip/Observable.h>
 #include <tulip/Graph.h>
 
@@ -29,8 +29,10 @@ namespace tlp {
 /**
  * @ingroup Checks
  * @brief Performs test to check if a graph is Simple.
- * From Wikipedia: "A simple graph is an undirected graph that has no loops and no more than one
- *edge between any two different vertices."
+ * An undirected graph is simple if it has no loops and no more than one
+ * edge between any unordered pair of vertices.
+ * A directed graph is simple if has no loops and no more than one
+ * edge between any ordered pair of vertices.
  **/
 class TLP_SCOPE SimpleTest : private Observable {
 public:
@@ -38,9 +40,10 @@ public:
    * @brief Checks if the graph is simple (i.e. it contains no self loops or parallel edges).
    *
    * @param graph The graph to check.
+   * @param directed Whether the graph shall be considered directed or not.
    * @return bool True if the graph is simple, false otherwise.
    **/
-  static bool isSimple(const Graph *graph);
+  static bool isSimple(const Graph *graph, const bool directed = false);
 
   /**
    * Makes the graph  simple by removing self loops and parallel edges if any.
@@ -51,9 +54,10 @@ public:
    *
    * @param graph The graph to make simple.
    * @param removed The edges that were removed to make the graph simple.
+   * @param directed Whether the graph shall be considered directed or not.
    * @return void
    **/
-  static void makeSimple(Graph *graph, std::vector<edge> &removed);
+  static void makeSimple(Graph *graph, std::vector<edge> &removed, const bool directed = false);
 
   /**
    * Performs simple test and stores found parallel edges in the multipleEdges vector
@@ -68,10 +72,11 @@ public:
    * @param multipleEdges The parallel edges that need to be removed to make the graph simple.
    *Defaults to 0.
    * @param loops The self loops that need to be removed to make the graph simple. Defaults to 0.
+   * @param directed Whether the graph shall be considered directed or not.
    * @return bool True if the graph is simple, false otherwise.
    **/
   static bool simpleTest(const Graph *graph, std::vector<edge> *multipleEdges = nullptr,
-                         std::vector<edge> *loops = nullptr);
+                         std::vector<edge> *loops = nullptr, const bool directed = false);
 
 private:
   SimpleTest();
@@ -80,14 +85,18 @@ private:
   void deleteResult(Graph *graph);
 
   /**
-   * @brief Singleton instance of this class.
+   * @brief Singleton instance of this class for undirected graphs.
    **/
-  static SimpleTest *instance;
+  static SimpleTest *undirInstance;
+  /**
+   * @brief Singleton instance of this class for directed graphs.
+   **/
+  static SimpleTest *dirInstance;
   /**
    * @brief Stored results for graphs. When a graph is updated, its entry is removed from the
    *hashmap.
    **/
-  TLP_HASH_MAP<const Graph *, bool> resultsBuffer;
+  std::unordered_map<const Graph *, bool> resultsBuffer;
 };
 } // namespace tlp
 #endif

--- a/library/tulip-python/bindings/tulip-core/SimpleTest.sip
+++ b/library/tulip-python/bindings/tulip-core/SimpleTest.sip
@@ -32,37 +32,41 @@ class SimpleTest   {
 
 public: 
 
-  static bool isSimple(tlp::Graph *graph);
+  static bool isSimple(tlp::Graph *graph, bool directed = false);
 %Docstring
-tlp.SimpleTest.isSimple(graph)
+tlp.SimpleTest.isSimple(graph,directed = false)
 
 Returns :const:`True` if the graph is simple (i.e. it contains no self loops or parallel edges),
 :const:`False` otherwise.
 
 :param graph: the graph on which to perform the simple test
 :type graph: :class:`tlp.Graph`
+:param directed: Indicates if the graph should be considered as directed or not
+:type boolean
 :rtype: boolean
 %End  
   
 //===========================================================================================   
   
-  static void makeSimple(tlp::Graph* graph, std::vector<tlp::edge> &removed /Out/) ;
+  static void makeSimple(tlp::Graph* graph, std::vector<tlp::edge> &removed /Out/, bool directed = false) ;
 %Docstring
-tlp.SimpleTest.makeSimple(graph)
+tlp.SimpleTest.makeSimple(graph,directed = false)
 
 Makes the graph  simple by removing self loops and parallel edges if any.
 Returns a list of removed edges.
 
 :param graph: the graph to make simple
 :type graph: :class:`tlp.Graph`
+:param directed: Indicates if the graph should be considered as directed or not
+:type boolean
 :rtype: list of :class:`tlp.edge`
 %End
  
 //===========================================================================================  
  
-  static bool simpleTest(tlp::Graph *graph, std::vector<tlp::edge> *multipleEdges /Out/, std::vector<tlp::edge> *loops /Out/) /TypeHint="Tuple[bool, List[tlp.edge], List[tlp.edge]]"/;
+  static bool simpleTest(tlp::Graph *graph, std::vector<tlp::edge> *multipleEdges /Out/, std::vector<tlp::edge> *loops /Out/, bool directed = false) /TypeHint="Tuple[bool, List[tlp.edge], List[tlp.edge]]"/;
 %Docstring
-tlp.SimpleTest.simpleTest(graph)
+tlp.SimpleTest.simpleTest(graph, bool directed = false)
 
 Performs a simple test and returns a tuple with 3 elements. The first element is a boolean indicating the
 result of the test. The second element is a list of found parallel edges. The third element is a list of
@@ -70,6 +74,8 @@ found self loops.
 
 :param graph: the graph on which to perform the simple test
 :type graph: :class:`tlp.Graph`
+:param directed: Indicates if the graph should be considered as directed or not
+:type boolean
 :rtype: (boolean, list of :class:`tlp.edge`, list of :class:`tlp.edge`)
 %End
 

--- a/plugins/selection/MultipleEdgeSelection.cpp
+++ b/plugins/selection/MultipleEdgeSelection.cpp
@@ -27,12 +27,17 @@ using namespace tlp;
 
 MultipleEdgeSelection::MultipleEdgeSelection(const tlp::PluginContext *context)
     : BooleanAlgorithm(context) {
+  addInParameter<bool>("directed", "Indicates if the graph should be considered as directed or not.", "false");
   addOutParameter<unsigned int>("#edges selected", "The number of multiple edges selected");
 }
 
 bool MultipleEdgeSelection::run() {
+  bool directed = false;
+  if(dataSet)
+    dataSet->get("directed",directed);
+
   vector<edge> multipleEdges;
-  SimpleTest::simpleTest(graph, &multipleEdges);
+  SimpleTest::simpleTest(graph, &multipleEdges,nullptr,directed);
   result->setAllNodeValue(false);
   result->setAllEdgeValue(false);
 

--- a/plugins/selection/MultipleEdgeSelection.h
+++ b/plugins/selection/MultipleEdgeSelection.h
@@ -40,7 +40,7 @@ public:
                     "considered as parallel if they have the same source/origin and the same "
                     "target/destination."
                     "If it exists n edges between two nodes, only n-1 edges will be selected.",
-                    "1.0", "Selection")
+                    "1.1", "Selection")
   MultipleEdgeSelection(const tlp::PluginContext *context);
   bool run() override;
 };

--- a/plugins/test/Simple.cpp
+++ b/plugins/test/Simple.cpp
@@ -23,13 +23,22 @@
 class SimpleTest : public tlp::GraphTest {
 public:
   PLUGININFORMATION("Simple", "Tulip team", "18/04/2012",
-                    "Tests whether a graph is simple or not.<br/>A simple graph is an undirected "
-                    "graph with no loops and no multiple edges.",
-                    "1.0", "Topological Test")
-  SimpleTest(const tlp::PluginContext *context) : tlp::GraphTest(context) {}
+                    "Tests whether a graph is simple or not.<br/>An undirected graph "
+                    "is simple if it has no loops and no more than one "
+                    "edge between any unordered pair of vertices. "
+                    "A directed graph is simple if has no loops and no more than one "
+                    "edge between any ordered pair of vertices.",
+                    "1.1", "Topological Test")
+  SimpleTest(const tlp::PluginContext *context) : tlp::GraphTest(context) {
+    addInParameter<bool>("directed", "Indicates if the graph should be considered as directed or not.", "false");
+  }
 
   bool test() override {
-    return tlp::SimpleTest::isSimple(graph);
+    bool directed = false;
+    if(dataSet){
+      dataSet->get("directed",directed);
+    }
+    return tlp::SimpleTest::isSimple(graph,directed);
   }
 };
 PLUGIN(SimpleTest)
@@ -37,15 +46,22 @@ PLUGIN(SimpleTest)
 class MakeSimple : public tlp::Algorithm {
 public:
   PLUGININFORMATION("Make Simple", "Tulip team", "18/04/2012",
-                    "Makes a graph simple.<br/>A simple "
-                    "graph is an undirected graph with "
-                    "no loops and no multiple edges.",
-                    "1.0", "Topology Update")
-  MakeSimple(const tlp::PluginContext *context) : tlp::Algorithm(context) {}
+                    "Makes a graph simple.<br/>An undirected graph "
+                    "is simple if it has no loops and no more than one "
+                    "edge between any unordered pair of vertices. "
+                    "A directed graph is simple if has no loops and no more than one "
+                    "edge between any ordered pair of vertices.",
+                    "1.1", "Topology Update")
+  MakeSimple(const tlp::PluginContext *context) : tlp::Algorithm(context) {
+    addInParameter<bool>("directed", "Indicates if the graph should be considered as directed or not.", "false");
+  }
 
   bool run() override {
+    bool directed = false;
+    if(dataSet)
+      dataSet->get("directed",directed);
     std::vector<tlp::edge> edges;
-    tlp::SimpleTest::makeSimple(graph, edges);
+    tlp::SimpleTest::makeSimple(graph, edges, directed);
     return true;
   }
 };


### PR DESCRIPTION
The goal of this PR is to add more flexibility for handling directed graphs. I focus here on testing whether a graph is "simple" or not and the selection/removal of multiples edges.

In the current version, Simple tests and multiple edges selection is only defined for undirected graphs. While it is true than "being simple" is theoretically only defined for undirected graphs, testing if multiple arcs a->b exist would be a nice feature to have in Tulip. Right now, we need to write a python script in order to do so while the functionality is pretty basic.  

### Detailed changes:

- Class `SimpleTest`: add a `directed` parameters (with default value `false`) to member function `isSimple`, `makeSimple` and `SimpleTest`. Since this class is a singleton that save previous test in a map, we now have two singletons (for directed and undirected graphs). Therefore both the directed and undirected test can be saved for a same graph.  
Also use `std::unordered_map` instead of `TLP_HASH_MAP`. Update documentation. Update the python binding in SimpleTest.sip.

- Plugin `Simple`: add a InParameter `directed` (with default value `false`) to the plugin. Switch to version 1.1. Update documentation.

- Plugin `Multiple Edges Selection`: add a InParameter `directed` (with default value `false`) to the plugin. Switch to version 1.1. Update documentation.

The changes preserve backward compatibility.

As possible future feature, we could think of a way to modify the graph properties when making the graph simple. For instance, one could sum of (or take the max of, take the min of, aggregate in a VectorProperty etc.) the values of properties for parallel edges. The only edge left would have the result of this computation as value. This is what is possible for example in the python/R library igraph (function [simplify](https://igraph.org/r/doc/simplify.html) ). This approach would however requires a lot of GUI modifications. Or maybe we could provide those features only. as python bindings. 

One the other hand, we could consider that thoses features should be considered as Data Import features. Maybe a good approach would be to add thoses features (making the graph simple with custom aggregation of Nodes/Edges properties) in the CSV Import. Let me know what you think !
 