### PR TITLE
ScatterPlotView: Fix possible crash with bogus input data (#147)

### DIFF
--- a/plugins/view/ScatterPlot2DView/ScatterPlot2DView.cpp
+++ b/plugins/view/ScatterPlot2DView/ScatterPlot2DView.cpp
@@ -329,16 +329,20 @@ void ScatterPlot2DView::setState(const DataSet &dataSet) {
   dataSet.get("detailed scatterplot x dim", detailScatterPlotX);
   dataSet.get("detailed scatterplot y dim", detailScatterPlotY);
 
-  if (!detailScatterPlotX.empty() && !detailScatterPlotY.empty()) {
-    pair<string, string> x_y = make_pair(detailScatterPlotX, detailScatterPlotY);
+  auto scatterPlotIdx = make_pair(detailScatterPlotX, detailScatterPlotY);
 
-    if (!scatterPlotsGenMap[x_y]) {
-      scatterPlotsMap[x_y]->generateOverview();
-      scatterPlotsGenMap[x_y] = true;
+  if (!detailScatterPlotX.empty() && !detailScatterPlotY.empty()) {
+
+    if (!scatterPlotsGenMap[scatterPlotIdx]) {
+      scatterPlotsMap[scatterPlotIdx]->generateOverview();
+      scatterPlotsGenMap[scatterPlotIdx] = true;
     }
 
-    switchFromMatrixToDetailView(scatterPlotsMap[make_pair(detailScatterPlotX, detailScatterPlotY)],
-                                 true);
+    auto *scatterPlot = scatterPlotsMap[scatterPlotIdx];
+
+    if (scatterPlot) {
+      switchFromMatrixToDetailView(scatterPlot, true);
+    }
   }
 
   registerTriggers();


### PR DESCRIPTION
This PR prevents possible crash when loading a ScatterPlotView from old configuration saved in a TLPX file (see #147).