### PR TITLE
Fix Tulip compilation with binutils 2.32 on MSYS2

### DIFF
--- a/software/CMakeLists.txt
+++ b/software/CMakeLists.txt
@@ -1,5 +1,12 @@
 ADD_SUBDIRECTORY(bitmaps)
 ADD_SUBDIRECTORY(crash_handling)
+
+# Override the CMAKE_RC_COMPILE_OBJECT variable to fix an issue with
+# the windres compiler coming with binutils 2.32 on MSYS2
+IF(WIN32 AND MINGW)
+  SET(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff -o <OBJECT> <SOURCE>")
+ENDIF(WIN32 AND MINGW)
+
 ADD_SUBDIRECTORY(tulip_perspective)
 IF(NOT TULIP_BUILD_FOR_APPIMAGE)
 ADD_SUBDIRECTORY(tulip)


### PR DESCRIPTION
[binutils](https://www.gnu.org/software/binutils/) has been [upgraded to version 2.32](https://github.com/msys2/MINGW-packages/commit/1ccbe5331faf0f04123c1f590e026f5e202454df) on MSYS2, unfortunately this [breaks Tulip build](https://ci.appveyor.com/project/tulip-dev/tulip/builds/26531803/job/9wt3r1mr2i9pn2o7) as the [`windres`](https://sourceware.org/binutils/docs/binutils/windres.html) compiler now ends up with errors.

This comes from the fact that the C++ compiler options are passed by CMake to `windres` but this is not needed at all for Tulip. So ensure those options are discarded by overriding the [CMAKE_RC_COMPILE_OBJECT](https://github.com/Kitware/CMake/blob/114c52fa5b890092e1409c232c97733a8c04d5bf/Modules/CMakeRCInformation.cmake#L45-L46) variable.

A similar issue has been observed [here](https://github.com/mxe/mxe/issues/1475) and I used the same workaround.