### PR TITLE
Fix PageRank computation

### DIFF
--- a/plugins/metric/PageRank.cpp
+++ b/plugins/metric/PageRank.cpp
@@ -115,8 +115,8 @@ public:
     NodeStaticProperty<double> deg(graph);
     tlp::degree(graph, deg, directed ? DIRECTED : UNDIRECTED, weight, false);
 
-    auto getNodes = getNodesIterator(directed ? DIRECTED : UNDIRECTED);
-    auto getEdges = getEdgesIterator(directed ? DIRECTED : UNDIRECTED);
+    auto getNodes = getNodesIterator(directed ? INV_DIRECTED : UNDIRECTED);
+    auto getEdges = getEdgesIterator(directed ? INV_DIRECTED : UNDIRECTED);
 
     for (unsigned int k = 0; k < kMax + 1; ++k) {
       if (!weight) {


### PR DESCRIPTION
In commit d9e583e7a468e839f06cdfd5e0a02f2069dd4210
the GraphTools getNodesIterator and getEdgesIterator methods were used in the plugin PageRank for cleaning up the code.

However, I believe the computation is now incorrect in the directed case.
Indeed
`auto getNodes = getNodesIterator(directed ? DIRECTED : UNDIRECTED);`
returns the out-nodes (resp. edges)  while the update of `next_pr` requires the value of `pr` for the in-nodes.
The same is also true for the weighted version (i.e. with getEdgesIterator)

`DIRECTED` should therefore be replaced by `INV_DIRECTED`.
Sry I did not spot this sooner btw, getting back to Tulip just now :)