### PR TITLE
Fix -Wdeprecated-copy GCC 9 warnings

### DIFF
--- a/library/tulip-core/include/tulip/Circle.h
+++ b/library/tulip-core/include/tulip/Circle.h
@@ -43,6 +43,7 @@ struct Circle : public Vector<Obj, 2, OTYPE> {
     (*this)[0] = x;
     (*this)[1] = y;
   }
+  Circle &operator=(const Circle &) = default;
   /**
    * Translate "this" by vector v
    */

--- a/library/tulip-core/include/tulip/Vector.h
+++ b/library/tulip-core/include/tulip/Vector.h
@@ -352,6 +352,8 @@ public:
   }
   inline DTYPE dist(const VECTOR &) const;
   inline TYPE dotProduct(const VECTOR &) const;
+
+  inline VECTOR &operator=(const VECTOR &) = default;
 };
 
 TEMPLATEVECTOR

--- a/library/tulip-core/include/tulip/vectorgraphproperty.h
+++ b/library/tulip-core/include/tulip/vectorgraphproperty.h
@@ -140,6 +140,7 @@ protected:
   VectorGraphProperty() : _values(nullptr), _graph(nullptr) {}
   VectorGraphProperty(const VectorGraphProperty &obj) : _values(obj._values), _graph(obj._graph) {}
   VectorGraphProperty(ValuesImpl *values, VectorGraph *graph) : _values(values), _graph(graph) {}
+  VectorGraphProperty &operator=(const VectorGraphProperty &) = default;
 
   ValuesImpl *_values; /**< TODO */
   VectorGraph *_graph; /**< TODO */
@@ -187,6 +188,7 @@ class EdgeProperty : public VectorGraphProperty<TYPE> {
 public:
   EdgeProperty() : VectorGraphProperty<TYPE>() {}
   EdgeProperty(const EdgeProperty &obj) : VectorGraphProperty<TYPE>(obj) {}
+  EdgeProperty &operator=(const EdgeProperty &) = default;
 #ifndef NDEBUG
   bool isValid() const;
 #endif
@@ -236,6 +238,7 @@ class NodeProperty : public VectorGraphProperty<TYPE> {
 public:
   NodeProperty() : VectorGraphProperty<TYPE>() {}
   NodeProperty(const NodeProperty &obj) : VectorGraphProperty<TYPE>(obj) {}
+  NodeProperty &operator=(const NodeProperty &) = default;
 #ifndef NDEBUG
   bool isValid() const;
 #endif

--- a/library/tulip-gui/include/tulip/PluginManager.h
+++ b/library/tulip-gui/include/tulip/PluginManager.h
@@ -46,6 +46,7 @@ struct TLP_QT_SCOPE PluginVersionInformation {
 
   PluginVersionInformation();
   PluginVersionInformation(const PluginVersionInformation &copy);
+  PluginVersionInformation &operator=(const PluginVersionInformation &) = default;
 };
 
 struct TLP_QT_SCOPE PluginInformation {
@@ -56,6 +57,7 @@ struct TLP_QT_SCOPE PluginInformation {
 
   PluginInformation();
   PluginInformation(const PluginInformation &copy);
+  PluginInformation &operator=(const PluginInformation &) = default;
 
   void fillLocalInfo(const tlp::Plugin &info);
 };

--- a/library/tulip-gui/include/tulip/TulipMetaTypes.h
+++ b/library/tulip-gui/include/tulip/TulipMetaTypes.h
@@ -57,6 +57,7 @@ struct TulipFileDescriptor {
     type = d.type;
     mustExist = d.mustExist;
   }
+  TulipFileDescriptor &operator=(const TulipFileDescriptor &) = default;
   QString absolutePath;
   FileType type;
   // indicate if the file or dir must exist

--- a/library/tulip-ogl/include/tulip/Camera.h
+++ b/library/tulip-ogl/include/tulip/Camera.h
@@ -62,6 +62,8 @@ public:
    */
   Camera(GlScene *scene, bool d3);
 
+  Camera(const Camera &camera) = default;
+
   Camera &operator=(const Camera &camera);
 
   /**

--- a/plugins/import/WebImport.cpp
+++ b/plugins/import/WebImport.cpp
@@ -37,6 +37,7 @@ public:
 
   UrlElement();
   UrlElement(const UrlElement &c);
+  UrlElement &operator=(const UrlElement &) = default;
   bool load();
   void clear();
   bool isHtmlPage();


### PR DESCRIPTION
When you are working on a C++ project, there is a simple rule to follow: if GCC starts emitting new warnings when its version evolves (see https://ci.appveyor.com/project/tulip-dev/tulip/build/job/wa5ql0gfd9oqtpgx?fullLog=true) and you did not touch any build configuration, you have to fix them and not ignore them.

Indeed, it gives you hints on how improve the performance of the produced binaries.

Tulip is not the only project experiencing these new warnings, see for instance https://github.com/tsduck/tsduck/issues/205 or https://github.com/freedesktop/libreoffice-cppunit/commit/78e64f0edb4f3271a6ddbcdf9cba05138597bfca