### PR TITLE
GraphPerspective: Delete static resources only when exiting Tulip (#145)

### DIFF
--- a/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp
+++ b/plugins/perspective/GraphPerspective/src/GraphPerspective.cpp
@@ -268,7 +268,9 @@ GraphPerspective::~GraphPerspective() {
 
 #ifdef TULIP_BUILD_PYTHON_COMPONENTS
   delete _pythonIDEDialog;
-  PythonCodeEditor::deleteStaticResources();
+  if (Perspective::instance() == this) {
+    PythonCodeEditor::deleteStaticResources();
+  }
 #endif
 
   delete _ui;


### PR DESCRIPTION
This fixes the observed crash when requesting the auto-completion list for Tulip algorithms in Python code editors.

I managed to identify where the issue was using `valgrind`, see output below:
```
==515== Invalid read of size 8
==515==    at 0x60FF46B: QListWidget::count() const (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x1E19489F: addItem (qlistwidget.h:217)
==515==    by 0x1E19489F: tlp::PythonCodeEditor::updateAutoCompletionList(bool) (PythonCodeEditor.cpp:1282)
==515==    by 0x1E1A8048: tlp::PythonShellWidget::updateAutoCompletionList(bool) (PythonShellWidget.cpp:299)
==515==    by 0x1E1924BF: tlp::PythonCodeEditor::showAutoCompletionList(bool) (PythonCodeEditor.cpp:1217)
==515==    by 0x1E198737: tlp::PythonCodeEditor::keyPressEvent(QKeyEvent*) (PythonCodeEditor.cpp:1009)
==515==    by 0x1E1A6AB3: tlp::PythonShellWidget::keyPressEvent(QKeyEvent*) (PythonShellWidget.cpp:208)
==515==    by 0x5EAFBA6: QWidget::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x5F52D1D: QFrame::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x5F55933: QAbstractScrollArea::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x6022AB4: QPlainTextEdit::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x5E714B0: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x5E798B0: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==  Address 0x223ab008 is 8 bytes inside a block of size 64 free'd
==515==    at 0x4836EAB: operator delete(void*) (vg_replace_malloc.c:576)
==515==    by 0x1E0919C0: deleteStaticResources (PythonCodeEditor.h:224)
==515==    by 0x1E0919C0: GraphPerspective::~GraphPerspective() (GraphPerspective.cpp:271)
==515==    by 0x1E091B38: GraphPerspective::~GraphPerspective() (GraphPerspective.cpp:275)
==515==    by 0x1E1B09A1: getAlgorithmPluginsListOfType (AutoCompletionDataBase.cpp:1169)
==515==    by 0x1E1B09A1: tryAlgorithmContext(QString const&, QString const&, QString const&) (AutoCompletionDataBase.cpp:1185)
==515==    by 0x1E1B5338: getTulipAlgorithmListIfContext (AutoCompletionDataBase.cpp:1225)
==515==    by 0x1E1B5338: tlp::AutoCompletionDataBase::getAutoCompletionListForContext(QString const&, QString const&, bool) (AutoCompletionDataBase.cpp:1358)
==515==    by 0x1E194829: tlp::PythonCodeEditor::updateAutoCompletionList(bool) (PythonCodeEditor.cpp:1279)
==515==    by 0x1E1A8048: tlp::PythonShellWidget::updateAutoCompletionList(bool) (PythonShellWidget.cpp:299)
==515==    by 0x1E1924BF: tlp::PythonCodeEditor::showAutoCompletionList(bool) (PythonCodeEditor.cpp:1217)
==515==    by 0x1E198737: tlp::PythonCodeEditor::keyPressEvent(QKeyEvent*) (PythonCodeEditor.cpp:1009)
==515==    by 0x1E1A6AB3: tlp::PythonShellWidget::keyPressEvent(QKeyEvent*) (PythonShellWidget.cpp:208)
==515==    by 0x5EAFBA6: QWidget::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==    by 0x5F52D1D: QFrame::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.11.3)
==515==  Block was alloc'd at
==515==    at 0x4835DEF: operator new(unsigned long) (vg_replace_malloc.c:334)
==515==    by 0x1E191F01: tlp::PythonCodeEditor::PythonCodeEditor(QWidget*) (PythonCodeEditor.cpp:475)
==515==    by 0x1E1A651C: tlp::PythonShellWidget::PythonShellWidget(QWidget*) (PythonShellWidget.cpp:59)
==515==    by 0x1E0C5D67: Ui_PythonPanel::setupUi(QWidget*) (ui_PythonPanel.h:128)
==515==    by 0x1E0C5072: PythonPanel::PythonPanel(QWidget*) (PythonPanel.cpp:35)
==515==    by 0x1E095143: GraphPerspective::start(tlp::PluginProgress*) (GraphPerspective.cpp:422)
==515==    by 0x115AF0: main (main.cpp:338)
```
Turns out I am the one that introduced this bug in commit 7a398f0f843891af2eaa18944a4afa0757d138af.

@p-mary , adding gui tests on auto-completion list features would be great.