### PR TITLE
tulip-python/tulipgui: Fix segfaults when requesting context menu

### DIFF
--- a/library/tulip-gui/src/Perspective.cpp
+++ b/library/tulip-gui/src/Perspective.cpp
@@ -180,8 +180,10 @@ void Perspective::showStatusMessage(const QString &msg) {
 }
 
 void Perspective::redirectStatusTipOfMenu(QMenu *menu) {
-  connect(menu, SIGNAL(hovered(QAction *)), instance(), SLOT(showStatusTipOf(QAction *)));
-  connect(menu, SIGNAL(aboutToHide()), instance()->mainWindow()->statusBar(), SLOT(clearMessage()));
+  if (Perspective::instance()) {
+    connect(menu, SIGNAL(hovered(QAction *)), instance(), SLOT(showStatusTipOf(QAction *)));
+    connect(menu, SIGNAL(aboutToHide()), instance()->mainWindow()->statusBar(), SLOT(clearMessage()));
+  }
 }
 
 void Perspective::showStatusTipOf(QAction *action) {

--- a/library/tulip-gui/src/View.cpp
+++ b/library/tulip-gui/src/View.cpp
@@ -126,8 +126,10 @@ void View::showContextMenu(const QPoint &point, const QPointF &scenePoint) {
 
     if (!menu.actions().empty()) {
       // clean up status bar when menu is hidden
-      connect(&menu, SIGNAL(aboutToHide()), Perspective::instance()->mainWindow()->statusBar(),
-              SLOT(clearMessage()));
+      if (Perspective::instance()) {
+        connect(&menu, SIGNAL(aboutToHide()), Perspective::instance()->mainWindow()->statusBar(),
+                SLOT(clearMessage()));
+      }
       menu.move(point);
       menu.exec();
     }


### PR DESCRIPTION
Just found this bug by looking at issue #133: when a view is created outside Tulip from the classical Python interpreter and the display of a context menu is requested => SEGFAULT