### PR TITLE
tulip-python: Add int tuples support for layout and size properties

### DIFF
--- a/doc/python/apichanges.rst
+++ b/doc/python/apichanges.rst
@@ -3,6 +3,36 @@
 Release notes and API changes
 =============================
 
+Tulip-Python 5.3.1
+------------------
+
+API improvements
+^^^^^^^^^^^^^^^^
+
+Values for graph properties of type :class:`tlp.ColorProperty`, :class:`tlp.LayoutProperty` and
+:class:`tlp.SizeProperty` can be set using tuples since Tulip-Python 5.1. But some restrictions
+regarding the types they should contain was making this feature confusing to use. In particular,
+trying to set a node value for a :class:`tlp.LayoutProperty` or a :class:`tlp.SizeProperty`
+using a tuple filled with ``int`` was raising an error as a tuple only filled with ``float``
+was expected.
+
+These type restrictions have been removed and you can now safely write::
+
+  viewLayout = graph.getLayoutProperty('viewLayout')
+  viewLayout[n] = (0, 0)
+  viewLayout[n] = (10.5, 0, 1.5)
+
+  viewSize = graph.getSizeProperty('viewSize')
+  viewSize[n] = (2, 2)
+  viewSize[n] = (1.5, 1, 1)
+
+  # or even shorter
+  graph['viewLayout'][n] = (0, 0)
+  graph['viewLayout'][n] = (10.5, 0, 1.5)
+
+  graph['viewSize'][n] = (2, 2)
+  graph['viewSize'][n] = (1.5, 1, 1)
+
 Tulip-Python 5.2
 -----------------
 

