### PR TITLE
Fix some issues related to meta-graph import / export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ IF(POLICY CMP0068)
   CMAKE_POLICY(SET CMP0068 OLD)
 ENDIF(POLICY CMP0068)
 
+IF(POLICY CMP0072)
+  CMAKE_POLICY(SET CMP0072 NEW)
+ENDIF(POLICY CMP0072)
+
 # enable the use of ccache for Tulip developers to speed up the build process
 IF(NOT MSVC)
   SET(TULIP_USE_CCACHE OFF CACHE BOOL "Do you want to use ccache to speed up the build process during Tulip development ? [OFF|ON]")

--- a/library/tulip-core/src/PropertyTypes.cpp
+++ b/library/tulip-core/src/PropertyTypes.cpp
@@ -69,11 +69,14 @@ bool GraphType::readb(istream &, RealType &) {
 // EdgeSetType
 void EdgeSetType::write(ostream &os, const RealType &v) {
   os << '(';
-  set<edge>::const_iterator it;
-
-  for (it = v.begin(); it != v.end(); ++it)
-    os << (*it).id << ' ';
-
+  size_t i = 0;
+  size_t vsize = v.size();
+  for (auto e : v) {
+    os << e.id;
+    if (++i != vsize) {
+      os << ' ';
+    }
+  }
   os << ')';
 }
 

--- a/library/tulip-core/src/TLPBExport.cpp
+++ b/library/tulip-core/src/TLPBExport.cpp
@@ -490,24 +490,32 @@ bool TLPBExport::exportGraph(std::ostream &os) {
             // re-index embedded edges
             const set<edge> &edges = static_cast<GraphProperty *>(prop)->getEdgeValue(e);
             set<edge> rEdges;
-            set<edge>::const_iterator its;
 
-            for (its = edges.begin(); its != edges.end(); ++its) {
-              rEdges.insert(getEdge(*its));
+            for (auto ee : edges) {
+              edge rEdge = getEdge(ee);
+              // do not export edges that are not elements of the root graph
+              if (rEdge.isValid()) {
+                rEdges.insert(rEdge);
+              }
             }
 
             // finally save set
             EdgeSetType::writeb(s, rEdges);
-          } else if (pnViewProp && !TulipBitmapDir.empty()) { // viewFont || viewTexture
-            string sVal = prop->getEdgeStringValue(e);
-            size_t pos = sVal.find(TulipBitmapDir);
 
-            if (pos != string::npos)
-              sVal.replace(pos, TulipBitmapDir.size(), "TulipBitmapDir/");
+          } else {
 
-            StringType::writeb(s, sVal);
-          } else
-            prop->writeEdgeValue(s, e);
+            if (pnViewProp && !TulipBitmapDir.empty()) { // viewFont || viewTexture
+              string sVal = prop->getEdgeStringValue(e);
+              size_t pos = sVal.find(TulipBitmapDir);
+
+              if (pos != string::npos)
+                sVal.replace(pos, TulipBitmapDir.size(), "TulipBitmapDir/");
+
+              StringType::writeb(s, sVal);
+            } else {
+              prop->writeEdgeValue(s, e);
+            }
+          }
 
           ++nbValues;
 

--- a/library/tulip-core/src/TLPExport.cpp
+++ b/library/tulip-core/src/TLPExport.cpp
@@ -365,13 +365,19 @@ public:
           set<edge> rEdges;
 
           for (auto ee : edges) {
-            rEdges.insert(getEdge(ee));
+            edge rEdge = getEdge(ee);
+            // do not export edges that are not elements of the root graph
+            if (rEdge.isValid()) {
+              rEdges.insert(rEdge);
+            }
           }
 
-          // finally save the vector
-          os << "(edge " << getEdge(e).id << " \"";
-          EdgeSetType::write(os, rEdges);
-          os << "\")" << endl;
+          if (!rEdges.empty()) {
+            // finally save the vector
+            os << "(edge " << getEdge(e).id << " \"";
+            EdgeSetType::write(os, rEdges);
+            os << "\")" << endl;
+          }
 
         } else {
 

--- a/library/tulip-core/src/TLPExport.cpp
+++ b/library/tulip-core/src/TLPExport.cpp
@@ -317,13 +317,13 @@ public:
         // sort nodes to ensure a predictable ordering of the ouput
         itN = new StableIterator<node>(itN, 0, true, true);
 
-      while (itN->hasNext()) {
-        auto itn = itN->next();
+      for (auto n : itN) {
+
         if (progress % (1 + nonDefaultvaluatedElementCount / 100) == 0)
           pluginProgress->progress(progress, nonDefaultvaluatedElementCount);
 
         ++progress;
-        string tmp = prop->getNodeStringValue(itn);
+        string tmp = prop->getNodeStringValue(n);
 
         // replace real path with symbolic one using TulipBitmapDir
         if (isPathViewProp && !TulipBitmapDir.empty()) {
@@ -341,9 +341,8 @@ public:
             continue;
         }
 
-        os << "(node " << getNode(itn).id << " \"" << convert(tmp) << "\")" << endl;
+        os << "(node " << getNode(n).id << " \"" << convert(tmp) << "\")" << endl;
       }
-      delete itN;
 
       Iterator<edge> *itE = prop->getNonDefaultValuatedEdges(g);
 
@@ -351,39 +350,33 @@ public:
         // sort edges to ensure a predictable ordering of the ouput
         itE = new StableIterator<edge>(itE, 0, true, true);
 
-      if (prop->getTypename() == GraphProperty::propertyTypename) {
-        while (itE->hasNext()) {
-          auto ite = itE->next();
-          if (progress % (1 + nonDefaultvaluatedElementCount / 100) == 0)
+      for (auto e : itE) {
+
+        if (progress % (1 + nonDefaultvaluatedElementCount / 100) == 0)
             pluginProgress->progress(progress, nonDefaultvaluatedElementCount);
 
           ++progress;
+
+        if (prop->getTypename() == GraphProperty::propertyTypename) {
 
           // for GraphProperty we must ensure the reindexing
           // of embedded edges
-          const set<edge> &edges = static_cast<GraphProperty *>(prop)->getEdgeValue(ite);
+          const set<edge> &edges = static_cast<GraphProperty *>(prop)->getEdgeValue(e);
           set<edge> rEdges;
-          set<edge>::const_iterator its;
 
-          for (its = edges.begin(); its != edges.end(); ++its) {
-            rEdges.insert(getEdge(*its));
+          for (auto ee : edges) {
+            rEdges.insert(getEdge(ee));
           }
 
           // finally save the vector
-          os << "(edge " << getEdge(ite).id << " \"";
+          os << "(edge " << getEdge(e).id << " \"";
           EdgeSetType::write(os, rEdges);
           os << "\")" << endl;
-        }
-      } else {
-        while (itE->hasNext()) {
-          auto ite = itE->next();
-          if (progress % (1 + nonDefaultvaluatedElementCount / 100) == 0)
 
-            pluginProgress->progress(progress, nonDefaultvaluatedElementCount);
+        } else {
 
-          ++progress;
           // replace real path with symbolic one using TulipBitmapDir
-          string tmp = prop->getEdgeStringValue(ite);
+          string tmp = prop->getEdgeStringValue(e);
 
           if (isPathViewProp && !TulipBitmapDir.empty()) {
             size_t pos = tmp.find(TulipBitmapDir);
@@ -392,11 +385,9 @@ public:
               tmp.replace(pos, TulipBitmapDir.size(), "TulipBitmapDir/");
           }
 
-          os << "(edge " << getEdge(ite).id << " \"" << convert(tmp) << "\")" << endl;
+          os << "(edge " << getEdge(e).id << " \"" << convert(tmp) << "\")" << endl;
         }
       }
-      delete itE;
-
       os << ")" << endl;
     }
   }

--- a/library/tulip-core/src/TlpJsonExport.cpp
+++ b/library/tulip-core/src/TlpJsonExport.cpp
@@ -282,9 +282,6 @@ public:
         _writer.writeString(EdgesValuesToken);
         _writer.writeMapOpen();
         for (auto e : property->getNonDefaultValuatedEdges(g)) {
-          stringstream temp;
-          temp << graph->edgePos(e);
-          _writer.writeString(temp.str());
 
           string sValue;
 
@@ -295,7 +292,15 @@ public:
             const set<edge> &edges = static_cast<GraphProperty *>(property)->getEdgeValue(e);
             set<edge> rEdges;
             for (auto ee : edges) {
-              rEdges.insert(edge(graph->edgePos(ee)));
+              edge rEdge = edge(graph->edgePos(ee));
+              // do not export edges that are not elements of the root graph
+              if (rEdge.isValid()) {
+                rEdges.insert(rEdge);
+              }
+            }
+
+            if (rEdges.empty()) {
+              continue;
             }
 
             sValue = EdgeSetType::toString(rEdges);
@@ -311,6 +316,9 @@ public:
             }
           }
 
+          stringstream temp;
+          temp << graph->edgePos(e);
+          _writer.writeString(temp.str());
           _writer.writeString(sValue);
         }
         _writer.writeMapClose();

--- a/library/tulip-core/src/TlpJsonImport.cpp
+++ b/library/tulip-core/src/TlpJsonImport.cpp
@@ -382,16 +382,22 @@ public:
 
           if (_parsingPathViewProperty) {
             // if needed replace symbolic path by real path
-            size_t pos = value.find("TulipBitmapDir/");
-
+            string eValue(value);
+            size_t pos = eValue.find("TulipBitmapDir/");
             if (pos != std::string::npos) {
-              string eValue(value);
               eValue.replace(pos, 15, TulipBitmapDir);
-              _currentProperty->setEdgeStringValue(e, eValue);
-            } else
+            }
+            _currentProperty->setEdgeStringValue(e, eValue);
+          } else {
+            // setEdgeStringValue is a no-op with GraphProperty
+            if (_currentProperty->getTypename() == GraphProperty::propertyTypename) {
+              set<edge> edges;
+              EdgeSetType::fromString(edges, value);
+              static_cast<GraphProperty*>(_currentProperty)->setEdgeValue(e, edges);
+            } else {
               _currentProperty->setEdgeStringValue(e, value);
-          } else
-            _currentProperty->setEdgeStringValue(e, value);
+            }
+          }
         }
       } else {
         tlp::error() << "The property '" << _propertyName << "'was null when trying to fill it"

--- a/tests/library/tulip/ImportExportTest.h
+++ b/tests/library/tulip/ImportExportTest.h
@@ -34,8 +34,10 @@ public:
   void testSubGraphsImportExport();
   void testAttributes();
   void testNanInfValuesImportExport();
+  void testMetaGraphImportExport();
 
 protected:
+  void updateIdProperty(tlp::Graph *graph) const;
   tlp::Graph *createSimpleGraph() const;
   void importExportGraph(tlp::Graph *original);
   void exportGraph(tlp::Graph *graph, const std::string &exportPluginName,
@@ -56,6 +58,7 @@ class TlpImportExportTest : public ImportExportTest {
   CPPUNIT_TEST(testAttributes);
   CPPUNIT_TEST(testSubGraphsImportExport);
   CPPUNIT_TEST(testNanInfValuesImportExport);
+  CPPUNIT_TEST(testMetaGraphImportExport);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -68,6 +71,7 @@ class TlpBImportExportTest : public ImportExportTest {
   CPPUNIT_TEST(testAttributes);
   CPPUNIT_TEST(testSubGraphsImportExport);
   CPPUNIT_TEST(testNanInfValuesImportExport);
+  CPPUNIT_TEST(testMetaGraphImportExport);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -80,6 +84,7 @@ class JsonImportExportTest : public ImportExportTest {
   CPPUNIT_TEST(testAttributes);
   CPPUNIT_TEST(testSubGraphsImportExport);
   CPPUNIT_TEST(testNanInfValuesImportExport);
+  CPPUNIT_TEST(testMetaGraphImportExport);
   CPPUNIT_TEST_SUITE_END();
 
 public:


### PR DESCRIPTION
I noticed an export issue when one tries to export a leaf sub-graph from a graph hierarchy containing meta-edges.

The issue was leading to a segfault, here is how to reproduce it from the Tulip GUI:
1. Import a Grid graph
2. Create a bunch of meta-nodes using the Group operation on some selected sub-graphs
3. Export the "groups" subgraph in the graph hierarchy to TLP format
4. Launch a new Tulip instance and import the previously exported graph
5. Try to export the graph again to TLP => SEGFAULT

```gdb
TLP_PLATEFORM linux
TLP_ARCH x86_64
TLP_COMPILER gcc
TLP_VERSION 5.3.1
TLP_STACK_BEGIN
#00 0x00007f0f0e1d6c59 in tlp::GraphImpl::edgePos(tlp::edge) const (+0x9) at /home/antoine/dev/tulip/library/tulip-core/include/tulip/IdManager.h:231 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-core-5.3.so                                                                                                                                                              
#01 0x00007f0f0e268730 in tlp::TLPExport::saveLocalProperties(std::ostream&, tlp::Graph*) (+0x1290) at /home/antoine/dev/tulip/library/tulip-core/src/TLPExport.cpp:113 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-core-5.3.so                                                                                                                                            
#02 0x00007f0f0e2696ff in tlp::TLPExport::exportGraph(std::ostream&) (+0x41f) at /home/antoine/dev/tulip/library/tulip-core/src/TLPExport.cpp:405 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-core-5.3.so                                                                                                                                                                  
#03 0x00007f0f0e1b2735 in tlp::exportGraph(tlp::Graph*, std::ostream&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tlp::DataSet&, tlp::PluginProgress*) (+0xf5) at /home/antoine/dev/tulip/library/tulip-core/src/Graph.cpp:460 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-core-5.3.so                                        
#04 0x00007f0f0e1b2f1b in tlp::saveGraph(tlp::Graph*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tlp::PluginProgress*, tlp::DataSet*) (+0x66b) at /home/antoine/dev/tulip/library/tulip-core/src/Graph.cpp:370 from /home/antoine/dev/tulip_build/install/bin/../lib/libtulip-core-5.3.so                                                        
#05 0x00007f0eebb6feb4 in GraphPerspective::exportGraph(tlp::Graph*) (+0x364) at /home/antoine/dev/tulip/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp:843 from /home/antoine/dev/tulip_build/install/lib/tulip/perspective/libGraphPerspective-5.3.1.so                                                                                                                      
#06 0x00007f0f0c64f906 in QMetaObject::activate(QObject*, int, int, void**) (+0x766) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                            
#07 0x00007f0f0d13bf02 in QAction::triggered(bool) (+0x42) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                   
#08 0x00007f0f0d13e510 in QAction::activate(QAction::ActionEvent) (+0xf0) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                    
#09 0x00007f0f0d2aea7c in ?? (+0x2cba7c) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                     
#10 0x00007f0f0d2b5fa0 in ?? (+0x2d2fa0) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                     
#11 0x00007f0f0d2b6f2b in QMenu::mouseReleaseEvent(QMouseEvent*) (+0x26b) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                    
#12 0x00007f0f0d180588 in QWidget::event(QEvent*) (+0x1d8) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                   
#13 0x00007f0f0d2b938b in QMenu::event(QEvent*) (+0x11b) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                     
#14 0x00007f0f0d1424b1 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (+0x81) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                      
#15 0x00007f0f0d149b98 in QApplication::notify(QObject*, QEvent*) (+0x458) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                   
#16 0x00007f0f0c6265a9 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (+0x179) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                         
#17 0x00007f0f0d148ec9 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool) (+0x1a9) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                                                                                                     
#18 0x00007f0f0d19b3d3 in ?? (+0x1b83d3) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                     
#19 0x00007f0f0d19db9e in ?? (+0x1bab9e) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                     
#20 0x00007f0f0d1424b1 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (+0x81) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                      
#21 0x00007f0f0d149950 in QApplication::notify(QObject*, QEvent*) (+0x210) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                   
#22 0x00007f0f0c6265a9 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (+0x179) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                         
#23 0x00007f0f0cb72fe3 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (+0x703) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                         
#24 0x00007f0f0cb74e25 in QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent*) (+0x135) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5           
#25 0x00007f0f0cb4f06b in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (+0xab) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                          
#26 0x00007f0f090333eb in ?? (+0xdd3eb) from /usr/lib/x86_64-linux-gnu/libQt5XcbQpa.so.5                                                                                                       
#27 0x00007f0f0c62527b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (+0x13b) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                      
#28 0x00007f0f0d2b3c4d in QMenu::exec(QPoint const&, QAction*) (+0x6d) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                       
#29 0x00007f0eebb63286 in GraphHierarchiesEditor::contextMenuRequested(QPoint const&) (+0x2e6) at /home/antoine/dev/tulip/plugins/perspective/GraphPerspective/src/GraphHierarchiesEditor.cpp:204 from /home/antoine/dev/tulip_build/install/lib/tulip/perspective/libGraphPerspective-5.3.1.so                                                                                               
#30 0x00007f0f0c64f906 in QMetaObject::activate(QObject*, int, int, void**) (+0x766) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                            
#31 0x00007f0f0d166b95 in QWidget::customContextMenuRequested(QPoint const&) (+0x35) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                         
#32 0x00007f0f0d1813b4 in QWidget::event(QEvent*) (+0x1004) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                  
#33 0x00007f0f0d223d1e in QFrame::event(QEvent*) (+0x1e) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                     
#34 0x00007f0f0d3951bb in QAbstractItemView::viewportEvent(QEvent*) (+0x1ab) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                 
#35 0x00007f0f0d3fd40b in QTreeView::viewportEvent(QEvent*) (+0x3b) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                          
#36 0x00007f0f0c6262bb in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (+0x9b) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                     
#37 0x00007f0f0d1424a1 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (+0x71) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                      
#38 0x00007f0f0d149dfe in QApplication::notify(QObject*, QEvent*) (+0x6be) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                   
#39 0x00007f0f0c6265a9 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (+0x179) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                         
#40 0x00007f0f0d19b801 in ?? (+0x1b8801) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                     
#41 0x00007f0f0d19db9e in ?? (+0x1bab9e) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                                                     
#42 0x00007f0f0d1424b1 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (+0x81) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                      
#43 0x00007f0f0d149950 in QApplication::notify(QObject*, QEvent*) (+0x210) from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5                                                                   
#44 0x00007f0f0c6265a9 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (+0x179) from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5                                                         
#45 0x00007f0f0cb72fe3 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (+0x703) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                         
#46 0x00007f0f0cb74e25 in QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent*) (+0x135) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5           
#47 0x00007f0f0cb4f06b in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (+0xab) from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5                          
TLP_STACK_END
```

If we look at the content of the TLP file for the exported graph, we can find what causes the observed issue:
```
(property  0 graph "viewMetaGraph"
(default "" "()")
(edge 27 "(4294967295)")
(edge 26 "(4294967295)")
(edge 8 "(4294967295)")
(edge 7 "(4294967295)")
(edge 97 "(4294967295)")
(edge 78 "(4294967295)")
(edge 69 "(4294967295)")
(edge 68 "(4294967295)")
(edge 160 "(4294967295)")
(edge 161 "(4294967295)")
(edge 162 "(4294967295)")
(edge 163 "(4294967295)")
(edge 164 "(4294967295)")
(edge 165 "(4294967295)")
(edge 166 "(4294967295)")
(edge 167 "(4294967295)")
)
```
The meta-edges info have been serialized but they should not as the original edges they
contain are not elements of the exported graph. Indeed here we are exporting a leaf sub-graph
of a graph hierarchy, thus the meta information must be discarded as it is impossible to restore
it on import in that case. Turns out this corner case was already handled for meta-nodes but
some extra processing is also required for meta-edges.

That PR fixes that particular issue. While adding tests for it, I noticed the JSON Import / Export plugins did not greatly handle meta information so I also fixed that. 