### PR TITLE
Add Color Interpolation for Enumerated Color Mapping

### DIFF
--- a/plugins/colors/DoubleStringsListRelationDialog.cpp
+++ b/plugins/colors/DoubleStringsListRelationDialog.cpp
@@ -21,6 +21,7 @@
 #include "ui_DoubleStringsListRelationDialog.h"
 
 #include <tulip/TlpQtTools.h>
+#include <tulip/ColorScale.h>
 
 #include <QScrollBar>
 
@@ -31,7 +32,7 @@ namespace tlp {
 DoubleStringsListRelationDialog::DoubleStringsListRelationDialog(
     const std::vector<std::string> &firstValues, const std::vector<Color> &secondValues,
     QWidget *parent)
-    : QDialog(parent), _ui(new Ui::DoubleStringsListRelationDialogData) {
+    : QDialog(parent), _ui(new Ui::DoubleStringsListRelationDialogData), lastNonInterpolateValues(secondValues) {
   _ui->setupUi(this);
 
   for (vector<string>::const_iterator it = firstValues.begin(); it != firstValues.end(); ++it) {
@@ -52,6 +53,8 @@ DoubleStringsListRelationDialog::DoubleStringsListRelationDialog(
           SLOT(scrollBarValueChanged(int)));
   connect(_ui->secondListWidget->verticalScrollBar(), SIGNAL(valueChanged(int)), this,
           SLOT(scrollBarValueChanged(int)));
+  connect(_ui->interpolateColorsCheckBox,SIGNAL(stateChanged(int)),this,
+          SLOT(interpolateCheckBoxChange(int)));
 }
 
 DoubleStringsListRelationDialog::~DoubleStringsListRelationDialog() {
@@ -118,5 +121,37 @@ void DoubleStringsListRelationDialog::scrollBarValueChanged(int value) {
 
   if (_ui->secondListWidget->verticalScrollBar()->value() != value)
     _ui->secondListWidget->verticalScrollBar()->setSliderPosition(value);
+}
+
+void DoubleStringsListRelationDialog::interpolateCheckBoxChange(int state) {
+  if(state == 0){
+    // If going back to no interpolated color values
+    // then replace the color columns with value in
+    // vector lastNonInterpolateValues
+    _ui->secondListWidget->clear();
+    for (vector<Color>::const_iterator it = lastNonInterpolateValues.begin(); it != lastNonInterpolateValues.end(); ++it) {
+      QListWidgetItem *item = new QListWidgetItem;
+      item->setBackground(QBrush(QColor((*it)[0], (*it)[1], (*it)[2], (*it)[3])));
+      _ui->secondListWidget->addItem(item);
+    }
+  }else{
+    // If we choose to interpolate then
+    // Save the current color values
+    lastNonInterpolateValues.clear();
+    for(int i = 0 ; i < _ui->secondListWidget->count(); ++i){
+      QColor color = _ui->secondListWidget->item(i)->background().color();
+      lastNonInterpolateValues.push_back(QColorToColor(color));
+    }
+    // replace the color colums with interpolated values
+    ColorScale tempCS = ColorScale(lastNonInterpolateValues);
+    float nbOfValues = static_cast<float>(_ui->firstListWidget->count());
+    _ui->secondListWidget->clear();
+    for(float i = 0.; i< nbOfValues; ++i){
+      QListWidgetItem *item = new QListWidgetItem;
+      Color ic = tempCS.getColorAtPos(i / (nbOfValues - 1.));
+      item->setBackground(QBrush(QColor(ic[0], ic[1], ic[2], ic[3])));
+      _ui->secondListWidget->addItem(item);
+    }
+  }
 }
 } // namespace tlp

--- a/plugins/colors/DoubleStringsListRelationDialog.h
+++ b/plugins/colors/DoubleStringsListRelationDialog.h
@@ -49,6 +49,10 @@ private slots:
   void upButtonColorClicked();
   void downButtonColorClicked();
   void scrollBarValueChanged(int value);
+  void interpolateCheckBoxChange(int state);
+
+private:
+  std::vector<Color> lastNonInterpolateValues;
 };
 } // namespace tlp
 

--- a/plugins/colors/DoubleStringsListRelationDialog.ui
+++ b/plugins/colors/DoubleStringsListRelationDialog.ui
@@ -281,11 +281,37 @@
     </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
      </property>
-    </widget>
+     <item>
+      <widget class="QCheckBox" name="interpolateColorsCheckBox">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;When checked&lt;/span&gt;, an interpolation is made to map each value to a color based on the current color scale. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;When unchecked&lt;/span&gt;, replace the color mapping with the last set of non-interpolated colors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Interpolated Colors</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+       <property name="centerButtons">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
See Issue #121 for discussion.
Add a `QCheckBox` in the `DoubleStringsListRelationDialog` dialog:
When checked, an interpolation is made to map each value to a color based on the current color scale. 
When unchecked, replace the color mapping with the last set of non-interpolated colors.

New window with box unchecked:
![colormap_unchecked](https://user-images.githubusercontent.com/27347677/59033763-ba4c0a80-8869-11e9-9131-1d1c39c963a8.png)
New window with box checked:
![colormap_checked](https://user-images.githubusercontent.com/27347677/59033768-bd46fb00-8869-11e9-8520-4bb5aaadd5e5.png)