--- a/library/tulip-python/bindings/tulip-core/Module.sip
+++ b/library/tulip-python/bindings/tulip-core/Module.sip
@@ -187,21 +187,32 @@ extern bool isTupleAndCanConvertToVec3fType(PyObject *pyObj);
 template <typename VEC_TYPE>
 VEC_TYPE *convertToVec3fType(PyObject *pyObj, float zVal = 0) {
   float x = 0, y = 0, z = zVal;
+  long xl = 0, yl = 0, zl = 0;
+  double xd = 0, yd = 0, zd = 0;
 
   bool isList = PyList_Check(pyObj);
 
-  PyObject *f = PyNumber_Float(isList ? PyList_GET_ITEM(pyObj, 0) : PyTuple_GET_ITEM(pyObj, 0));
-  x = float(PyFloat_AsDouble(f));
-  Py_XDECREF(f);
+  PyObject *f = isList ? PyList_GET_ITEM(pyObj, 0) : PyTuple_GET_ITEM(pyObj, 0);
+  if (convertPyObjectToLong(f, xl)) {
+    x = float(xl);
+  } else if (convertPyObjectToDouble(f, xd)) {
+    x = float(xd);
+  }
 
-  f = PyNumber_Float(isList ? PyList_GET_ITEM(pyObj, 1) : PyTuple_GET_ITEM(pyObj, 1));
-  y = float(PyFloat_AsDouble(f));
-  Py_XDECREF(f);
+  f = isList ? PyList_GET_ITEM(pyObj, 1) : PyTuple_GET_ITEM(pyObj, 1);
+  if (convertPyObjectToLong(f, yl)) {
+    y = float(yl);
+  } else if (convertPyObjectToDouble(f, yd)) {
+    y = float(yd);
+  }
 
   if ((isList && PyList_GET_SIZE(pyObj) > 2) || PyTuple_GET_SIZE(pyObj) > 2) {
-    f = PyNumber_Float(isList ? PyList_GET_ITEM(pyObj, 2) : PyTuple_GET_ITEM(pyObj, 2));
-    z = float(PyFloat_AsDouble(f));
-    Py_XDECREF(f);
+    f = isList ? PyList_GET_ITEM(pyObj, 2) : PyTuple_GET_ITEM(pyObj, 2);
+    if (convertPyObjectToLong(f, zl)) {
+      z = float(zl);
+    } else if (convertPyObjectToDouble(f, zd)) {
+      z = float(zd);
+    }
   }
 
   return new VEC_TYPE(x, y, z);
@@ -321,7 +332,18 @@ bool isTupleAndCanConvertToVec3fType(PyObject *pyObj) {
 
   for (SIP_SSIZE_T i = 0; i < PyTuple_GET_SIZE(pyObj); ++i) {
     PyObject *item = PyTuple_GET_ITEM(pyObj, i);
-    if (PyBool_Check(item) || !PyFloat_Check(item)) {
+    bool canConvert = false;
+#if PY_MAJOR_VERSION >= 3
+    if (!PyBool_Check(item) && PyLong_Check(item)) {
+#else
+    if (!PyBool_Check(item) && (PyLong_Check(item) || PyInt_Check(item))) {
+#endif
+      canConvert = canConvert || true;
+    }
+    if (!PyBool_Check(item) && PyFloat_Check(item)) {
+      canConvert = canConvert || true;
+    }
+    if (!canConvert) {
       return false;
     }
   }

--- a/library/tulip-python/bindings/tulip-core/PropertyProxy.sip
+++ b/library/tulip-python/bindings/tulip-core/PropertyProxy.sip
@@ -529,10 +529,21 @@ public:
   }
 %End
 
- void __setitem__(const tlp::node n, const tlp::Coord &val);
+ void __setitem__(const tlp::node n, const tlp::Coord &val /GetWrapper/);
 %MethodCode
   if (sipCpp->getGraph()->isElement(*a0)) {
-    sipCpp->setNodeValue(*a0, *a1);
+    // when a tuple is provided as input, constrain its elements to float type
+    // for creating a layout property otherwise create a color property
+    const sipTypeDef *sipType = sipFindType("tlp::Color");
+    if (sipCanConvertToType(a1Wrapper, sipType, SIP_NOT_NONE)) {
+      int state=0, err=0;
+      void *cppType = sipConvertToType(a1Wrapper, sipType, Py_None, SIP_NOT_NONE, &state, &err);
+      tlp::Color *c = new tlp::Color(*static_cast<tlp::Color*>(cppType));
+      sipCpp->setNodeValue(*a0, *c);
+      delete c;
+    } else {
+      sipCpp->setNodeValue(*a0, *a1);
+    }
   } else {
     sipIsErr = throwInvalidNodeException(sipCpp->getGraph(), *a0);
   }
@@ -592,10 +603,22 @@ void __setitem__(const tlp::node n, const std::vector<int> &val /Constrained/);
   }
 %End
 
-  void __setitem__(const tlp::node n, const std::vector<tlp::Coord> &val);
+  void __setitem__(const tlp::node n, const std::vector<tlp::Coord> &val /GetWrapper/);
 %MethodCode
   if (sipCpp->getGraph()->isElement(*a0)) {
-    sipCpp->setNodeValue(*a0, *a1);
+    // when a list of tuples is provided as input, constrain tuples elements to float type
+    // for creating a coord vector property otherwise create a color vector property
+    const sipTypeDef *sipType = sipFindType("std::vector<tlp::Color>");
+    if (sipCanConvertToType(a1Wrapper, sipType, SIP_NOT_NONE)) {
+      int state=0, err=0;
+      void *cppType = sipConvertToType(a1Wrapper, sipType, Py_None, SIP_NOT_NONE, &state, &err);
+      std::vector<tlp::Color> *vc =
+        new std::vector<tlp::Color>(*static_cast<std::vector<tlp::Color>*>(cppType));
+      sipCpp->setNodeValue(*a0, *vc);
+      delete vc;
+    } else {
+      sipCpp->setNodeValue(*a0, *a1);
+    }
   } else {
     sipIsErr = throwInvalidNodeException(sipCpp->getGraph(), *a0);
   }
@@ -768,9 +791,20 @@ void __setitem__(const tlp::node n, const std::vector<int> &val /Constrained/);
   sipCpp->setAllNodeValue(*a0);
 %End
 
-  void setAllNodeValue(const tlp::Coord &val);
+  void setAllNodeValue(const tlp::Coord &val /GetWrapper/);
 %MethodCode
-  sipCpp->setAllNodeValue(*a0);
+  // when a tuple is provided as input, constrain its elements to float type
+  // for creating a layout property otherwise create a color property
+  const sipTypeDef *sipType = sipFindType("tlp::Color");
+  if (sipCanConvertToType(a0Wrapper, sipType, SIP_NOT_NONE)) {
+    int state=0, err=0;
+    void *cppType = sipConvertToType(a0Wrapper, sipType, Py_None, SIP_NOT_NONE, &state, &err);
+    tlp::Color *c = new tlp::Color(*static_cast<tlp::Color*>(cppType));
+    sipCpp->setAllNodeValue(*c);
+    delete c;
+  } else {
+    sipCpp->setAllNodeValue(*a0);
+  }
 %End
 
   void setAllNodeValue(const tlp::Color &val);
@@ -803,9 +837,21 @@ void __setitem__(const tlp::node n, const std::vector<int> &val /Constrained/);
   sipCpp->setAllNodeValue(*a0);
 %End
 
-  void setAllNodeValue(const std::vector<tlp::Coord> &val);
+  void setAllNodeValue(const std::vector<tlp::Coord> &val /GetWrapper/);
 %MethodCode
-  sipCpp->setAllNodeValue(*a0);
+  // when a list of tuples is provided as input, constrain tuples elements to float type
+  // for creating a coord vector property otherwise create a color vector property
+  const sipTypeDef *sipType = sipFindType("std::vector<tlp::Color>");
+  if (sipCanConvertToType(a0Wrapper, sipType, SIP_NOT_NONE)) {
+    int state=0, err=0;
+    void *cppType = sipConvertToType(a0Wrapper, sipType, Py_None, SIP_NOT_NONE, &state, &err);
+    std::vector<tlp::Color> *vc =
+      new std::vector<tlp::Color>(*static_cast<std::vector<tlp::Color>*>(cppType));
+    sipCpp->setAllNodeValue(*vc);
+    delete vc;
+  } else {
+    sipCpp->setAllNodeValue(*a0);
+  }
 %End
 
   void setAllNodeValue(const std::vector<tlp::Color> &val);
@@ -886,7 +932,7 @@ void setAllNodeValue(SIP_PYOBJECT val);
   sipCpp->setAllEdgeValue(*a0);
 %End
 
-void setAllEdgeValue(SIP_PYOBJECT val);
+  void setAllEdgeValue(SIP_PYOBJECT val);
 %MethodCode
   std::string pythonType(a0->ob_type->tp_name);
   std::string errMsg = "Error : unable to create a graph property for Python type '" + pythonType + "'.";

--- a/tests/python/test_graph_properties.py
+++ b/tests/python/test_graph_properties.py
@@ -53,6 +53,9 @@ def random_coord():
 def random_coord_tuple():
   return (rand_c_float(), rand_c_float(), rand_c_float())
 
+def random_coord_tuple_int():
+  return (rand_int(), rand_int(), rand_int())
+
 def random_size():
   return tlp.Size(rand_c_float(), rand_c_float(), rand_c_float())
 
@@ -80,6 +83,10 @@ def random_coord_list():
 def random_coord_tuple_list():
   size = random.randint(1, max_list_size)
   return [random_coord_tuple() for i in range(size)]
+
+def random_coord_tuple_int_list():
+  size = random.randint(1, max_list_size)
+  return [random_coord_tuple_int() for i in range(size)]
 
 def random_double_list():
   size = random.randint(1, max_list_size)
@@ -110,14 +117,15 @@ class TestGraphProperties(unittest.TestCase):
     self.sub_graph = self.graph.inducedSubGraph(sg_nodes)
 
   def tearDown(self):
-    self.graph.delLocalProperty(self.prop_name)
+    if self.graph.existProperty(self.prop_name):
+        self.graph.delLocalProperty(self.prop_name)
     self.prop = None
     self.graph = None
     self.n = None
     self.e = None
 
-  def generic_property_test(self, prop_type, node_default_value, edge_defaul_value,
-                            node_value, edge_value):
+  def generic_property_test(self, prop_type, node_default_value, edge_default_value,
+                            node_value, edge_value, check_type_inference = True):
     # test some basic operations on property
     self.assertTrue(self.graph.existProperty(self.prop_name))
     self.assertTrue(isinstance(self.graph.getProperty(self.prop_name), prop_type))
@@ -142,27 +150,30 @@ class TestGraphProperties(unittest.TestCase):
       else:
         self.assertEqual(self.prop[n], node_default_value)
 
-    self.prop.setAllEdgeValue(edge_defaul_value)
+    self.prop.setAllEdgeValue(edge_default_value)
     self.prop.setValueToGraphEdges(edge_value, self.sub_graph)
     for e in self.graph.getEdges():
       if self.sub_graph.isElement(e):
         self.assertEqual(self.prop[e], edge_value)
       else:
-        self.assertEqual(self.prop[e], edge_defaul_value)
+        self.assertEqual(self.prop[e], edge_default_value)
 
     # ensure that an exception is correctly thrown when the property is deleted from the C++ layer
     # but there is still a reference to it in the Python one
     self.graph.delLocalProperty(self.prop_name)
     self.assertFalse(self.graph.existProperty(self.prop_name))
     with self.assertRaisesRegexp(RuntimeError, 'wrapped C/C\+\+ object .* has been deleted'):
-     self.prop.setAllEdgeValue(edge_defaul_value)
+     self.prop.setAllEdgeValue(edge_default_value)
+
+    if not check_type_inference:
+        return
 
     # test that the property can be automatically created by type inference
     self.graph[self.prop_name][self.graph.getRandomNode()] = node_value
     self.prop = self.graph[self.prop_name]
     self.assertTrue(isinstance(self.graph.getProperty(self.prop_name), prop_type))
     self.assertTrue(self.graph.existProperty(self.prop_name))
-    
+
 
   def test_boolean_property(self):
     self.prop = self.graph.getBooleanProperty(self.prop_name)
@@ -171,97 +182,121 @@ class TestGraphProperties(unittest.TestCase):
 
   def test_color_property(self):
     self.prop = self.graph.getColorProperty(self.prop_name)
-    self.generic_property_test(tlp.ColorProperty, random_color(), random_color(), 
+    self.generic_property_test(tlp.ColorProperty, random_color(), random_color(),
                                random_color(), random_color())
 
   def test_color_property_tuple(self):
     self.prop = self.graph.getColorProperty(self.prop_name)
-    self.generic_property_test(tlp.ColorProperty, random_color_tuple(), random_color_tuple(), 
+    self.generic_property_test(tlp.ColorProperty, random_color_tuple(), random_color_tuple(),
                                random_color_tuple(), random_color_tuple())
 
-    
+
   def test_double_property(self):
     self.prop = self.graph.getDoubleProperty(self.prop_name)
-    self.generic_property_test(tlp.DoubleProperty, rand_float(), rand_float(), 
+    self.generic_property_test(tlp.DoubleProperty, rand_float(), rand_float(),
                                rand_float(), rand_float())
 
-    
+
   def test_integer_property(self):
     self.prop = self.graph.getIntegerProperty(self.prop_name)
-    self.generic_property_test(tlp.IntegerProperty, rand_int(), rand_int(), 
+    self.generic_property_test(tlp.IntegerProperty, rand_int(), rand_int(),
                                rand_int(), rand_int())
 
 
   def test_layout_property(self):
     self.prop = self.graph.getLayoutProperty(self.prop_name)
-    self.generic_property_test(tlp.LayoutProperty, random_coord(), random_coord_list(), 
+    self.generic_property_test(tlp.LayoutProperty, random_coord(), random_coord_list(),
                                random_coord(), random_coord_list())
+
 
   def test_layout_property_tuple(self):
     self.prop = self.graph.getLayoutProperty(self.prop_name)
-    self.generic_property_test(tlp.LayoutProperty, random_coord_tuple(), random_coord_tuple_list(), 
+    self.generic_property_test(tlp.LayoutProperty, random_coord_tuple(), random_coord_tuple_list(),
                                random_coord_tuple(), random_coord_tuple_list())
+
+
+  def test_layout_property_tuple_int(self):
+    self.prop = self.graph.getLayoutProperty(self.prop_name)
+    self.generic_property_test(tlp.LayoutProperty, random_coord_tuple_int(), random_coord_tuple_list(),
+                               random_coord_tuple_int(), random_coord_tuple_list(), check_type_inference=False)
+
 
   def test_size_property(self):
     self.prop = self.graph.getSizeProperty(self.prop_name)
-    self.generic_property_test(tlp.SizeProperty, random_size(), random_size(), 
+    self.generic_property_test(tlp.SizeProperty, random_size(), random_size(),
                                random_size(), random_size())
+
+
+  def test_size_property_tuple_int(self):
+    self.prop = self.graph.getSizeProperty(self.prop_name)
+    self.generic_property_test(tlp.SizeProperty, random_coord_tuple_int(), random_coord_tuple_int(),
+                               random_coord_tuple_int(), random_coord_tuple_int(), check_type_inference=False)
 
 
   def test_string_property(self):
     self.prop = self.graph.getStringProperty(self.prop_name)
-    self.generic_property_test(tlp.StringProperty, random_string(), random_string(), 
+    self.generic_property_test(tlp.StringProperty, random_string(), random_string(),
                                random_string(), random_string())
 
-    
+
   def test_boolean_vector_property(self):
     self.prop = self.graph.getBooleanVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.BooleanVectorProperty, random_boolean_list(), random_boolean_list(), 
+    self.generic_property_test(tlp.BooleanVectorProperty, random_boolean_list(), random_boolean_list(),
                                random_boolean_list(True), random_boolean_list(True))
 
 
   def test_color_vector_property(self):
     self.prop = self.graph.getColorVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.ColorVectorProperty, random_color_list(), random_color_list(), 
+    self.generic_property_test(tlp.ColorVectorProperty, random_color_list(), random_color_list(),
                                random_color_list(), random_color_list())
 
 
   def test_color_tuple_vector_property(self):
     self.prop = self.graph.getColorVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.ColorVectorProperty, random_color_tuple_list(), random_color_tuple_list(), 
+    self.generic_property_test(tlp.ColorVectorProperty, random_color_tuple_list(), random_color_tuple_list(),
                                random_color_tuple_list(), random_color_tuple_list())
-  
+
 
   def test_coord_vector_property(self):
     self.prop = self.graph.getCoordVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.CoordVectorProperty, random_coord_list(), random_coord_list(), 
+    self.generic_property_test(tlp.CoordVectorProperty, random_coord_list(), random_coord_list(),
                                random_coord_list(), random_coord_list())
 
 
   def test_coord_tuple_vector_property(self):
     self.prop = self.graph.getCoordVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.CoordVectorProperty, random_coord_tuple_list(), random_coord_tuple_list(), 
+    self.generic_property_test(tlp.CoordVectorProperty, random_coord_tuple_list(), random_coord_tuple_list(),
                                random_coord_tuple_list(), random_coord_tuple_list())
-  
+
+
+  def test_coord_tuple_int_vector_property(self):
+    self.prop = self.graph.getCoordVectorProperty(self.prop_name)
+    self.generic_property_test(tlp.CoordVectorProperty, random_coord_tuple_int_list(), random_coord_tuple_int_list(),
+                               random_coord_tuple_int_list(), random_coord_tuple_int_list(), check_type_inference=False)
+
 
   def test_double_vector_property(self):
     self.prop = self.graph.getDoubleVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.DoubleVectorProperty, random_double_list(), random_double_list(), 
+    self.generic_property_test(tlp.DoubleVectorProperty, random_double_list(), random_double_list(),
                                random_double_list(), random_double_list())
 
   def test_int_vector_property(self):
     self.prop = self.graph.getIntegerVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.IntegerVectorProperty, random_int_list(), random_int_list(), 
+    self.generic_property_test(tlp.IntegerVectorProperty, random_int_list(), random_int_list(),
                                random_int_list(), random_int_list())
 
 
   def test_size_vector_property(self):
     self.prop = self.graph.getSizeVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.SizeVectorProperty, random_size_list(), random_size_list(), 
+    self.generic_property_test(tlp.SizeVectorProperty, random_size_list(), random_size_list(),
                                random_size_list(), random_size_list())
 
+  def test_size_tuple_int_vector_property(self):
+    self.prop = self.graph.getSizeVectorProperty(self.prop_name)
+    self.generic_property_test(tlp.SizeVectorProperty, random_coord_tuple_int_list(), random_coord_tuple_int_list(),
+                               random_coord_tuple_int_list(), random_coord_tuple_int_list(), check_type_inference=False)
 
   def test_string_vector_property(self):
     self.prop = self.graph.getStringVectorProperty(self.prop_name)
-    self.generic_property_test(tlp.StringVectorProperty, random_string_list(), random_string_list(), 
+    self.generic_property_test(tlp.StringVectorProperty, random_string_list(), random_string_list(),
                                random_string_list(), random_string_list())


### PR DESCRIPTION
I found a way to fix #120 while ensuring no regression on the `tulip-python` features implemented so far (thanks to the great hacking features provided by [SIP](https://www.riverbankcomputing.com/software/sip/intro) and the strong unit tests I wrote by the past). I must admit that this behavior was quite confusing and annoying.

You can now safely write in your Tulip-Python code:
```python
viewLayout = graph.getLayoutProperty('viewLayout')
viewLayout[n] = (0, 0)
viewLayout[n] = (10.5, 0, 1.5)

viewSize = graph.getSizeProperty('viewSize')
viewSize[n] = (2, 2)
viewSize[n] = (1.5, 1, 1)

# or even shorter
graph['viewLayout'][n] = (0, 0)
graph['viewLayout'][n] = (10.5, 0, 1.5)

graph['viewSize'][n] = (2, 2)
graph['viewSize'][n] = (1.5, 1, 1)
```