### PR TITLE
tulip-ogl/GlVertexArrayManager: Fix segfault with selected graph elements

### DIFF
--- a/library/tulip-ogl/src/GlVertexArrayManager.cpp
+++ b/library/tulip-ogl/src/GlVertexArrayManager.cpp
@@ -282,10 +282,10 @@ inline void vector_set_size(std::vector<T> &v, unsigned int sz) {
 }
 
 void GlVertexArrayManager::reserveMemoryForGraphElts(unsigned int nbNodes, unsigned int nbEdges) {
-  auto nbSelectedNodes = inputData->getElementSelected()->numberOfNonDefaultValuatedNodes();
+  auto nbSelectedNodes = inputData->getElementSelected()->numberOfNonDefaultValuatedNodes(inputData->getGraph());
   pointsNodesRenderingIndexArray.reserve(nbNodes - nbSelectedNodes);
   pointsNodesSelectedRenderingIndexArray.reserve(nbSelectedNodes);
-  auto nbSelectedEdges = inputData->getElementSelected()->numberOfNonDefaultValuatedEdges();
+  auto nbSelectedEdges = inputData->getElementSelected()->numberOfNonDefaultValuatedEdges(inputData->getGraph());
   pointsEdgesRenderingIndexArray.reserve(nbEdges - nbSelectedEdges);
   pointsEdgesSelectedRenderingIndexArray.reserve(nbSelectedEdges);
 


### PR DESCRIPTION
I experienced a segfault when editing a graph with metanodes and selecting elements.

```gdb
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
TLP_PLATEFORM linux
TLP_ARCH x86_64
TLP_COMPILER gcc
TLP_VERSION 5.3.1
TLP_STACK_BEGIN
#00 0x00007fae672aee97 in gsignal (+0xc7) at /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/nptl-signals.h:80 from /lib/x86_64-linux-gnu/libc.so.6                                                                                                                  
#01 0x00007fae672b0801 in abort (+0x141) at /build/glibc-OTsEL5/glibc-2.27/stdlib/abort.c:79 from /lib/x86_64-linux-gnu/libc.so.6          
#02 0x00007fae67905957 in ?? (+0x8c957) from /usr/lib/x86_64-linux-gnu/libstdc++.so.6                                                      
#03 0x00007fae6790bab6 in ?? (+0x92ab6) from /usr/lib/x86_64-linux-gnu/libstdc++.so.6                                                      
#04 0x00007fae6790baf1 in ?? (+0x92af1) from /usr/lib/x86_64-linux-gnu/libstdc++.so.6                                                      
#05 0x00007fae6790bd24 in ?? (+0x92d24) from /usr/lib/x86_64-linux-gnu/libstdc++.so.6                                                      
#06 0x00007fae6790c29c in ?? (+0x9329c) from /usr/lib/x86_64-linux-gnu/libstdc++.so.6                                                      
#07 0x00007fae696c9dcf in std::vector<unsigned int, std::allocator<unsigned int> >::reserve(unsigned long) (+0x6f) at /usr/include/c++/7/ext/new_allocator.h:111 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-core-5.3.so                                           
#08 0x00007fae66fb58cd in tlp::GlVertexArrayManager::reserveMemoryForGraphElts(unsigned int, unsigned int) (+0x4d) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlVertexArrayManager.cpp:286 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so            
#09 0x00007fae66f4da5b in tlp::GlGraphRenderer::visitGraph(tlp::GlSceneVisitor*, bool) (+0x5b) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlGraphRenderer.cpp:53 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                                      
#10 0x00007fae66f4f2ed in tlp::GlGraphHighDetailsRenderer::draw(float, tlp::Camera*) (+0x38d) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlGraphHighDetailsRenderer.cpp:243 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                           
#11 0x00007fae66f9d718 in tlp::GlScene::draw() (+0x528) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlScene.cpp:209 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                                                                                    
#12 0x00007fae66f816c2 in tlp::GlMetaNodeRenderer::render(tlp::node, float, tlp::Camera*) (+0x12d2) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlMetaNodeRenderer.cpp:160 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                             
#13 0x00007fae66f829e3 in tlp::GlNode::draw(float, tlp::GlGraphInputData const*, tlp::Camera*) (+0x1f3) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlNode.cpp:104 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                                     
#14 0x00007fae66f4f7b2 in tlp::GlGraphHighDetailsRenderer::draw(float, tlp::Camera*) (+0x852) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlGraphHighDetailsRenderer.cpp:283 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                           
#15 0x00007fae66f9d718 in tlp::GlScene::draw() (+0x528) at /home/antoine/dev/tulip/library/tulip-ogl/src/GlScene.cpp:209 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-ogl-5.3.so                                                                                    
#16 0x00007fae69ff9bb2 in tlp::GlMainWidget::render(QFlags<tlp::GlMainWidget::RenderingOption>, bool) (+0x132) at /home/antoine/dev/tulip/library/tulip-gui/src/GlMainWidget.cpp:256 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-gui-5.3.so                        
#17 0x00007fae6a08f092 in tlp::GlMainWidgetGraphicsItem::paint(QPainter*, QStyleOptionGraphicsItem const*, QWidget*) (+0x62) at /home/antoine/dev/tulip/library/tulip-gui/src/GlMainWidgetGraphicsItem.cpp:113 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-gui-5.3.so                                                                                                                                         
#18 0x00007fae68f91ad6 in ?? (+0x46fad6) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                 
#19 0x00007fae68f920e8 in ?? (+0x4700e8) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                 
#20 0x00007fae68f928da in ?? (+0x4708da) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                 
#21 0x00007fae68fb7645 in QGraphicsView::paintEvent(QPaintEvent*) (+0x3b5) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5               
#22 0x00007fae68cbe9c8 in QWidget::event(QEvent*) (+0x1e8) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                               
#23 0x00007fae68d617ee in QFrame::event(QEvent*) (+0x1e) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                 
#24 0x00007fae68fb6213 in QGraphicsView::viewportEvent(QEvent*) (+0x163) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                 
#25 0x00007fae67e82a9d in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (+0xad) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                                                                                            
#26 0x00007fae68c7e635 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (+0x75) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5  
#27 0x00007fae68c85b90 in QApplication::notify(QObject*, QEvent*) (+0x2f0) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5               
#28 0x00007fae67e82d18 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (+0x118) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5     
#29 0x00007fae68cb7595 in QWidgetPrivate::sendPaintEvent(QRegion const&) (+0x35) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5         
#30 0x00007fae68cb7d6d in QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, int, QPainter*, QWidgetBackingStore*) (+0x78d) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                   
#31 0x00007fae68c8c35b in QWidgetPrivate::repaint_sys(QRegion const&) (+0x15b) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5           
#32 0x00007fae68cdbacc in ?? (+0x1b9acc) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                 
#33 0x00007fae68cdc739 in ?? (+0x1ba739) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                 
#34 0x00007fae68c7e65c in QApplicationPrivate::notify_helper(QObject*, QEvent*) (+0x9c) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5  
#35 0x00007fae68c85b90 in QApplication::notify(QObject*, QEvent*) (+0x2f0) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5               
#36 0x00007fae67e82d18 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (+0x118) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5     
#37 0x00007fae6844d19a in QGuiApplicationPrivate::processExposeEvent(QWindowSystemInterfacePrivate::ExposeEvent*) (+0xca) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                                                                                                               
#38 0x00007fae6844d3ed in QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent*) (+0x1bd) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                                                                                                  
#39 0x00007fae68425b4b in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (+0xbb) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                                                                                                                 
#40 0x00007fae5f6c559a in ?? (+0x6c59a) from /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5                                                   
#41 0x00007fae63c46317 in g_main_context_dispatch (+0x2e7) from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0                                 
#42 0x00007fae63c46550 in ?? (+0x4c550) from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0                                                    
#43 0x00007fae63c465dc in g_main_context_iteration (+0x2c) from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0                                 
#44 0x00007fae67edfdaf in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (+0x5f) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                                                                                           
#45 0x00007fae67e8103a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (+0x13a) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5  
#46 0x00007fae67e8a170 in QCoreApplication::exec() (+0x90) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                  
#47 0x0000559cd28db4fd in main (+0xaed) at /home/antoine/dev/tulip/software/tulip_perspective/src/main.cpp:360 from /home/antoine/dev/tulip_build/./install/bin/tulip_perspective                                                                                                     
TLP_STACK_END
```
When a subgraph is rendered and the number of selected nodes / edges in the root graph
is greater than the number of nodes / edges in the subgraph, a std::bad_alloc was raised.
    
As the number of selected nodes / edges was computed for the root graph and not for
the subgraph during the rendering process, a bad vector size value was computed leading
to the observed crash.

This is a critical bug that can happen pretty often when playing with selection and subgraphs rendering. 